### PR TITLE
style(ci): normalize green runner indentation

### DIFF
--- a/ci/scripts/green.mjs
+++ b/ci/scripts/green.mjs
@@ -12,7 +12,7 @@ function die(msg, code = 1) {
 
 function run(cmd, args, label, opts = {}) {
   process.stdout.write(`\n== GREEN STEP: ${label} ==\n`);
-    // If a step asks to run "node", prefer the current Node binary.
+  // If a step asks to run "node", prefer the current Node binary.
   // GitHub Actions can surface ENOENT when spawning "node" by name.
   if (cmd === "node" || cmd === "node.exe") cmd = process.execPath;
 

--- a/ci/scripts/green_fast.mjs
+++ b/ci/scripts/green_fast.mjs
@@ -79,7 +79,7 @@ function runNpm(script, extraEnv = {}) {
     };
   }
 
-    const nodeExec = (node === "node" || node === "node.exe") ? process.execPath : node;
+  const nodeExec = (node === "node" || node === "node.exe") ? process.execPath : node;
 
   const r = spawnSync(nodeExec, [npmCli, "run", script], {
     encoding: "utf8",


### PR DESCRIPTION
Non-functional: fixes indentation drift in green.mjs and green_fast.mjs. Keeps LF + UTF8-noBOM.