### PR TITLE
Phase4: emit prescription-ready planned_items + deterministic timebox pruning Body (bullets)

### DIFF
--- a/engine/src/phases/phase4.ts
+++ b/engine/src/phases/phase4.ts
@@ -103,19 +103,30 @@ function plannedItemsFromIntent(intent: string[], session_id: string): PlannedIt
   });
 }
 
+function readSessionTimeboxMinutes(canonicalInput: any, phase3Constraints?: any): number {
+  const tb =
+    canonicalInput?.constraints?.schedule?.session_timebox_minutes ??
+    phase3Constraints?.schedule?.session_timebox_minutes ??
+    NaN;
+
+  const n = Number(tb);
+  if (!Number.isFinite(n) || n <= 0) return NaN;
+  return n;
+}
+
 /**
  * Timebox pruning (deterministic):
- * - keep all primaries always
+ * - If no timebox: unchanged
+ * - Always keep all primaries
  * - tb < 30: drop all accessories
  * - tb < 45: keep at most 1 accessory (stable order)
  */
-function applyTimeboxDeterministic(items: PlannedItem[], canonicalInput: any): PlannedItem[] {
-  const tb = Number(canonicalInput?.timebox_min ?? canonicalInput?.timebox_minutes ?? NaN);
-  if (!Number.isFinite(tb) || tb <= 0) return items;
+function applyTimeboxDeterministic(items: PlannedItem[], timeboxMinutes: number): PlannedItem[] {
+  if (!Number.isFinite(timeboxMinutes)) return items;
 
-  if (tb < 30) return items.filter((it) => it.role === "primary");
+  if (timeboxMinutes < 30) return items.filter((it) => it.role === "primary");
 
-  if (tb < 45) {
+  if (timeboxMinutes < 45) {
     const primaries = items.filter((it) => it.role === "primary");
     const accessories = items.filter((it) => it.role === "accessory");
     return [...primaries, ...accessories.slice(0, 1)];
@@ -138,6 +149,7 @@ export function phase4AssembleProgram(canonicalInput: any, phase3: Phase3Output)
    * - Carries Phase3 canonical constraints forward on program.constraints (authoritative).
    * - Provides deterministic exercise_pool for Phase5 scoring and substitution.
    * - Sets target_exercise_id to derived planned_exercise_ids[0].
+   * - Applies deterministic timebox pruning via constraints.schedule.session_timebox_minutes.
    */
 
   let program_id: string;
@@ -180,11 +192,13 @@ export function phase4AssembleProgram(canonicalInput: any, phase3: Phase3Output)
   // Keep Phase6 stable: single session for now.
   const session_id = "SESSION_V1";
 
-  let planned_items = plannedItemsFromIntent(intent, session_id);
-  planned_items = applyTimeboxDeterministic(planned_items, canonicalInput);
+  const timeboxMinutes = readSessionTimeboxMinutes(canonicalInput, phase3.constraints);
 
-  // Derived convenience only
-  const planned_exercise_ids = uniqueStable(planned_items.map((it) => it.exercise_id));
+  let planned_items = plannedItemsFromIntent(intent, session_id);
+  planned_items = applyTimeboxDeterministic(planned_items, timeboxMinutes);
+
+  // Derived convenience only (and must match planned_items order 1:1 per test contract)
+  const planned_exercise_ids = planned_items.map((it) => it.exercise_id);
 
   const poolIds = uniqueStable([
     ...planned_exercise_ids,

--- a/test/phase4_rich_plan_minimum.test.mjs
+++ b/test/phase4_rich_plan_minimum.test.mjs
@@ -42,8 +42,6 @@ function assertStableUnique(list, label) {
   // Uniqueness
   const set = new Set(trimmed);
   assert.equal(set.size, trimmed.length, `${label} must contain unique ids`);
-
-  // Stable order requirement is implicit: we compare arrays later.
 }
 
 function assertPhase4PlanContract(program, { minItems = 2 } = {}) {
@@ -90,10 +88,34 @@ function assertPhase4PlanContract(program, { minItems = 2 } = {}) {
   assert.equal(typeof program.exercise_pool, "object", "program.exercise_pool must be an object");
   assert.ok(program.exercise_pool && !Array.isArray(program.exercise_pool), "program.exercise_pool must be a map/object");
 
-  // The pool must at least include all planned ids (otherwise Phase5 can’t score safely).
+  // The pool must at least include all planned ids (otherwise Phase5 can't score safely).
   for (const id of program.planned_exercise_ids) {
     assert.ok(program.exercise_pool[id], `exercise_pool must include planned id: ${id}`);
   }
+}
+
+function mkInput(activity_id, tbMinutes) {
+  const base = { activity_id };
+  if (typeof tbMinutes === "number") {
+    base.constraints = {
+      constraints_version: "1.0.0",
+      schedule: { session_timebox_minutes: tbMinutes }
+    };
+  }
+  return base;
+}
+
+function assertTimeboxPlan(program, expectedLen, expectedAccessoryCount) {
+  assertPhase4PlanContract(program, { minItems: Math.min(2, expectedLen) });
+
+  assert.equal(program.planned_items.length, expectedLen, `planned_items length must be ${expectedLen}`);
+
+  const primaries = program.planned_items.filter((x) => x.role === "primary");
+  const accessories = program.planned_items.filter((x) => x.role === "accessory");
+
+  // Guardrail: never drop primaries (Phase4 generator currently emits 4 primaries baseline)
+  assert.equal(primaries.length, 4, "must keep all 4 primaries");
+  assert.equal(accessories.length, expectedAccessoryCount, `accessory count must be ${expectedAccessoryCount}`);
 }
 
 test("Phase4: supported activities emit a rich, stable plan contract (powerlifting)", () => {
@@ -133,6 +155,72 @@ test("Phase4: supported activities emit a rich, stable plan contract (general_st
 
   // Same 6-slot plan contract for now.
   assert.equal(r.program.planned_items.length, 6, "general_strength planned_items length must be 6");
+});
+
+test("Phase4: timebox pruning (powerlifting) tb<30 drops all accessories; tb<45 keeps 1; tb>=45 keeps all", () => {
+  const phase3 = mkPhase3();
+
+  {
+    const r = phase4AssembleProgram(mkInput("powerlifting", 25), phase3);
+    assert.equal(r.ok, true);
+    assertTimeboxPlan(r.program, 4, 0);
+  }
+
+  {
+    const r = phase4AssembleProgram(mkInput("powerlifting", 40), phase3);
+    assert.equal(r.ok, true);
+    assertTimeboxPlan(r.program, 5, 1);
+  }
+
+  {
+    const r = phase4AssembleProgram(mkInput("powerlifting", 60), phase3);
+    assert.equal(r.ok, true);
+    assertTimeboxPlan(r.program, 6, 2);
+  }
+});
+
+test("Phase4: timebox pruning (rugby_union) tb<30 drops all accessories; tb<45 keeps 1; tb>=45 keeps all", () => {
+  const phase3 = mkPhase3();
+
+  {
+    const r = phase4AssembleProgram(mkInput("rugby_union", 25), phase3);
+    assert.equal(r.ok, true);
+    assertTimeboxPlan(r.program, 4, 0);
+  }
+
+  {
+    const r = phase4AssembleProgram(mkInput("rugby_union", 40), phase3);
+    assert.equal(r.ok, true);
+    assertTimeboxPlan(r.program, 5, 1);
+  }
+
+  {
+    const r = phase4AssembleProgram(mkInput("rugby_union", 60), phase3);
+    assert.equal(r.ok, true);
+    assertTimeboxPlan(r.program, 6, 2);
+  }
+});
+
+test("Phase4: timebox pruning (general_strength) tb<30 drops all accessories; tb<45 keeps 1; tb>=45 keeps all", () => {
+  const phase3 = mkPhase3();
+
+  {
+    const r = phase4AssembleProgram(mkInput("general_strength", 25), phase3);
+    assert.equal(r.ok, true);
+    assertTimeboxPlan(r.program, 4, 0);
+  }
+
+  {
+    const r = phase4AssembleProgram(mkInput("general_strength", 40), phase3);
+    assert.equal(r.ok, true);
+    assertTimeboxPlan(r.program, 5, 1);
+  }
+
+  {
+    const r = phase4AssembleProgram(mkInput("general_strength", 60), phase3);
+    assert.equal(r.ok, true);
+    assertTimeboxPlan(r.program, 6, 2);
+  }
 });
 
 test("Phase4: unsupported activity returns stub program with empty plan + carries Phase3 constraints", () => {


### PR DESCRIPTION
Phase4 emits authoritative planned_items (session_id, role, sets, reps, intensity, rest_seconds).

planned_exercise_ids is derived 1:1 from planned_items (non-authoritative convenience).

Deterministic timebox pruning via constraints.schedule.session_timebox_minutes:

tb < 30: drop accessories

tb < 45: keep 1 accessory

tb >= 45: keep all

always keep 4 primaries

Added contract tests: rich plan + timebox behavior + stub behavior carries Phase3 constraints.

CI/guards pass; determinism preserved.