### PR TITLE
ci: allow green:fast as an authoritative entrypoint

### DIFF
--- a/ci/guards/green_entrypoint_guard.mjs
+++ b/ci/guards/green_entrypoint_guard.mjs
@@ -15,10 +15,11 @@ const fromGreen = process.env.KOLOSSEUM_GREEN_ENTRYPOINT === "1";
 
 // Allowlist:
 // - Entrypoints (intended human invocations)
-// - Internal steps required by those entrypoints (so green/dev:fast can actually run)
+// - Internal steps required by those entrypoints (so green/dev:fast/ci/green:fast can actually run)
 const allowed = new Set([
   // entrypoints
   "green",
+  "green:fast",
   "ci",
   "ci:parity",
   "dev:fast",
@@ -26,7 +27,7 @@ const allowed = new Set([
   "dev:status:full",
   "dev:prepush:smart",
 
-  // internal steps used by green/dev:fast/ci
+  // internal steps used by green/dev:fast/ci/green:fast
   "lint:fast",
   "test:unit",
   "test:ci",
@@ -38,11 +39,12 @@ if (fromGreen) process.exit(0);
 if (allowed.has(lifecycle)) process.exit(0);
 
 die(
-  "CI_GREEN_ENTRYPOINT_REQUIRED\\n" +
-    "Use an authoritative entry point:\\n" +
-    "  npm run green\\n" +
-    "  npm run dev:fast\\n" +
-    "  npm run ci:parity\\n" +
-    "\\nThis guard blocks ad-hoc partial runs and implicit writes.\\n" +
+  "CI_GREEN_ENTRYPOINT_REQUIRED\n" +
+    "Use an authoritative entry point:\n" +
+    "  npm run green\n" +
+    "  npm run green:fast\n" +
+    "  npm run dev:fast\n" +
+    "  npm run ci:parity\n" +
+    "\nThis guard blocks ad-hoc partial runs and implicit writes.\n" +
     `Blocked: npm_lifecycle_event=${lifecycle || "(unknown)"}`
 );


### PR DESCRIPTION
## What changed
-

## Why
-

## Tests
- [ ] npm test
- [ ] npm run lint

## Risk
-

## Rollback plan
-
