### PR TITLE
Ticket-032: Phase5 planned_items preferred; single-substitution invariant

### DIFF
--- a/engine/src/phases/phase5.ts
+++ b/engine/src/phases/phase5.ts
@@ -25,12 +25,16 @@ export type Phase5Result =
  *
  * Ticket-030: timebox-safe targeting
  * - Phase5 MUST respect Phase4's *pruned* plan ordering.
- * - Today Phase4 emits planned_exercise_ids (pruned by timebox). planned_items may appear later.
- * - Therefore: planned_items[0] (if present) else planned_exercise_ids[0] else target_exercise_id else first candidate.
+ * - Today: Phase4 exposes planned_exercise_ids (pruned). planned_items may be internal/added later.
+ *
+ * Ticket-032: planned_items canonical (when present)
+ * - If planned_items exists, Phase5 MUST target planned_items[0].exercise_id.
+ * - Otherwise, target planned_exercise_ids[0], then target_exercise_id, then first candidate.
+ *
+ * IMPORTANT (E2E / Ticket-011):
+ * - Phase5 emits AT MOST ONE substitution rule (single-target), not one per planned item.
  */
-type PlannedItemLike = {
-  exercise_id?: unknown;
-};
+type PlannedItemLike = { exercise_id?: unknown };
 
 type Phase5ProgramLike = {
   exercises?: ExerciseSignature[];
@@ -124,12 +128,15 @@ function getPlannedTarget(program: Phase5ProgramLike): { id: string; index: numb
   return null;
 }
 
-function resolveTarget(program: Phase5ProgramLike, candidates: ExerciseSignature[]): { id: string; planned_item_index: number | null } | null {
-  // Future-proof: if planned_items appears, it is canonical post-Phase4.
+function resolveTarget(
+  program: Phase5ProgramLike,
+  candidates: ExerciseSignature[]
+): { id: string; planned_item_index: number | null } | null {
+  // Ticket-032: planned_items is canonical when present.
   const planned = getPlannedTarget(program);
   if (planned) return { id: planned.id, planned_item_index: planned.index };
 
-  // Current Phase4 contract: planned_exercise_ids is the pruned plan order. Prefer it over target_exercise_id.
+  // Ticket-030: planned_exercise_ids is current pruned plan order (prefer it over target_exercise_id).
   if (Array.isArray(program.planned_exercise_ids) && program.planned_exercise_ids.length > 0) {
     const first = String(program.planned_exercise_ids[0] ?? "");
     if (first) return { id: first, planned_item_index: null };
@@ -194,6 +201,15 @@ export function phase5ApplySubstitutionAndAdjustment(program: unknown, _canonica
 
   const target = targetId ? findById(candidates, targetId) : null;
   const constraints = normalizeConstraints(program.constraints);
+
+  // Ticket-011 invariant: empty constraints => no substitution
+  if (isEmptyConstraints(constraints)) {
+    return {
+      ok: true,
+      adjustments: [],
+      notes: ["PHASE_5: empty constraints; no substitution (Ticket 011 invariant)"]
+    };
+  }
 
   // Target missing => pick against fallback target (keep planned_item_index for traceability)
   if (!target) {

--- a/test/phase5.test.mjs
+++ b/test/phase5.test.mjs
@@ -15,7 +15,7 @@ const BASE = {
   bias_mode: "none"
 };
 
-test("Phase 5 returns empty adjustments when Phase 4 is a stub (non-powerlifting)", () => {
+test("Phase 5 returns empty adjustments when Phase 4 is a stub (unsupported activity)", () => {
   const res = runEngine({
     ...BASE,
     activity_id: "rugby"
@@ -26,7 +26,7 @@ test("Phase 5 returns empty adjustments when Phase 4 is a stub (non-powerlifting
   assert.deepEqual(res.phase5.adjustments, []);
 });
 
-test("Phase 5 targets Phase 4 pruned plan order (timebox-safe) and substitutes when constraints require it", () => {
+test("Phase 5 targets Phase4 pruned plan order (planned_items preferred when present) and substitutes when constraints require it", () => {
   const res = runEngine({
     ...BASE,
     activity_id: "powerlifting",
@@ -40,9 +40,8 @@ test("Phase 5 targets Phase 4 pruned plan order (timebox-safe) and substitutes w
   assert.ok(res.phase4);
   assert.ok(res.phase5);
 
-  // Canonical target for Phase5 must come from Phase4's plan order:
-  // - planned_items[0].exercise_id if Phase4 ever migrates
-  // - otherwise planned_exercise_ids[0] (current Phase4 contract, pruned by timebox)
+  // Expected target is Phase4's post-prune plan head:
+  // Prefer planned_items[0].exercise_id if Phase4 exposes it; otherwise planned_exercise_ids[0].
   let expectedTarget = null;
 
   if (res.phase4.planned_items && Array.isArray(res.phase4.planned_items) && res.phase4.planned_items.length > 0) {
@@ -65,4 +64,6 @@ test("Phase 5 targets Phase 4 pruned plan order (timebox-safe) and substitutes w
   assert.ok(details && typeof details === "object");
 
   assert.equal(details.target_exercise_id, expectedTarget);
+  assert.equal(typeof details.substitute_exercise_id, "string");
+  assert.ok(details.substitute_exercise_id.length > 0);
 });


### PR DESCRIPTION
Phase5 now selects its substitution target from the canonical post-prune plan order: planned_items[0].exercise_id when present, otherwise planned_exercise_ids[0] for the current Phase4 contract. This preserves timebox-safe ordering, keeps Ticket-011 behavior (substitute only when the chosen target is disqualified), and restores the E2E “exactly one substitution in multi-plan” invariant by emitting a single deterministic adjustment tied to the first planned item rather than scoring multiple planned exercises.