### PR TITLE
ticket013: allow empty Phase1 constraints envelope

### DIFF
--- a/ci/schemas/phase1.input.schema.v1.0.0.json
+++ b/ci/schemas/phase1.input.schema.v1.0.0.json
@@ -1,0 +1,71 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Phase1Input v1.0.0 (starter)",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "consent_granted",
+    "engine_version",
+    "enum_bundle_version",
+    "phase1_schema_version",
+    "actor_type",
+    "execution_scope",
+    "activity_id",
+    "nd_mode",
+    "instruction_density",
+    "exposure_prompt_density",
+    "bias_mode"
+  ],
+  "properties": {
+    "constraints": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "avoid_joint_stress_tags": {
+          "type": "array",
+          "items": { "type": "string" },
+          "minItems": 1
+        },
+        "banned_equipment_ids": {
+          "type": "array",
+          "items": { "type": "string" },
+          "minItems": 1
+        },
+        "available_equipment_ids": {
+          "type": "array",
+          "items": { "type": "string" },
+          "minItems": 1
+        }
+      }
+    },
+
+    "consent_granted": { "type": "boolean", "const": true },
+
+    "engine_version": { "type": "string", "const": "EB2-1.0.0" },
+    "enum_bundle_version": { "type": "string", "const": "EB2-1.0.0" },
+    "phase1_schema_version": { "type": "string", "const": "1.0.0" },
+
+    "actor_type": { "type": "string", "enum": ["athlete", "coach", "org_admin"] },
+    "execution_scope": { "type": "string", "enum": ["individual", "coach_managed", "org_managed"] },
+
+    "governing_authority_id": { "type": "string" },
+
+    "activity_id": { "type": "string", "minLength": 1 },
+    "sport_role_id": { "type": "string" },
+
+    "nd_mode": { "type": "boolean" },
+    "instruction_density": { "type": "string" },
+    "exposure_prompt_density": { "type": "string" },
+    "bias_mode": { "type": "string" }
+  },
+  "allOf": [
+    {
+      "if": {
+        "properties": { "execution_scope": { "enum": ["coach_managed", "org_managed"] } },
+        "required": ["execution_scope"]
+      },
+      "then": { "required": ["governing_authority_id"] }
+    }
+  ]
+}
+

--- a/docs/TICKET_013_PHASE1_EMPTY_CONSTRAINTS_ALLOWED.md
+++ b/docs/TICKET_013_PHASE1_EMPTY_CONSTRAINTS_ALLOWED.md
@@ -1,0 +1,22 @@
+# TICKET 013 — Phase1: allow empty constraints envelope
+
+## Goal
+Allow an explicit Phase1 `constraints: {}` envelope to be schema-valid. This supports the “sovereign envelope” rule where an explicitly provided empty constraints object suppresses Phase3 default constraint injection.
+
+## Problem
+Phase1 schema previously required `constraints` to contain at least one property. That made the explicit empty envelope `{}` invalid even though it is a meaningful signal.
+
+## Change
+- `ci/schemas/phase1.input.schema.v1.0.0.json`:
+  - Removed `constraints.minProperties` requirement.
+  - `constraints` may now be omitted, `{}`, or contain supported keys.
+
+## Invariants
+- `additionalProperties: false` is retained at the Phase1 root.
+- `constraints.additionalProperties: false` is retained (closed-world keys only).
+- Individual constraint arrays retain `minItems: 1` (no empty arrays).
+
+## Acceptance
+- `npm run lint` passes.
+- `npm test` passes.
+- Explicit `{ constraints: {} }` is schema-valid.


### PR DESCRIPTION
Resolves schema conflict by restoring Phase1 input schema
and explicitly allowing empty constraints envelopes.
Unblocks downstream tickets relying on sovereign Phase1 envelope.