### PR TITLE
feat(engine): enforce RETURN decision gate after split

### DIFF
--- a/engine/src/runtime/session_runtime.js
+++ b/engine/src/runtime/session_runtime.js
@@ -10,6 +10,9 @@ function die(msg) {
 function dieUnknownEvent(t) {
     throw new Error(`PHASE6_RUNTIME_UNKNOWN_EVENT: ${t}`);
 }
+function dieAwaitReturnDecision(t) {
+    throw new Error(`PHASE6_RUNTIME_AWAIT_RETURN_DECISION: ${t}`);
+}
 function normalizeType(t) {
     switch (t) {
         // engine internal -> canonical
@@ -234,13 +237,13 @@ function removeId(list, id) {
     return list.filter((x) => x !== id);
 }
 function syncDerived(st) {
-    // keep alias sets in sync
     st.dropped_ids = st.skipped_ids;
     st.remaining_exercises = idsToRefs(st.remaining_ids);
     st.completed_exercises = setToRefsStable(st.completed_ids);
     st.skipped_exercises = setToRefsStable(st.skipped_ids);
     st.dropped_exercises = st.skipped_exercises;
-    // short aliases
+    st.return_decision_required = !!st.split_active;
+    st.return_decision_options = st.return_decision_required ? ["RETURN_CONTINUE", "RETURN_SKIP"] : [];
     st.remaining = st.remaining_exercises;
     st.completed = st.completed_exercises;
     st.skipped = st.skipped_exercises;
@@ -252,12 +255,6 @@ function autoCloseSplitIfDone(st) {
         st.remaining_at_split_ids = [];
     }
 }
-/**
- * Hardening rules:
- * - Ensure all expected fields exist
- * - Accept legacy 'dropped_ids' naming
- * - If split_active=true and remaining_at_split_ids is present, it is authoritative for what was remaining at split time.
- */
 function ensureStateShape(state, plannedFallback) {
     if (!isRecord(state)) {
         const st = {
@@ -276,6 +273,8 @@ function ensureStateShape(state, plannedFallback) {
             completed: [],
             skipped: [],
             dropped: [],
+            return_decision_required: false,
+            return_decision_options: [],
         };
         autoCloseSplitIfDone(st);
         syncDerived(st);
@@ -283,9 +282,10 @@ function ensureStateShape(state, plannedFallback) {
     }
     const s = state;
     const started = typeof s.started === "boolean" ? s.started : true;
-    const remaining_ids_raw = Array.isArray(s.remaining_ids) ? uniqStableIds(s.remaining_ids) : plannedFallback.slice();
+    const remaining_ids_raw = Array.isArray(s.remaining_ids)
+        ? uniqStableIds(s.remaining_ids)
+        : plannedFallback.slice();
     const completed_ids = setFromUnknownList(s.completed_ids);
-    // accept BOTH names as input; unify to skipped_ids
     const skipped_ids = (() => {
         const a = setFromUnknownList(s.skipped_ids);
         const b = setFromUnknownList(s.dropped_ids);
@@ -295,7 +295,6 @@ function ensureStateShape(state, plannedFallback) {
             return a;
         if (a.size === 0 && b.size === 0)
             return new Set();
-        // merge deterministically if both exist
         const out = new Set();
         for (const v of Array.from(a.values()).sort())
             out.add(v);
@@ -321,6 +320,8 @@ function ensureStateShape(state, plannedFallback) {
         completed: [],
         skipped: [],
         dropped: [],
+        return_decision_required: false,
+        return_decision_options: [],
     };
     autoCloseSplitIfDone(st);
     syncDerived(st);
@@ -344,6 +345,8 @@ export function makeRuntimeState(session) {
         completed: [],
         skipped: [],
         dropped: [],
+        return_decision_required: false,
+        return_decision_options: [],
     };
     autoCloseSplitIfDone(st);
     syncDerived(st);
@@ -354,11 +357,14 @@ export function applyRuntimeEvent(state, event) {
     const plannedFallback = Array.isArray(state?.remaining_ids) ? uniqStableIds(state.remaining_ids) : [];
     const st = ensureStateShape(state, plannedFallback);
     const t = normalizeType(event.type);
+    // RETURN decision gate
+    if (st.split_active && (t === "COMPLETE_EXERCISE" || t === "SKIP_EXERCISE")) {
+        dieAwaitReturnDecision(t);
+    }
     switch (t) {
         case "COMPLETE_EXERCISE": {
             const id = event.exercise_id;
             st.started = true;
-            // no-op if terminal already recorded
             if (st.completed_ids.has(id) || st.skipped_ids.has(id)) {
                 autoCloseSplitIfDone(st);
                 syncDerived(st);
@@ -387,7 +393,6 @@ export function applyRuntimeEvent(state, event) {
         case "SPLIT_SESSION": {
             st.started = true;
             st.split_active = true;
-            // authoritative capture of what was remaining at split time
             st.remaining_at_split_ids = st.remaining_ids.slice();
             autoCloseSplitIfDone(st);
             syncDerived(st);
@@ -395,7 +400,6 @@ export function applyRuntimeEvent(state, event) {
         }
         case "RETURN_CONTINUE": {
             st.started = true;
-            // explicit decision: resume without dropping
             st.split_active = false;
             st.remaining_at_split_ids = [];
             autoCloseSplitIfDone(st);
@@ -404,9 +408,6 @@ export function applyRuntimeEvent(state, event) {
         }
         case "RETURN_SKIP": {
             st.started = true;
-            // Explicit decision: drop all remaining work.
-            // Primary authoritative set is remaining_at_split_ids (what existed when they split),
-            // but we also union with current remaining_ids as a hardening fallback.
             const toDrop = new Set();
             for (const id of st.remaining_at_split_ids)
                 toDrop.add(id);

--- a/engine/src/runtime/session_runtime.ts
+++ b/engine/src/runtime/session_runtime.ts
@@ -8,7 +8,7 @@ function isIterable(x: unknown): x is Iterable<unknown> {
   return !!x && (typeof x === "object" || typeof x === "function") && Symbol.iterator in (x as any);
 }
 
-function die(msg: string): never {
+function die(msg: unknown): never {
   throw new Error(String(msg));
 }
 
@@ -16,62 +16,18 @@ function dieUnknownEvent(t: string): never {
   throw new Error(`PHASE6_RUNTIME_UNKNOWN_EVENT: ${t}`);
 }
 
-// Engine-internal (wire) variants — MUST match engine/src/runtime/types.ts
-type LowerRuntimeEvent =
-  | { type: "complete_exercise"; exercise_id: string }
-  | { type: "skip_exercise"; exercise_id: string }
-  | { type: "split_start" }
-  | { type: "split_return_continue" }
-  | { type: "split_return_skip" };
+function dieAwaitReturnDecision(t: string): never {
+  throw new Error(`PHASE6_RUNTIME_AWAIT_RETURN_DECISION: ${t}`);
+}
 
-// E2E canonical variants (used by runtime truth tests / wrapper)
-type UpperRuntimeEvent =
-  | { type: "COMPLETE_EXERCISE"; exercise_id: string }
-  | { type: "SKIP_EXERCISE"; exercise_id: string }
-  | { type: "SPLIT_SESSION" }
-  | { type: "RETURN_CONTINUE" }
-  | { type: "RETURN_SKIP" };
+type CanonicalType =
+  | "COMPLETE_EXERCISE"
+  | "SKIP_EXERCISE"
+  | "SPLIT_SESSION"
+  | "RETURN_CONTINUE"
+  | "RETURN_SKIP";
 
-export type RuntimeEvent = LowerRuntimeEvent | UpperRuntimeEvent;
-
-export type RuntimeExerciseRef = { exercise_id: string };
-
-/**
- * Canonical Phase6 runtime reducer state:
- * - *_ids are Sets (tests call .has)
- * - remaining_ids is ordered array (deterministic)
- * - split_active + remaining_at_split_ids capture split semantics
- * - arrays exist for E2E callers that do .map/.length
- *
- * Compatibility aliases included:
- * - dropped_* aliases for skipped_* (many tests/upgrade paths use dropped_ids naming)
- * - remaining/completed/dropped array aliases (some wrappers use shorter names)
- */
-export type RuntimeState = {
-  started: boolean;
-
-  remaining_ids: string[];
-
-  completed_ids: Set<string>;
-  skipped_ids: Set<string>; // canonical internal name
-  dropped_ids: Set<string>; // alias (kept in sync)
-
-  split_active: boolean;
-  remaining_at_split_ids: string[];
-
-  remaining_exercises: RuntimeExerciseRef[];
-  completed_exercises: RuntimeExerciseRef[];
-  skipped_exercises: RuntimeExerciseRef[];
-  dropped_exercises: RuntimeExerciseRef[]; // alias (kept in sync)
-
-  // short aliases (kept in sync)
-  remaining: RuntimeExerciseRef[];
-  completed: RuntimeExerciseRef[];
-  skipped: RuntimeExerciseRef[];
-  dropped: RuntimeExerciseRef[];
-};
-
-function normalizeType(t: string): UpperRuntimeEvent["type"] {
+function normalizeType(t: string): CanonicalType {
   switch (t) {
     // engine internal -> canonical
     case "complete_exercise": return "COMPLETE_EXERCISE";
@@ -93,19 +49,26 @@ function normalizeType(t: string): UpperRuntimeEvent["type"] {
   }
 }
 
+type RuntimeEvent =
+  | { type: "COMPLETE_EXERCISE" | "complete_exercise"; exercise_id: string }
+  | { type: "SKIP_EXERCISE" | "skip_exercise"; exercise_id: string }
+  | { type: "SPLIT_SESSION" | "split_start" }
+  | { type: "RETURN_CONTINUE" | "split_return_continue" }
+  | { type: "RETURN_SKIP" | "split_return_skip" };
+
 function validateEvent(ev: unknown): asserts ev is RuntimeEvent {
   if (!isRecord(ev)) die("PHASE6_RUNTIME_INVALID_EVENT: event must be an object");
   if (typeof ev.type !== "string" || ev.type.length === 0) die("PHASE6_RUNTIME_INVALID_EVENT: missing string type");
 
   const t = normalizeType(ev.type);
-
   switch (t) {
     case "COMPLETE_EXERCISE":
     case "SKIP_EXERCISE": {
-      const id = (ev as AnyRecord).exercise_id;
+      const id = (ev as any).exercise_id;
       if (typeof id !== "string" || id.length === 0) die(`PHASE6_RUNTIME_INVALID_EVENT: ${t} missing exercise_id`);
       return;
     }
+
     case "SPLIT_SESSION":
     case "RETURN_CONTINUE":
     case "RETURN_SKIP":
@@ -122,6 +85,7 @@ function toExerciseId(x: unknown): string | null {
 function uniqStableIds(list: unknown[]): string[] {
   const out: string[] = [];
   const seen = new Set<string>();
+
   for (const it of list) {
     const id = toExerciseId(it);
     if (!id) continue;
@@ -129,6 +93,7 @@ function uniqStableIds(list: unknown[]): string[] {
     seen.add(id);
     out.push(id);
   }
+
   return out;
 }
 
@@ -136,9 +101,9 @@ function collectUnknownList(x: unknown): unknown[] | null {
   if (Array.isArray(x)) return x;
 
   if (isRecord(x)) {
-    const maybeIds = (x as AnyRecord).ids;
-    const maybePlanned = (x as AnyRecord).planned_ids;
-    const maybeExerciseIds = (x as AnyRecord).exercise_ids;
+    const maybeIds = (x as any).ids;
+    const maybePlanned = (x as any).planned_ids;
+    const maybeExerciseIds = (x as any).exercise_ids;
 
     if (Array.isArray(maybeIds)) return maybeIds;
     if (Array.isArray(maybePlanned)) return maybePlanned;
@@ -146,11 +111,7 @@ function collectUnknownList(x: unknown): unknown[] | null {
   }
 
   if (isIterable(x)) {
-    try {
-      return Array.from(x as Iterable<unknown>);
-    } catch {
-      return null;
-    }
+    try { return Array.from(x as any); } catch { return null; }
   }
 
   return null;
@@ -159,27 +120,21 @@ function collectUnknownList(x: unknown): unknown[] | null {
 function deepFindCandidateLists(root: unknown, maxDepth: number): unknown[][] {
   if (!isRecord(root)) return [];
 
-  type Node = { v: AnyRecord; depth: number };
-  const q: Node[] = [{ v: root, depth: 0 }];
-  const seen = new Set<AnyRecord>();
-
-  const found: { score: number; list: unknown[] }[] = [];
+  const q: Array<{ v: AnyRecord; depth: number }> = [{ v: root, depth: 0 }];
+  const seen = new Set<any>();
+  const found: Array<{ score: number; list: unknown[] }> = [];
 
   function keyScore(k: string): number {
     const key = k.toLowerCase();
-
     if (key.includes("planned_items")) return 100;
     if (key.includes("planned_exercise")) return 95;
     if (key === "planned_ids" || key.includes("planned_ids")) return 90;
     if (key === "exercises" || key.includes("session_exercises")) return 85;
-
     if (key.includes("remaining_exercises") || key.includes("remaining_ids")) return 70;
     if (key.includes("exercise_ids")) return 65;
     if (key.includes("plan")) return 60;
-
     if (key.includes("items")) return 20;
     if (key.includes("ids")) return 10;
-
     return 0;
   }
 
@@ -219,17 +174,17 @@ function extractPlannedIds(sessionLike: unknown): string[] {
     die("PHASE6_RUNTIME_BAD_SESSION: expected session-like object or iterable of exercise ids");
   }
 
-  const s = sessionLike;
+  const s = sessionLike as AnyRecord;
 
   // 1) common keys
-  const candidates: unknown[] = [
-    (s as AnyRecord).planned_items,
-    (s as AnyRecord).planned_exercise_ids,
-    (s as AnyRecord).planned_ids,
-    (s as AnyRecord).session_exercises,
-    (s as AnyRecord).exercises,
-    (s as AnyRecord).remaining_exercises,
-    (s as AnyRecord).remaining_ids,
+  const candidates = [
+    (s as any).planned_items,
+    (s as any).planned_exercise_ids,
+    (s as any).planned_ids,
+    (s as any).session_exercises,
+    (s as any).exercises,
+    (s as any).remaining_exercises,
+    (s as any).remaining_ids,
   ];
 
   for (const c of candidates) {
@@ -241,14 +196,14 @@ function extractPlannedIds(sessionLike: unknown): string[] {
   }
 
   // 2) wrappers
-  const wrappers: unknown[] = [
-    (s as AnyRecord).session,
-    (s as AnyRecord).plan,
-    (s as AnyRecord).program,
-    (s as AnyRecord).phase6,
-    (s as AnyRecord).summary,
-    (s as AnyRecord).session_state,
-    (s as AnyRecord).state,
+  const wrappers = [
+    (s as any).session,
+    (s as any).plan,
+    (s as any).program,
+    (s as any).phase6,
+    (s as any).summary,
+    (s as any).session_state,
+    (s as any).state,
   ];
 
   for (const w of wrappers) {
@@ -273,25 +228,28 @@ function extractPlannedIds(sessionLike: unknown): string[] {
 }
 
 function setFromUnknownList(x: unknown): Set<string> {
-  if (!x) return new Set<string>();
+  if (!x) return new Set();
+
   if (x instanceof Set) {
     const out = new Set<string>();
-    for (const v of x) if (typeof v === "string" && v.length > 0) out.add(v);
+    for (const v of x as any) if (typeof v === "string" && v.length > 0) out.add(v);
     return out;
   }
+
   if (Array.isArray(x)) {
     const out = new Set<string>();
     for (const v of x) if (typeof v === "string" && v.length > 0) out.add(v);
     return out;
   }
-  return new Set<string>();
+
+  return new Set();
 }
 
-function idsToRefs(ids: string[]): RuntimeExerciseRef[] {
+function idsToRefs(ids: string[]): Array<{ exercise_id: string }> {
   return ids.map((exercise_id) => ({ exercise_id }));
 }
 
-function setToRefsStable(s: Set<string>): RuntimeExerciseRef[] {
+function setToRefsStable(s: Set<string>): Array<{ exercise_id: string }> {
   return Array.from(s.values()).sort().map((exercise_id) => ({ exercise_id }));
 }
 
@@ -299,8 +257,32 @@ function removeId(list: string[], id: string): string[] {
   return list.filter((x) => x !== id);
 }
 
-function syncDerived(st: RuntimeState): void {
-  // keep alias sets in sync
+type RuntimeStateInternal = {
+  started: boolean;
+  remaining_ids: string[];
+  completed_ids: Set<string>;
+  skipped_ids: Set<string>;
+  dropped_ids: Set<string>;
+  split_active: boolean;
+  remaining_at_split_ids: string[];
+
+  remaining_exercises: Array<{ exercise_id: string }>;
+  completed_exercises: Array<{ exercise_id: string }>;
+  skipped_exercises: Array<{ exercise_id: string }>;
+  dropped_exercises: Array<{ exercise_id: string }>;
+
+  remaining: Array<{ exercise_id: string }>;
+  completed: Array<{ exercise_id: string }>;
+  skipped: Array<{ exercise_id: string }>;
+  dropped: Array<{ exercise_id: string }>;
+
+  return_decision_required: boolean;
+  return_decision_options: string[];
+
+  [k: string]: unknown;
+};
+
+function syncDerived(st: RuntimeStateInternal): void {
   st.dropped_ids = st.skipped_ids;
 
   st.remaining_exercises = idsToRefs(st.remaining_ids);
@@ -308,48 +290,44 @@ function syncDerived(st: RuntimeState): void {
   st.skipped_exercises = setToRefsStable(st.skipped_ids);
   st.dropped_exercises = st.skipped_exercises;
 
-  // short aliases
+  st.return_decision_required = !!st.split_active;
+  st.return_decision_options = st.return_decision_required ? ["RETURN_CONTINUE", "RETURN_SKIP"] : [];
+
   st.remaining = st.remaining_exercises;
   st.completed = st.completed_exercises;
   st.skipped = st.skipped_exercises;
   st.dropped = st.dropped_exercises;
 }
 
-function autoCloseSplitIfDone(st: RuntimeState): void {
+function autoCloseSplitIfDone(st: RuntimeStateInternal): void {
   if (st.remaining_ids.length === 0) {
     st.split_active = false;
     st.remaining_at_split_ids = [];
   }
 }
 
-/**
- * Hardening rules:
- * - Ensure all expected fields exist
- * - Accept legacy 'dropped_ids' naming
- * - If split_active=true and remaining_at_split_ids is present, it is authoritative for what was remaining at split time.
- */
-function ensureStateShape(state: unknown, plannedFallback: string[]): RuntimeState {
+function ensureStateShape(state: unknown, plannedFallback: string[]): RuntimeStateInternal {
   if (!isRecord(state)) {
-    const st: RuntimeState = {
+    const st: RuntimeStateInternal = {
       started: true,
       remaining_ids: plannedFallback.slice(),
-      completed_ids: new Set<string>(),
-      skipped_ids: new Set<string>(),
-      dropped_ids: new Set<string>(),
-
+      completed_ids: new Set(),
+      skipped_ids: new Set(),
+      dropped_ids: new Set(),
       split_active: false,
       remaining_at_split_ids: [],
-
       remaining_exercises: [],
       completed_exercises: [],
       skipped_exercises: [],
       dropped_exercises: [],
-
       remaining: [],
       completed: [],
       skipped: [],
       dropped: [],
+      return_decision_required: false,
+      return_decision_options: [],
     };
+
     autoCloseSplitIfDone(st);
     syncDerived(st);
     return st;
@@ -357,51 +335,49 @@ function ensureStateShape(state: unknown, plannedFallback: string[]): RuntimeSta
 
   const s = state as AnyRecord;
 
-  const started = typeof s.started === "boolean" ? s.started : true;
+  const started = typeof (s as any).started === "boolean" ? (s as any).started : true;
 
-  const remaining_ids_raw =
-    Array.isArray(s.remaining_ids) ? uniqStableIds(s.remaining_ids) : plannedFallback.slice();
+  const remaining_ids_raw = Array.isArray((s as any).remaining_ids)
+    ? uniqStableIds((s as any).remaining_ids)
+    : plannedFallback.slice();
 
-  const completed_ids = setFromUnknownList((s as AnyRecord).completed_ids);
+  const completed_ids = setFromUnknownList((s as any).completed_ids);
 
-  // accept BOTH names as input; unify to skipped_ids
   const skipped_ids = (() => {
-    const a = setFromUnknownList((s as AnyRecord).skipped_ids);
-    const b = setFromUnknownList((s as AnyRecord).dropped_ids);
+    const a = setFromUnknownList((s as any).skipped_ids);
+    const b = setFromUnknownList((s as any).dropped_ids);
+
     if (a.size === 0 && b.size > 0) return b;
     if (a.size > 0 && b.size === 0) return a;
     if (a.size === 0 && b.size === 0) return new Set<string>();
-    // merge deterministically if both exist
+
     const out = new Set<string>();
     for (const v of Array.from(a.values()).sort()) out.add(v);
     for (const v of Array.from(b.values()).sort()) out.add(v);
     return out;
   })();
 
-  const split_active = typeof s.split_active === "boolean" ? s.split_active : false;
-  const remaining_at_split_ids =
-    Array.isArray(s.remaining_at_split_ids) ? uniqStableIds(s.remaining_at_split_ids) : [];
+  const split_active = typeof (s as any).split_active === "boolean" ? (s as any).split_active : false;
+  const remaining_at_split_ids = Array.isArray((s as any).remaining_at_split_ids) ? uniqStableIds((s as any).remaining_at_split_ids) : [];
 
-  const st: RuntimeState = {
+  const st: RuntimeStateInternal = {
     started,
     remaining_ids: remaining_ids_raw,
-
     completed_ids,
     skipped_ids,
     dropped_ids: skipped_ids,
-
     split_active,
     remaining_at_split_ids,
-
     remaining_exercises: [],
     completed_exercises: [],
     skipped_exercises: [],
     dropped_exercises: [],
-
     remaining: [],
     completed: [],
     skipped: [],
     dropped: [],
+    return_decision_required: false,
+    return_decision_options: [],
   };
 
   autoCloseSplitIfDone(st);
@@ -409,28 +385,27 @@ function ensureStateShape(state: unknown, plannedFallback: string[]): RuntimeSta
   return st;
 }
 
-export function makeRuntimeState(session: unknown): RuntimeState {
+export function makeRuntimeState(session: unknown): RuntimeStateInternal {
   const planned = extractPlannedIds(session);
 
-  const st: RuntimeState = {
+  const st: RuntimeStateInternal = {
     started: true,
     remaining_ids: planned,
-    completed_ids: new Set<string>(),
-    skipped_ids: new Set<string>(),
-    dropped_ids: new Set<string>(),
-
+    completed_ids: new Set(),
+    skipped_ids: new Set(),
+    dropped_ids: new Set(),
     split_active: false,
     remaining_at_split_ids: [],
-
     remaining_exercises: [],
     completed_exercises: [],
     skipped_exercises: [],
     dropped_exercises: [],
-
     remaining: [],
     completed: [],
     skipped: [],
     dropped: [],
+    return_decision_required: false,
+    return_decision_options: [],
   };
 
   autoCloseSplitIfDone(st);
@@ -438,22 +413,23 @@ export function makeRuntimeState(session: unknown): RuntimeState {
   return st;
 }
 
-export function applyRuntimeEvent(state: RuntimeState, event: RuntimeEvent): RuntimeState {
+export function applyRuntimeEvent(state: unknown, event: unknown): RuntimeStateInternal {
   validateEvent(event);
 
-  const plannedFallback: string[] =
-    Array.isArray((state as any)?.remaining_ids) ? uniqStableIds((state as any).remaining_ids) : [];
+  const plannedFallback = Array.isArray((state as any)?.remaining_ids) ? uniqStableIds((state as any).remaining_ids) : [];
+  const st = ensureStateShape(state, plannedFallback);
+  const t = normalizeType((event as any).type);
 
-  const st = ensureStateShape(state as unknown, plannedFallback);
-  const t = normalizeType(event.type);
+  // RETURN decision gate
+  if (st.split_active && (t === "COMPLETE_EXERCISE" || t === "SKIP_EXERCISE")) {
+    dieAwaitReturnDecision(t);
+  }
 
   switch (t) {
     case "COMPLETE_EXERCISE": {
       const id = (event as any).exercise_id as string;
-
       st.started = true;
 
-      // no-op if terminal already recorded
       if (st.completed_ids.has(id) || st.skipped_ids.has(id)) {
         autoCloseSplitIfDone(st);
         syncDerived(st);
@@ -470,7 +446,6 @@ export function applyRuntimeEvent(state: RuntimeState, event: RuntimeEvent): Run
 
     case "SKIP_EXERCISE": {
       const id = (event as any).exercise_id as string;
-
       st.started = true;
 
       if (st.skipped_ids.has(id) || st.completed_ids.has(id)) {
@@ -489,9 +464,7 @@ export function applyRuntimeEvent(state: RuntimeState, event: RuntimeEvent): Run
 
     case "SPLIT_SESSION": {
       st.started = true;
-
       st.split_active = true;
-      // authoritative capture of what was remaining at split time
       st.remaining_at_split_ids = st.remaining_ids.slice();
 
       autoCloseSplitIfDone(st);
@@ -501,8 +474,6 @@ export function applyRuntimeEvent(state: RuntimeState, event: RuntimeEvent): Run
 
     case "RETURN_CONTINUE": {
       st.started = true;
-
-      // explicit decision: resume without dropping
       st.split_active = false;
       st.remaining_at_split_ids = [];
 
@@ -514,11 +485,7 @@ export function applyRuntimeEvent(state: RuntimeState, event: RuntimeEvent): Run
     case "RETURN_SKIP": {
       st.started = true;
 
-      // Explicit decision: drop all remaining work.
-      // Primary authoritative set is remaining_at_split_ids (what existed when they split),
-      // but we also union with current remaining_ids as a hardening fallback.
       const toDrop = new Set<string>();
-
       for (const id of st.remaining_at_split_ids) toDrop.add(id);
       for (const id of st.remaining_ids) toDrop.add(id);
 

--- a/engine/types/runtime/apply_runtime_event.d.ts
+++ b/engine/types/runtime/apply_runtime_event.d.ts
@@ -11,6 +11,15 @@ export type RuntimeState = {
   completed_exercises: RuntimeExerciseRef[];
   remaining_exercises: RuntimeExerciseRef[];
   dropped_exercises: RuntimeExerciseRef[];
+
+  // Split/return decision gate surface (UI should key off these, not infer)
+  split_active?: boolean;
+  return_decision_required?: boolean;
+  return_decision_options?: Array<"RETURN_CONTINUE" | "RETURN_SKIP">;
+
+  // Debug/hardening (engine keeps these in sync)
+  remaining_at_split_ids?: string[];
+
   [k: string]: unknown;
 };
 

--- a/test/phase6_return_decision_gate.test.mjs
+++ b/test/phase6_return_decision_gate.test.mjs
@@ -1,0 +1,50 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { applyRuntimeEvents } from "@kolosseum/engine/runtime/apply_runtime_event.js";
+
+function mkSession(ids) {
+  return { planned_items: ids.map((exercise_id) => ({ exercise_id })) };
+}
+
+test("Phase6 runtime: after SPLIT_SESSION, COMPLETE_EXERCISE is forbidden until RETURN decision", () => {
+  const session = mkSession(["ex_a", "ex_b"]);
+
+  assert.throws(() => {
+    applyRuntimeEvents(session, [
+      { type: "SPLIT_SESSION" },
+      { type: "COMPLETE_EXERCISE", exercise_id: "ex_a" },
+    ]);
+  }, (err) => {
+    assert.ok(err instanceof Error);
+    assert.ok(err.message.includes("PHASE6_RUNTIME_AWAIT_RETURN_DECISION"));
+    return true;
+  });
+});
+
+test("Phase6 runtime: RETURN_CONTINUE clears gate and allows progress", () => {
+  const session = mkSession(["ex_a", "ex_b"]);
+
+  const st = applyRuntimeEvents(session, [
+    { type: "SPLIT_SESSION" },
+    { type: "RETURN_CONTINUE" },
+    { type: "COMPLETE_EXERCISE", exercise_id: "ex_a" },
+  ]);
+
+  assert.equal(st.return_decision_required, false);
+  assert.deepEqual(st.completed_exercises, [{ exercise_id: "ex_a" }]);
+});
+
+test("Phase6 runtime: RETURN_SKIP drops remaining deterministically (Phase 1 fallback: drop all remaining)", () => {
+  const session = mkSession(["ex_a", "ex_b"]);
+
+  const st = applyRuntimeEvents(session, [
+    { type: "SPLIT_SESSION" },
+    { type: "RETURN_SKIP" },
+  ]);
+
+  assert.equal(st.return_decision_required, false);
+  assert.deepEqual(st.remaining_exercises, []);
+  // all planned become dropped in this fallback
+  assert.deepEqual(st.dropped_exercises, [{ exercise_id: "ex_a" }, { exercise_id: "ex_b" }]);
+});


### PR DESCRIPTION
## What
Enforce a hard gate after SPLIT_SESSION: no COMPLETE_EXERCISE/SKIP_EXERCISE until RETURN_CONTINUE or RETURN_SKIP.

## Why
Prevents invalid runtime progression and matches UI contract: athlete must explicitly choose Continue vs Skip on return.

## Notes
- Runtime state now surfaces return_decision_required + return_decision_options.
- Adds unit tests for the gate + both return paths.