### PR TITLE
Phase4: harden registry contract + Phase3 timebox precedence

### DIFF
--- a/engine/src/phases/phase4.ts
+++ b/engine/src/phases/phase4.ts
@@ -104,9 +104,10 @@ function plannedItemsFromIntent(intent: string[], session_id: string): PlannedIt
 }
 
 function readSessionTimeboxMinutes(canonicalInput: any, phase3Constraints?: any): number {
+  // Hardening: prefer Phase3 canonical constraints over raw input.
   const tb =
-    canonicalInput?.constraints?.schedule?.session_timebox_minutes ??
     phase3Constraints?.schedule?.session_timebox_minutes ??
+    canonicalInput?.constraints?.schedule?.session_timebox_minutes ??
     NaN;
 
   const n = Number(tb);
@@ -135,6 +136,14 @@ function applyTimeboxDeterministic(items: PlannedItem[], timeboxMinutes: number)
   return items;
 }
 
+function findMissingPlannedIds(entries: Record<string, ExerciseSignature>, plannedIds: string[]): string[] {
+  const missing: string[] = [];
+  for (const id of plannedIds) {
+    if (!entries[id]) missing.push(id);
+  }
+  return missing;
+}
+
 export function phase4AssembleProgram(canonicalInput: any, phase3: Phase3Output): Phase4Result {
   const activity = String(canonicalInput?.activity_id ?? "");
 
@@ -150,6 +159,7 @@ export function phase4AssembleProgram(canonicalInput: any, phase3: Phase3Output)
    * - Provides deterministic exercise_pool for Phase5 scoring and substitution.
    * - Sets target_exercise_id to derived planned_exercise_ids[0].
    * - Applies deterministic timebox pruning via constraints.schedule.session_timebox_minutes.
+   * - Hardening: FAIL HARD if any planned exercise_id is missing from registry.
    */
 
   let program_id: string;
@@ -200,6 +210,19 @@ export function phase4AssembleProgram(canonicalInput: any, phase3: Phase3Output)
   // Derived convenience only (and must match planned_items order 1:1 per test contract)
   const planned_exercise_ids = planned_items.map((it) => it.exercise_id);
 
+  // Hardening: planned ids MUST exist in registry (no silent omission).
+  const missingPlanned = findMissingPlannedIds(entries, planned_exercise_ids);
+  if (missingPlanned.length > 0) {
+    return {
+      ok: false,
+      failure_token: "PHASE4_MISSING_PLANNED_EXERCISE",
+      details: {
+        registry_path: regPath,
+        missing_exercise_ids: missingPlanned
+      }
+    };
+  }
+
   const poolIds = uniqueStable([
     ...planned_exercise_ids,
     "dumbbell_bench_press",
@@ -209,6 +232,8 @@ export function phase4AssembleProgram(canonicalInput: any, phase3: Phase3Output)
   ]);
 
   const exercise_pool: Record<string, ExerciseSignature> = {};
+
+  // Planned ids are guaranteed present (above). Extras are best-effort.
   for (const id of poolIds) {
     if (entries[id]) {
       exercise_pool[id] = pick(entries, id);

--- a/test/phase4_rich_plan_minimum.test.mjs
+++ b/test/phase4_rich_plan_minimum.test.mjs
@@ -1,5 +1,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
 
 // Phase4 is compiled under dist/engine/... (node runs .mjs tests, so import JS output).
 import { phase4AssembleProgram } from "../dist/engine/src/phases/phase4.js";
@@ -9,12 +11,12 @@ function mkPhase3(constraints = { constraints_version: "1.0.0" }) {
 }
 
 function assertNonEmptyString(v, label) {
-  assert.equal(typeof v, "string", `${label} must be a string`);
+  assert.equal(typeof v, "string");
   assert.ok(v.trim().length > 0, `${label} must be non-empty`);
 }
 
 function assertPositiveInt(v, label) {
-  assert.equal(typeof v, "number", `${label} must be a number`);
+  assert.equal(typeof v, "number");
   assert.ok(Number.isInteger(v), `${label} must be an integer`);
   assert.ok(v > 0, `${label} must be > 0`);
 }
@@ -24,22 +26,18 @@ function assertPlannedItem(it, index) {
   assertNonEmptyString(it.item_id, `planned_items[${index}].item_id`);
   assertNonEmptyString(it.exercise_id, `planned_items[${index}].exercise_id`);
 
-  // These are required for Phase6 emission + rendered_text formatting.
   assertPositiveInt(it.sets, `planned_items[${index}].sets`);
   assertPositiveInt(it.reps, `planned_items[${index}].reps`);
 }
 
 function assertStableUnique(list, label) {
   assert.ok(Array.isArray(list), `${label} must be an array`);
-  const asStrings = list.map((x) => String(x));
-  const trimmed = asStrings.map((s) => s.trim());
+  const trimmed = list.map((x) => String(x).trim());
 
-  // No blanks
   for (let i = 0; i < trimmed.length; i++) {
     assert.ok(trimmed[i].length > 0, `${label}[${i}] must be non-empty`);
   }
 
-  // Uniqueness
   const set = new Set(trimmed);
   assert.equal(set.size, trimmed.length, `${label} must contain unique ids`);
 }
@@ -48,11 +46,9 @@ function assertPhase4PlanContract(program, { minItems = 2 } = {}) {
   assertNonEmptyString(program.program_id, "program.program_id");
   assertNonEmptyString(program.version, "program.version");
 
-  // planned_items is the authoritative plan surface (rich path used by Phase6).
   assert.ok(Array.isArray(program.planned_items), "program.planned_items must be an array");
   assert.ok(program.planned_items.length >= minItems, `program.planned_items must have >= ${minItems} items`);
 
-  // planned_exercise_ids must exist and be 1:1 with planned_items, same order.
   assert.ok(Array.isArray(program.planned_exercise_ids), "program.planned_exercise_ids must be an array");
   assert.equal(
     program.planned_exercise_ids.length,
@@ -60,7 +56,6 @@ function assertPhase4PlanContract(program, { minItems = 2 } = {}) {
     "program.planned_exercise_ids length must equal planned_items length"
   );
 
-  // Validate every planned item shape + content.
   for (let i = 0; i < program.planned_items.length; i++) {
     assertPlannedItem(program.planned_items[i], i);
   }
@@ -72,10 +67,8 @@ function assertPhase4PlanContract(program, { minItems = 2 } = {}) {
     "program.planned_exercise_ids must equal planned_items.exercise_id (same order)"
   );
 
-  // Must be stable unique ids.
   assertStableUnique(program.planned_exercise_ids, "program.planned_exercise_ids");
 
-  // Deterministic target: first planned id.
   assertNonEmptyString(program.target_exercise_id, "program.target_exercise_id");
   assert.equal(
     program.target_exercise_id,
@@ -83,12 +76,12 @@ function assertPhase4PlanContract(program, { minItems = 2 } = {}) {
     "program.target_exercise_id must equal planned_exercise_ids[0]"
   );
 
-  // Candidate pool for substitution (Phase5) must be present and consistent.
   assert.ok(Array.isArray(program.exercises), "program.exercises must be an array");
-  assert.equal(typeof program.exercise_pool, "object", "program.exercise_pool must be an object");
-  assert.ok(program.exercise_pool && !Array.isArray(program.exercise_pool), "program.exercise_pool must be a map/object");
 
-  // The pool must at least include all planned ids (otherwise Phase5 can't score safely).
+  assert.ok(program.exercise_pool !== null && program.exercise_pool !== undefined, "program.exercise_pool must exist");
+  assert.equal(typeof program.exercise_pool, "object");
+  assert.ok(!Array.isArray(program.exercise_pool), "program.exercise_pool must be a map/object");
+
   for (const id of program.planned_exercise_ids) {
     assert.ok(program.exercise_pool[id], `exercise_pool must include planned id: ${id}`);
   }
@@ -113,7 +106,6 @@ function assertTimeboxPlan(program, expectedLen, expectedAccessoryCount) {
   const primaries = program.planned_items.filter((x) => x.role === "primary");
   const accessories = program.planned_items.filter((x) => x.role === "accessory");
 
-  // Guardrail: never drop primaries (Phase4 generator currently emits 4 primaries baseline)
   assert.equal(primaries.length, 4, "must keep all 4 primaries");
   assert.equal(accessories.length, expectedAccessoryCount, `accessory count must be ${expectedAccessoryCount}`);
 }
@@ -127,9 +119,6 @@ test("Phase4: supported activities emit a rich, stable plan contract (powerlifti
   assert.ok(r.program, "result.program must exist");
 
   assertPhase4PlanContract(r.program, { minItems: 2 });
-
-  // Powerlifting currently emits a 6-slot plan (guardrail). If this changes intentionally,
-  // update this test in the same commit as the engine change.
   assert.equal(r.program.planned_items.length, 6, "powerlifting planned_items length must be 6");
 });
 
@@ -140,8 +129,6 @@ test("Phase4: supported activities emit a rich, stable plan contract (rugby_unio
   const r = phase4AssembleProgram(canonicalInput, phase3);
   assert.equal(r.ok, true, "phase4AssembleProgram should succeed");
   assertPhase4PlanContract(r.program, { minItems: 2 });
-
-  // Same 6-slot plan contract for now.
   assert.equal(r.program.planned_items.length, 6, "rugby_union planned_items length must be 6");
 });
 
@@ -152,8 +139,6 @@ test("Phase4: supported activities emit a rich, stable plan contract (general_st
   const r = phase4AssembleProgram(canonicalInput, phase3);
   assert.equal(r.ok, true, "phase4AssembleProgram should succeed");
   assertPhase4PlanContract(r.program, { minItems: 2 });
-
-  // Same 6-slot plan contract for now.
   assert.equal(r.program.planned_items.length, 6, "general_strength planned_items length must be 6");
 });
 
@@ -239,6 +224,111 @@ test("Phase4: unsupported activity returns stub program with empty plan + carrie
   assert.deepEqual(r.program.planned_exercise_ids, [], "stub planned_exercise_ids must be empty");
   assert.equal(r.program.target_exercise_id, "", "stub target_exercise_id must be empty");
 
-  // Constraints must be carried forward.
   assert.deepEqual(r.program.constraints, constraints, "stub must carry Phase3 constraints");
+});
+
+test("Phase4: Phase3 timebox is sovereign over raw input when both are present and disagree", () => {
+  const canonicalInput = mkInput("powerlifting", 60);
+  const phase3 = mkPhase3({
+    constraints_version: "1.0.0",
+    schedule: { session_timebox_minutes: 25 }
+  });
+
+  const r = phase4AssembleProgram(canonicalInput, phase3);
+  assert.equal(r.ok, true);
+  assertTimeboxPlan(r.program, 4, 0);
+});
+
+function entryMatchesId(obj, targetId) {
+  if (!obj || typeof obj !== "object") return false;
+  const candidates = [
+    obj.exercise_id,
+    obj.exerciseId,
+    obj.id,
+    obj.key,
+    obj.slug
+  ];
+  return candidates.some((v) => String(v ?? "") === targetId);
+}
+
+// Deep search: does the JSON contain bench_press either as a map key OR as an entry id field?
+function deepHasExerciseId(node, targetId) {
+  if (Array.isArray(node)) {
+    for (const el of node) {
+      if (deepHasExerciseId(el, targetId)) return true;
+    }
+    return false;
+  }
+
+  if (node && typeof node === "object") {
+    // key match (map registry)
+    if (Object.prototype.hasOwnProperty.call(node, targetId)) return true;
+
+    // entry match (array/object entries)
+    if (entryMatchesId(node, targetId)) return true;
+
+    for (const v of Object.values(node)) {
+      if (deepHasExerciseId(v, targetId)) return true;
+    }
+    return false;
+  }
+
+  return false;
+}
+
+// Deep remove:
+// - deletes object properties named targetId
+// - filters arrays removing objects whose id fields match targetId
+function deepRemoveExerciseId(node, targetId) {
+  if (Array.isArray(node)) {
+    const out = [];
+    for (const el of node) {
+      if (el && typeof el === "object" && entryMatchesId(el, targetId)) continue;
+      out.push(deepRemoveExerciseId(el, targetId));
+    }
+    return out;
+  }
+
+  if (node && typeof node === "object") {
+    const out = {};
+    for (const [k, v] of Object.entries(node)) {
+      if (k === targetId) continue; // delete map key
+      out[k] = deepRemoveExerciseId(v, targetId);
+    }
+    return out;
+  }
+
+  return node;
+}
+
+test("Phase4: FAIL HARD if any planned exercise_id is missing from registry (no silent omission)", () => {
+  const repoRoot = process.cwd();
+  const regPath = path.join(repoRoot, "registries", "exercise", "exercise.registry.json");
+  const original = fs.readFileSync(regPath, "utf8");
+
+  try {
+    const parsed = JSON.parse(original);
+
+    assert.ok(deepHasExerciseId(parsed, "bench_press"), "registry must contain bench_press for this test");
+
+    const modified = deepRemoveExerciseId(parsed, "bench_press");
+
+    // This is the assertion that was failing before; now it will work for key-maps and id-fields.
+    assert.ok(!deepHasExerciseId(modified, "bench_press"), "mutation must remove bench_press");
+
+    fs.writeFileSync(regPath, JSON.stringify(modified, null, 2) + "\n", "utf8");
+
+    const canonicalInput = { activity_id: "powerlifting" };
+    const phase3 = mkPhase3();
+
+    const r = phase4AssembleProgram(canonicalInput, phase3);
+
+    assert.equal(r.ok, false, "phase4AssembleProgram must fail when planned id missing");
+    assert.equal(r.failure_token, "PHASE4_MISSING_PLANNED_EXERCISE");
+    assert.ok(r.details, "details must exist");
+    assert.ok(Array.isArray(r.details.missing_exercise_ids), "details.missing_exercise_ids must be an array");
+    assert.ok(r.details.missing_exercise_ids.includes("bench_press"), "missing list must include bench_press");
+  } finally {
+    fs.writeFileSync(regPath, original, "utf8");
+  }
 });


### PR DESCRIPTION
What changed

Phase4 now prefers Phase3 canonical timebox over raw input.

Phase4 fails hard if any planned exercise is missing from the registry (no silent omission).

Tests expanded to cover Phase3 sovereignty + missing-registry failure.

Why

Prevents “quietly degraded” substitution pool + undefined Phase5 scoring.

Enforces single source of truth for constraints as Phase3 becomes sovereign.

Risk

If registry is incomplete/mis-keyed, Phase4 returns ok:false with PHASE4_MISSING_PLANNED_EXERCISE (intended).