### PR TITLE
ci: fix green runner node spawn on Actions

### DIFF
--- a/ci/scripts/green.mjs
+++ b/ci/scripts/green.mjs
@@ -12,6 +12,10 @@ function die(msg, code = 1) {
 
 function run(cmd, args, label, opts = {}) {
   process.stdout.write(`\n== GREEN STEP: ${label} ==\n`);
+    // If a step asks to run "node", prefer the current Node binary.
+  // GitHub Actions can surface ENOENT when spawning "node" by name.
+  if (cmd === "node" || cmd === "node.exe") cmd = process.execPath;
+
   const r = spawnSync(cmd, args, {
     stdio: "inherit",
     shell: false,

--- a/ci/scripts/green_fast.mjs
+++ b/ci/scripts/green_fast.mjs
@@ -79,7 +79,9 @@ function runNpm(script, extraEnv = {}) {
     };
   }
 
-  const r = spawnSync(node, [npmCli, "run", script], {
+    const nodeExec = (node === "node" || node === "node.exe") ? process.execPath : node;
+
+  const r = spawnSync(nodeExec, [npmCli, "run", script], {
     encoding: "utf8",
     stdio: "inherit",
     shell: false,


### PR DESCRIPTION
Fixes CI failure on GitHub Actions: green runner was spawning cmd='node' which can fail with ENOENT. When cmd/node is 'node' or 'node.exe', use process.execPath instead.