### PR TITLE
api: session state cache v1 (TTL) + invalidation

### DIFF
--- a/src/api/session_state_cache.ts
+++ b/src/api/session_state_cache.ts
@@ -1,0 +1,121 @@
+// src/api/session_state_cache.ts
+type CacheEntry = {
+  expires_at_ms: number;
+  payload_json: string; // store serialized JSON for immutability
+};
+
+export type SessionStateCache = {
+  get: (session_id: string) => any | null;
+  set: (session_id: string, payload: unknown, ttl_ms: number) => void;
+  del: (session_id: string) => void;
+  clear: () => void;
+  stats: () => { size: number; hits: number; misses: number };
+};
+
+function nowMs(): number {
+  return Date.now();
+}
+
+export function createSessionStateCache(opts?: { max_entries?: number }): SessionStateCache {
+  const max = Number(opts?.max_entries ?? 10_000);
+  const m = new Map<string, CacheEntry>();
+
+  let hits = 0;
+  let misses = 0;
+
+  function sweepExpired(limit: number): number {
+    const n = nowMs();
+    let removed = 0;
+    for (const [k, v] of m) {
+      if (v.expires_at_ms <= n) {
+        m.delete(k);
+        removed += 1;
+        if (removed >= limit) break;
+      }
+    }
+    return removed;
+  }
+
+  function enforceMax(): void {
+    if (m.size <= max) return;
+
+    // First try clearing expired entries (cheap win)
+    sweepExpired(Math.min(512, m.size));
+
+    // Still too big? Hard-evict oldest-ish by iterating insertion order.
+    while (m.size > max) {
+      const firstKey = m.keys().next().value as string | undefined;
+      if (!firstKey) break;
+      m.delete(firstKey);
+    }
+  }
+
+  function get(session_id: string) {
+    const v = m.get(session_id);
+    if (!v) {
+      misses += 1;
+      return null;
+    }
+
+    if (v.expires_at_ms <= nowMs()) {
+      m.delete(session_id);
+      misses += 1;
+      return null;
+    }
+
+    hits += 1;
+
+    // defensive parse; if corrupted, drop
+    try {
+      return JSON.parse(v.payload_json);
+    } catch {
+      m.delete(session_id);
+      misses += 1;
+      return null;
+    }
+  }
+
+  function set(session_id: string, payload: unknown, ttl_ms: number) {
+    const ttl = Number(ttl_ms);
+    if (!Number.isFinite(ttl) || ttl <= 0) return;
+
+    // do not cache null/undefined
+    if (payload === null || typeof payload === "undefined") return;
+
+    // serialize once
+    let payload_json: string;
+    try {
+      payload_json = JSON.stringify(payload);
+    } catch {
+      return; // non-serializable => don't cache
+    }
+
+    m.set(session_id, {
+      expires_at_ms: nowMs() + ttl,
+      payload_json
+    });
+
+    enforceMax();
+  }
+
+  function del(session_id: string) {
+    m.delete(session_id);
+  }
+
+  function clear() {
+    m.clear();
+    hits = 0;
+    misses = 0;
+  }
+
+  function stats() {
+    // opportunistic cleanup so size reflects reality
+    sweepExpired(Math.min(512, m.size));
+    return { size: m.size, hits, misses };
+  }
+
+  return { get, set, del, clear, stats };
+}
+
+// Default cache instance used by sessions.handlers.ts
+export const sessionStateCache = createSessionStateCache({ max_entries: 10_000 });

--- a/src/api/sessions.handlers.ts
+++ b/src/api/sessions.handlers.ts
@@ -21,6 +21,8 @@ import {
   internalError
 } from "./http_errors.js";
 
+import { sessionStateCache } from "./session_state_cache.js";
+
 type JsonRecord = Record<string, unknown>;
 
 function isRecord(v: unknown): v is JsonRecord {
@@ -337,6 +339,10 @@ export async function startSession(req: Request, res: Response) {
       );
 
       await client.query("COMMIT");
+
+      // invalidate cache after successful commit
+      sessionStateCache.del(session_id);
+
       return res.json({ ok: true, session_id, started: true });
     }
 
@@ -370,6 +376,10 @@ export async function startSession(req: Request, res: Response) {
     );
 
     await client.query("COMMIT");
+
+    // invalidate cache after successful commit
+    sessionStateCache.del(session_id);
+
     return res.status(200).json({ ok: true, session_id, started: true, seq });
   } catch (err: unknown) {
     try {
@@ -484,6 +494,10 @@ export async function appendRuntimeEvent(req: Request, res: Response) {
     );
 
     await client.query("COMMIT");
+
+    // invalidate cache after successful commit
+    sessionStateCache.del(session_id);
+
     return res.status(201).json({ ok: true, session_id, seq });
   } catch (err: unknown) {
     try {
@@ -514,14 +528,23 @@ export async function listRuntimeEvents(req: Request, res: Response) {
   return res.json({ session_id, events: r.rows });
 }
 
+const SESSION_STATE_CACHE_TTL_MS = 2000;
+
 /**
  * GET /sessions/:session_id/state
  * - O(1) read from sessions.session_state_summary (no runtime_events scan)
  * - Once started=true, response is derived ONLY from stored runtime snapshot + reducer-owned invariants.
+ * - Cache v1: read-through, short TTL, invalidated on start/events commit.
  */
 export async function getSessionState(req: Request, res: Response) {
   const session_id = asString(req.params?.session_id);
   if (!session_id) throw badRequest("Missing session_id");
+
+  // Cache-first (do not cache errors)
+  const cached = sessionStateCache.get(session_id);
+  if (cached) {
+    return res.json(cached);
+  }
 
   const client = await pool.connect();
   try {
@@ -570,7 +593,7 @@ export async function getSessionState(req: Request, res: Response) {
     const completed_exercises = toPlannedExercisesFromIds(planned, uniqStable(trace.completed_ids));
     const dropped_exercises = toPlannedExercisesFromIds(planned, uniqStable(trace.dropped_ids));
 
-    return res.json({
+    const payload = {
       session_id,
       started: trace.started,
       remaining_exercises,
@@ -578,7 +601,11 @@ export async function getSessionState(req: Request, res: Response) {
       dropped_exercises,
       trace,
       event_log: [] // history is /events; state is O(1)
-    });
+    };
+
+    sessionStateCache.set(session_id, payload, SESSION_STATE_CACHE_TTL_MS);
+
+    return res.json(payload);
   } finally {
     client.release();
   }

--- a/test/api_session_state_cache_v1.test.mjs
+++ b/test/api_session_state_cache_v1.test.mjs
@@ -1,0 +1,221 @@
+// test/api_session_state_cache_v1.test.mjs
+import test, { mock } from "node:test";
+import assert from "node:assert/strict";
+
+// Requires: node --test --experimental-test-module-mocks
+
+const distPoolUrl = new URL("../dist/src/db/pool.js", import.meta.url).href;
+const distHandlerUrl = new URL("../dist/src/api/sessions.handlers.js", import.meta.url).href;
+const distHttpErrorsUrl = new URL("../dist/src/api/http_errors.js", import.meta.url).href;
+
+// We do NOT mock session_state_cache; we want the real cache behavior.
+
+let connectCalls = 0;
+let loadStateSelectCalls = 0;
+let nextSeq = 0;
+
+function makeDbClient() {
+  return {
+    query: async (sql, _params) => {
+      const s = String(sql);
+
+      if (/BEGIN/i.test(s)) return { rowCount: 0, rows: [] };
+      if (/COMMIT/i.test(s)) return { rowCount: 0, rows: [] };
+      if (/ROLLBACK/i.test(s)) return { rowCount: 0, rows: [] };
+
+      // loadSession() in getSessionState()
+      if (/SELECT session_id, planned_session, session_state_summary\s+FROM sessions\s+WHERE session_id = \$1/i.test(s)) {
+        loadStateSelectCalls += 1;
+        return {
+          rowCount: 1,
+          rows: [
+            {
+              session_id: "s_cache",
+              planned_session: {
+                exercises: [{ exercise_id: "ex1", source: "program" }],
+                notes: []
+              },
+              session_state_summary: {
+                started: true,
+                runtime: {
+                  remaining_ids: ["ex1"],
+                  return_decision_required: false,
+                  return_decision_options: []
+                }
+              }
+            }
+          ]
+        };
+      }
+
+      // loadSessionForUpdate() in appendRuntimeEvent()
+      if (/SELECT session_id, status, planned_session, session_state_summary\s+FROM sessions\s+WHERE session_id = \$1\s+FOR UPDATE/i.test(s)) {
+        return {
+          rowCount: 1,
+          rows: [
+            {
+              session_id: "s_cache",
+              status: "in_progress",
+              planned_session: {
+                exercises: [{ exercise_id: "ex1", source: "program" }],
+                notes: []
+              },
+              session_state_summary: {
+                started: true,
+                runtime: {
+                  remaining_ids: ["ex1"],
+                  return_decision_required: false,
+                  return_decision_options: []
+                }
+              }
+            }
+          ]
+        };
+      }
+
+      // allocNextSeq(): seed
+      if (/INSERT INTO session_event_seq\(session_id, next_seq\)/i.test(s)) {
+        return { rowCount: 1, rows: [] };
+      }
+
+      // allocNextSeq(): bump
+      if (/UPDATE session_event_seq\s+SET next_seq = next_seq \+ 1/i.test(s)) {
+        nextSeq += 1;
+        return { rowCount: 1, rows: [{ next_seq: nextSeq }] };
+      }
+
+      // runtime_events insert
+      if (/INSERT INTO runtime_events\(session_id, seq, event\)/i.test(s)) {
+        return { rowCount: 1, rows: [] };
+      }
+
+      // session summary update
+      if (/UPDATE sessions\s+SET session_state_summary = \$2::jsonb/i.test(s)) {
+        return { rowCount: 1, rows: [] };
+      }
+
+      // status update (auto-start path)
+      if (/UPDATE sessions\s+SET status = 'in_progress'/i.test(s)) {
+        return { rowCount: 1, rows: [] };
+      }
+
+      return { rowCount: 0, rows: [] };
+    },
+    release: () => {}
+  };
+}
+
+mock.module(distPoolUrl, {
+  namedExports: {
+    pool: {
+      connect: async () => {
+        connectCalls += 1;
+        return makeDbClient();
+      },
+      query: async () => ({ rowCount: 0, rows: [] })
+    }
+  }
+});
+
+mock.module(distHttpErrorsUrl, {
+  namedExports: {
+    badRequest: (msg, meta) => Object.assign(new Error(msg), { status: 400, meta }),
+    notFound: (msg, meta) => Object.assign(new Error(msg), { status: 404, meta }),
+    upstreamBadGateway: (msg, meta) => Object.assign(new Error(msg), { status: 502, meta }),
+    internalError: (msg, meta) => Object.assign(new Error(msg), { status: 500, meta })
+  }
+});
+
+mock.module("@kolosseum/engine/runtime/session_summary.js", {
+  namedExports: {
+    normalizeSummary: (_planned, rawSummary) => ({ summary: rawSummary, needsUpgrade: false }),
+    deriveTrace: (summary) => {
+      const rt = summary?.runtime ?? {};
+      return {
+        started: summary?.started === true,
+        remaining_ids: rt.remaining_ids ?? [],
+        completed_ids: rt.completed_ids ?? [],
+        dropped_ids: rt.dropped_ids ?? []
+      };
+    },
+    validateWireRuntimeEvent: (x) => x,
+    applyWireEvent: (summary, ev) => {
+      // minimal reducer: if COMPLETE_EXERCISE, move ex1 from remaining -> completed
+      if (ev?.type === "COMPLETE_EXERCISE") {
+        const rt = summary.runtime ?? {};
+        const remaining = Array.isArray(rt.remaining_ids) ? rt.remaining_ids : [];
+        const completed = Array.isArray(rt.completed_ids) ? rt.completed_ids : [];
+        const exId = ev.exercise_id;
+
+        return {
+          ...summary,
+          runtime: {
+            ...rt,
+            remaining_ids: remaining.filter((x) => x !== exId),
+            completed_ids: completed.concat([exId]),
+            return_decision_required: rt.return_decision_required ?? false,
+            return_decision_options: rt.return_decision_options ?? []
+          }
+        };
+      }
+      return summary;
+    }
+  }
+});
+
+const { getSessionState, appendRuntimeEvent } = await import(distHandlerUrl);
+
+function makeRes() {
+  return {
+    _status: null,
+    _json: null,
+    status(code) { this._status = code; return this; },
+    json(payload) { this._json = payload; return this; }
+  };
+}
+
+test("GET /sessions/:id/state is cached (second call avoids DB connect/select)", async () => {
+  connectCalls = 0;
+  loadStateSelectCalls = 0;
+
+  const req = { params: { session_id: "s_cache" } };
+  const res1 = makeRes();
+  await getSessionState(req, res1);
+
+  const res2 = makeRes();
+  await getSessionState(req, res2);
+
+  assert.equal(connectCalls, 1, "expected only one DB connect due to cache hit");
+  assert.equal(loadStateSelectCalls, 1, "expected only one loadSession SELECT due to cache hit");
+  assert.equal(res1._json.session_id, "s_cache");
+  assert.equal(res2._json.session_id, "s_cache");
+});
+
+test("appendRuntimeEvent invalidates session state cache (next state call hits DB again)", async () => {
+  connectCalls = 0;
+  loadStateSelectCalls = 0;
+  nextSeq = 0;
+
+  // prime cache
+  const reqState = { params: { session_id: "s_cache" } };
+  const resPrime = makeRes();
+  await getSessionState(reqState, resPrime);
+
+  assert.equal(connectCalls, 1);
+  assert.equal(loadStateSelectCalls, 1);
+
+  // apply event -> should invalidate cache on commit
+  const reqEv = {
+    params: { session_id: "s_cache" },
+    body: { event: { type: "COMPLETE_EXERCISE", exercise_id: "ex1" } }
+  };
+  const resEv = makeRes();
+  await appendRuntimeEvent(reqEv, resEv);
+
+  // next state call should re-hit DB (cache invalidated)
+  const resAfter = makeRes();
+  await getSessionState(reqState, resAfter);
+
+  assert.equal(connectCalls, 2, "expected second DB connect after invalidation");
+  assert.equal(loadStateSelectCalls, 2, "expected second loadSession SELECT after invalidation");
+});


### PR DESCRIPTION
Adds a small in-memory read-through cache for GET /sessions/:id/state (TTL 2000ms), invalidated on /start and /events commits. Includes unit tests proving cache hit and invalidation. No schema changes.