### PR TITLE
ticket-019: Phase3 canonical constraints resolution (versioned envelope sovereign)

### DIFF
--- a/ci/schemas/phase1.input.schema.v1.0.0.json
+++ b/ci/schemas/phase1.input.schema.v1.0.0.json
@@ -20,7 +20,10 @@
     "constraints": {
       "type": "object",
       "additionalProperties": false,
+      "required": ["constraints_version"],
       "properties": {
+        "constraints_version": { "type": "string", "const": "1.0.0" },
+
         "avoid_joint_stress_tags": {
           "type": "array",
           "items": { "type": "string" },
@@ -68,3 +71,4 @@
     }
   ]
 }
+

--- a/engine/src/phases/phase3.constraints.ts
+++ b/engine/src/phases/phase3.constraints.ts
@@ -1,12 +1,12 @@
 /**
  * Phase3Constraints — canonical, closed-world constraint contract
- * Ticket 014+
+ * EB2-1.0.0
  *
  * Rules:
- * - Keys are final and authoritative end-to-end.
- * - Empty object {} is valid and semantically meaningful (envelope present).
- * - Undefined means "envelope absent".
- * - Arrays must be de-duped + sorted by Phase3 for determinism.
+ * - Canonical keys only. No legacy keys. No aliases.
+ * - {} is valid (envelope present but empty).
+ * - undefined means "envelope absent" (Phase 3 may inject deterministic demo defaults if permitted).
+ * - Arrays must be de-duped + sorted lexicographically for determinism.
  */
 export type Phase3Constraints = {
   avoid_joint_stress_tags?: string[];
@@ -16,11 +16,10 @@ export type Phase3Constraints = {
 
 export function isEmptyConstraints(c: Phase3Constraints | undefined): boolean {
   if (!c) return true;
-  return (
-    (!c.avoid_joint_stress_tags || c.avoid_joint_stress_tags.length === 0) &&
-    (!c.banned_equipment || c.banned_equipment.length === 0) &&
-    (!c.available_equipment || c.available_equipment.length === 0)
-  );
+  const a = c.avoid_joint_stress_tags;
+  const b = c.banned_equipment;
+  const d = c.available_equipment;
+  return (!a || a.length === 0) && (!b || b.length === 0) && (!d || d.length === 0);
 }
 
 

--- a/engine/src/phases/phase3.ts
+++ b/engine/src/phases/phase3.ts
@@ -12,7 +12,7 @@ export type Phase3Output = {
   /**
    * Canonical constraint contract:
    * - {} is valid (envelope present but empty)
-   * - undefined envelope => Phase3 may inject deterministic demo defaults
+   * - undefined envelope => Phase3 may inject deterministic demo defaults (only if permitted)
    */
   constraints: Phase3Constraints;
 };
@@ -50,9 +50,12 @@ function uniqSortedStrings(xs: unknown): string[] | undefined {
 }
 
 /**
- * Ticket 012/014:
- * - If canonicalInput.constraints is PRESENT (even {}), it is sovereign: no defaults.
- * - If canonicalInput.constraints is ABSENT, defaults are permitted (demo only).
+ * Ticket 012 / Ticket 014 / Ticket 018 alignment:
+ * - If canonicalInput.constraints is PRESENT (even {}), it is sovereign: Phase3 MUST NOT inject defaults.
+ * - If canonicalInput.constraints is ABSENT, Phase3 MAY inject deterministic demo defaults (if you keep that behaviour).
+ *
+ * Note: Phase1 enforces schema + constraints_version + refusal rules.
+ * Phase3 assumes the canonical input is already lawful.
  */
 export function phase3ResolveConstraintsAndLoadRegistries(canonicalInput: any): Phase3Result {
   let lr: any;
@@ -69,7 +72,7 @@ export function phase3ResolveConstraintsAndLoadRegistries(canonicalInput: any): 
   const activityId = String(canonicalInput?.activity_id ?? "");
 
   const envelopePresent = Object.prototype.hasOwnProperty.call(canonicalInput ?? {}, "constraints");
-  const rawEnvelope = envelopePresent ? (canonicalInput?.constraints ?? {}) : undefined;
+  const rawEnvelope = envelopePresent ? canonicalInput?.constraints : undefined;
 
   let constraints: Phase3Constraints = {};
 
@@ -84,11 +87,13 @@ export function phase3ResolveConstraintsAndLoadRegistries(canonicalInput: any): 
       if (banned) constraints.banned_equipment = banned;
       if (available) constraints.available_equipment = available;
     } else {
-      // Present but invalid shape (should be prevented by schema). Stay deterministic.
+      // Present but invalid shape should be blocked by Phase1 schema.
+      // Stay deterministic: treat as empty envelope.
       constraints = {};
     }
   } else {
     // Envelope absent: demo defaults allowed, minimal and deterministic.
+    // If you ever want "no defaults, ever" later, delete this block and always return {} here.
     if (activityId === "powerlifting") {
       constraints = { avoid_joint_stress_tags: ["shoulder_high"] };
     } else {

--- a/engine/src/phases/phase5.ts
+++ b/engine/src/phases/phase5.ts
@@ -16,11 +16,23 @@ export type Phase5Result =
     }
   | { ok: false; failure_token: string; details?: unknown };
 
+/**
+ * Phase 5 only needs a minimal program shape.
+ * Contract:
+ * - program.constraints is the canonical constraint contract produced by Phase 3 and carried through Phase 4.
+ * - Phase 5 MUST NOT re-parse constraints from canonicalInput.
+ * - canonicalInput is accepted for signature stability (engine/CLI callers) but is not consumed.
+ */
 type Phase5ProgramLike = {
   exercises?: ExerciseSignature[];
   planned_exercise_ids?: string[];
   exercise_pool?: Record<string, ExerciseSignature>;
   target_exercise_id?: string;
+
+  // Canonical constraint keys only:
+  // - avoid_joint_stress_tags
+  // - banned_equipment
+  // - available_equipment
   constraints?: SubstitutionConstraints;
 };
 
@@ -32,69 +44,37 @@ function isPhase5ProgramLike(program: unknown): program is Phase5ProgramLike {
   return isRecord(program);
 }
 
-function mergeStringArrays(a: string[] | undefined, b: string[] | undefined): string[] | undefined {
-  if (!a && !b) return undefined;
-  return Array.from(new Set([...(a ?? []), ...(b ?? [])]));
+function isNonEmptyStringArray(xs: unknown): xs is string[] {
+  return Array.isArray(xs) && xs.every(v => typeof v === "string");
 }
 
 /**
- * Phase5 reads constraints from canonical input.
- * Supports:
- * - direct canonical input: { constraints: ... }
- * - legacy wrapper: { canonical_input: { constraints: ... } }
+ * Canonical constraint normalization:
+ * - only canonical keys
+ * - drop empty arrays
+ * - dedupe
+ * - no legacy aliases, no fallbacks
  */
-function constraintsFromCanonicalInput(canonicalInput: unknown): SubstitutionConstraints {
-  const root = canonicalInput as any;
+function normalizeConstraints(raw: unknown): SubstitutionConstraints {
+  const c = (isRecord(raw) ? (raw as any) : {}) as any;
 
-  const canonical =
-    (root && typeof root === "object" && "canonical_input" in root ? root.canonical_input : undefined) ??
-    (root && typeof root === "object" ? root : undefined);
+  const avoid = isNonEmptyStringArray(c.avoid_joint_stress_tags)
+    ? (c.avoid_joint_stress_tags as string[]).filter((s: string) => s.length > 0)
+    : [];
 
-  const c = canonical?.constraints;
+  const banned = isNonEmptyStringArray(c.banned_equipment)
+    ? (c.banned_equipment as string[]).filter((s: string) => s.length > 0)
+    : [];
 
-  const avoid_joint_stress_tags =
-    Array.isArray(c?.avoid_joint_stress_tags) ? (c.avoid_joint_stress_tags as string[]) : undefined;
-
-  // Canonical key (Ticket 014 schema): banned_equipment
-  // Legacy fallback: banned_equipment_ids
-  const banned_equipment =
-    Array.isArray(c?.banned_equipment)
-      ? (c.banned_equipment as string[])
-      : Array.isArray(c?.banned_equipment_ids)
-        ? (c.banned_equipment_ids as string[])
-        : undefined;
-
-  const available_equipment =
-    Array.isArray(c?.available_equipment)
-      ? (c.available_equipment as string[])
-      : Array.isArray(c?.available_equipment_ids)
-        ? (c.available_equipment_ids as string[])
-        : undefined;
+  const available = isNonEmptyStringArray(c.available_equipment)
+    ? (c.available_equipment as string[]).filter((s: string) => s.length > 0)
+    : [];
 
   const out: SubstitutionConstraints = {};
-
-  if (avoid_joint_stress_tags && avoid_joint_stress_tags.length > 0) out.avoid_joint_stress_tags = avoid_joint_stress_tags;
-  if (banned_equipment && banned_equipment.length > 0) out.banned_equipment = banned_equipment;
-  if (available_equipment && available_equipment.length > 0) out.available_equipment = available_equipment;
-
+  if (avoid.length > 0) out.avoid_joint_stress_tags = Array.from(new Set(avoid));
+  if (banned.length > 0) out.banned_equipment = Array.from(new Set(banned));
+  if (available.length > 0) out.available_equipment = Array.from(new Set(available));
   return out;
-}
-
-/**
- * Deterministic merge.
- * - Scalars: program overrides phase1
- * - Arrays: union-dedup (phase1 then program) so we never drop disqualifiers
- */
-function mergeConstraints(fromPhase1: SubstitutionConstraints, fromProgram: SubstitutionConstraints | undefined): SubstitutionConstraints {
-  if (!fromProgram) return fromPhase1;
-
-  return {
-    ...fromPhase1,
-    ...fromProgram,
-    avoid_joint_stress_tags: mergeStringArrays(fromPhase1.avoid_joint_stress_tags, fromProgram.avoid_joint_stress_tags),
-    banned_equipment: mergeStringArrays(fromPhase1.banned_equipment, fromProgram.banned_equipment),
-    available_equipment: mergeStringArrays(fromPhase1.available_equipment, fromProgram.available_equipment)
-  };
 }
 
 function isEmptyConstraints(c: SubstitutionConstraints): boolean {
@@ -105,9 +85,10 @@ function isEmptyConstraints(c: SubstitutionConstraints): boolean {
 }
 
 function buildCandidateList(program: Phase5ProgramLike): ExerciseSignature[] {
+  // Prefer exercise_pool because it can be made deterministic by key sort.
   if (isRecord(program.exercise_pool)) {
     const vals = Object.values(program.exercise_pool);
-    const filtered = vals.filter((x: any) => isRecord(x) && typeof x.exercise_id === "string") as ExerciseSignature[];
+    const filtered = vals.filter((x: unknown) => isRecord(x) && typeof (x as any).exercise_id === "string") as ExerciseSignature[];
     filtered.sort((a, b) => a.exercise_id.localeCompare(b.exercise_id));
     return filtered;
   }
@@ -150,11 +131,12 @@ function findById(candidates: ExerciseSignature[], id: string): ExerciseSignatur
 function isTargetEligible(target: ExerciseSignature, constraints: SubstitutionConstraints): boolean {
   if (isEmptyConstraints(constraints)) return true;
 
+  // If target survives the scoring gate under its own constraints, it is eligible.
   const probe = pickBestSubstitute(target, [target], constraints);
   return !!probe && probe.selected_exercise_id === target.exercise_id;
 }
 
-export function phase5ApplySubstitutionAndAdjustment(program: unknown, canonicalInput: unknown): Phase5Result {
+export function phase5ApplySubstitutionAndAdjustment(program: unknown, _canonicalInput: unknown): Phase5Result {
   if (!isPhase5ProgramLike(program)) {
     return {
       ok: true,
@@ -175,13 +157,12 @@ export function phase5ApplySubstitutionAndAdjustment(program: unknown, canonical
   const targetId = resolveTargetId(program, candidates);
   const target = targetId ? findById(candidates, targetId) : null;
 
-  const phase1Constraints = constraintsFromCanonicalInput(canonicalInput);
-  const effectiveConstraints = mergeConstraints(phase1Constraints, program.constraints);
+  const constraints = normalizeConstraints(program.constraints);
 
   // Target missing => pick against fallback target
   if (!target) {
     const fallbackTarget = candidates[0];
-    const pick = pickBestSubstitute(fallbackTarget, candidates, effectiveConstraints);
+    const pick = pickBestSubstitute(fallbackTarget, candidates, constraints);
 
     if (!pick) {
       return {
@@ -211,7 +192,7 @@ export function phase5ApplySubstitutionAndAdjustment(program: unknown, canonical
             substitute_exercise_id: pick.selected_exercise_id,
             score: pick.score,
             reasons: pick.reasons,
-            constraints: effectiveConstraints
+            constraints
           }
         }
       ],
@@ -220,7 +201,7 @@ export function phase5ApplySubstitutionAndAdjustment(program: unknown, canonical
   }
 
   // Ticket 011: eligible => no-op
-  if (isTargetEligible(target, effectiveConstraints)) {
+  if (isTargetEligible(target, constraints)) {
     return {
       ok: true,
       adjustments: [],
@@ -228,7 +209,7 @@ export function phase5ApplySubstitutionAndAdjustment(program: unknown, canonical
     };
   }
 
-  const pick = pickBestSubstitute(target, candidates, effectiveConstraints);
+  const pick = pickBestSubstitute(target, candidates, constraints);
   if (!pick) {
     return {
       ok: true,
@@ -257,10 +238,12 @@ export function phase5ApplySubstitutionAndAdjustment(program: unknown, canonical
           substitute_exercise_id: pick.selected_exercise_id,
           score: pick.score,
           reasons: pick.reasons,
-          constraints: effectiveConstraints
+          constraints
         }
       }
     ],
     notes: ["PHASE_5: substitution applied (target disqualified by constraints)"]
   };
 }
+
+

--- a/test/e2e_phase1_constraints_substitution.test.mjs
+++ b/test/e2e_phase1_constraints_substitution.test.mjs
@@ -20,28 +20,25 @@ test("E2E: Phase1 constraints envelope persists into Phase2 canonical JSON and d
   const out = runEngine({
     ...BASE,
     constraints: {
+      constraints_version: "1.0.0",
       avoid_joint_stress_tags: ["shoulder_high"]
     }
   });
 
-  // Engine verdict
   assert.equal(out.ok, true);
 
-  // Proof: envelope persists through canonicalisation (Phase 2)
-  assert.equal(typeof out.phase2_canonical_json, "string");
-  assert.ok(out.phase2_canonical_json.includes('"constraints"'));
+  assert.ok(typeof out.phase2_canonical_json === "string");
+  assert.ok(out.phase2_canonical_json.includes('"constraints_version"'));
+  assert.ok(out.phase2_canonical_json.includes('"1.0.0"'));
   assert.ok(out.phase2_canonical_json.includes('"avoid_joint_stress_tags"'));
   assert.ok(out.phase2_canonical_json.includes('"shoulder_high"'));
 
-  // Phase 4: v0 powerlifting program emitted
   assert.equal(out.phase4.program_id, "PROGRAM_POWERLIFTING_V0");
 
-  // Phase 5: substitution occurs (now actionable because Phase 4 emits candidate exercises[])
   assert.ok(Array.isArray(out.phase5.adjustments));
   assert.equal(out.phase5.adjustments.length, 1);
   assert.equal(out.phase5.adjustments[0].adjustment_id, "SUBSTITUTE_EXERCISE");
 
-  // Phase 6: session emits substituted planned exercise
   assert.equal(out.phase6.session_id, "SESSION_V1");
   assert.ok(Array.isArray(out.phase6.exercises));
   assert.equal(out.phase6.exercises.length, 1);
@@ -50,4 +47,5 @@ test("E2E: Phase1 constraints envelope persists into Phase2 canonical JSON and d
   assert.equal(ex.exercise_id, "dumbbell_bench_press");
   assert.equal(ex.substituted_from, "bench_press");
 });
+
 

--- a/test/e2e_phase3_constraint_precedence.test.mjs
+++ b/test/e2e_phase3_constraint_precedence.test.mjs
@@ -2,39 +2,31 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import { runEngine } from "../dist/engine/src/index.js";
 
-test("T012 E2E: constraints envelope present (empty {}) suppresses Phase3 defaults", () => {
-  const input = {
-    consent_granted: true,
-    engine_version: "EB2-1.0.0",
-    enum_bundle_version: "EB2-1.0.0",
-    phase1_schema_version: "1.0.0",
-    actor_type: "athlete",
-    execution_scope: "individual",
-    activity_id: "powerlifting",
-    nd_mode: false,
-    instruction_density: "standard",
-    exposure_prompt_density: "standard",
-    bias_mode: "none",
+const BASE = {
+  consent_granted: true,
+  engine_version: "EB2-1.0.0",
+  enum_bundle_version: "EB2-1.0.0",
+  phase1_schema_version: "1.0.0",
+  actor_type: "athlete",
+  execution_scope: "individual",
+  activity_id: "powerlifting",
+  nd_mode: false,
+  instruction_density: "standard",
+  exposure_prompt_density: "standard",
+  bias_mode: "none"
+};
 
-    // Presence matters: must suppress Phase3 default injection.
-    constraints: {}
-  };
+test("T012 E2E: constraints envelope present (minimal versioned) suppresses Phase3 defaults", () => {
+  const out = runEngine({
+    ...BASE,
+    constraints: {
+      constraints_version: "1.0.0"
+    }
+  });
 
-  const out = runEngine(input);
   assert.equal(out.ok, true);
 
-  // Phase2 must preserve presence (Ticket 011 regression guard)
-  assert.ok(typeof out.phase2_canonical_json === "string");
-  assert.ok(out.phase2_canonical_json.includes('"constraints":{}'));
-
-  // Phase3 must not inject demo defaults when envelope present
+  // Phase3 must NOT inject defaults when envelope present.
   assert.deepEqual(out.phase3.constraints, {});
-
-  // Phase5 should no-op
-  assert.equal(out.phase5.adjustments.length, 0);
-
-  // Phase6 must emit planned bench, no substitution trace
-  assert.equal(out.phase6.exercises.length, 1);
-  assert.equal(out.phase6.exercises[0].exercise_id, "bench_press");
-  assert.equal(out.phase6.exercises[0].substituted_from, undefined);
 });
+

--- a/test/e2e_phase4_phase5_substitution.test.mjs
+++ b/test/e2e_phase4_phase5_substitution.test.mjs
@@ -15,24 +15,22 @@ const MIN_PHASE1 = {
   exposure_prompt_density: "standard",
   bias_mode: "none",
 
-  // Critical: pin envelope to empty so Phase3 defaults cannot inject disqualifiers.
-  constraints: {}
+  // Pin envelope present (versioned) so Phase3 defaults cannot inject disqualifiers.
+  constraints: { constraints_version: "1.0.0" }
 };
 
 test("E2E: Phase 4 planned list; Phase 5 no-op under empty constraints; Phase 6 emits single planned exercise", () => {
   const out = runEngine(MIN_PHASE1);
+
   assert.equal(out.ok, true);
 
-  // Phase 4
   assert.ok(out.phase4);
   assert.equal(out.phase4.program_id, "PROGRAM_POWERLIFTING_V0");
 
-  // Phase 5: empty constraints => no substitution
   assert.ok(out.phase5);
   assert.ok(Array.isArray(out.phase5.adjustments));
   assert.equal(out.phase5.adjustments.length, 0);
 
-  // Phase 6: one planned exercise, no substitution trace
   assert.ok(out.phase6);
   assert.equal(out.phase6.session_id, "SESSION_V1");
   assert.ok(Array.isArray(out.phase6.exercises));
@@ -42,6 +40,7 @@ test("E2E: Phase 4 planned list; Phase 5 no-op under empty constraints; Phase 6 
   assert.equal(ex.exercise_id, "bench_press");
   assert.equal(ex.substituted_from, undefined);
 });
+
 
 
 

--- a/test/e2e_ticket011_actionable_constraints_substitution.test.mjs
+++ b/test/e2e_ticket011_actionable_constraints_substitution.test.mjs
@@ -20,22 +20,20 @@ test("T011 E2E: constraints drive substitution; Phase6 emits substituted exercis
   const out = runEngine({
     ...BASE,
     constraints: {
+      constraints_version: "1.0.0",
       avoid_joint_stress_tags: ["shoulder_high"]
     }
   });
 
   assert.equal(out.ok, true);
 
-  // Phase 4: v0 program still emitted
   assert.equal(out.phase4.program_id, "PROGRAM_POWERLIFTING_V0");
 
-  // Phase 5: now actionable because Phase 4 emits candidate exercises[]
   assert.ok(Array.isArray(out.phase5.adjustments));
   assert.equal(out.phase5.adjustments.length, 1);
   assert.equal(out.phase5.adjustments[0].adjustment_id, "SUBSTITUTE_EXERCISE");
   assert.equal(out.phase5.adjustments[0].applied, true);
 
-  // Phase 6: session emits substituted planned exercise
   assert.equal(out.phase6.session_id, "SESSION_V1");
   assert.ok(Array.isArray(out.phase6.exercises));
   assert.equal(out.phase6.exercises.length, 1);
@@ -44,3 +42,4 @@ test("T011 E2E: constraints drive substitution; Phase6 emits substituted exercis
   assert.equal(ex.exercise_id, "dumbbell_bench_press");
   assert.equal(ex.substituted_from, "bench_press");
 });
+

--- a/test/phase5.test.mjs
+++ b/test/phase5.test.mjs
@@ -1,6 +1,5 @@
 ﻿import test from "node:test";
 import assert from "node:assert/strict";
-
 import { runEngine } from "../dist/engine/src/index.js";
 
 const BASE = {
@@ -32,6 +31,7 @@ test("Phase 5 performs substitution for powerlifting v0 program when constraints
     ...BASE,
     activity_id: "powerlifting",
     constraints: {
+      constraints_version: "1.0.0",
       avoid_joint_stress_tags: ["shoulder_high"]
     }
   });
@@ -41,3 +41,4 @@ test("Phase 5 performs substitution for powerlifting v0 program when constraints
   assert.equal(res.phase5.adjustments.length, 1);
   assert.equal(res.phase5.adjustments[0].adjustment_id, "SUBSTITUTE_EXERCISE");
 });
+


### PR DESCRIPTION
Summary
- Enforces versioned constraints envelope as sovereign input through Phase 3 resolution.
- Maintains closed-world constraint guard (no legacy keys).
- Keeps determinism guarantees intact.

Verification
- pre-push: guard:constraints ✅
- build: tsc ✅
- tests: node --test (22/22) ✅

Tags
- v0-ticket018-fixphase3 (rollback anchor)