### PR TITLE
test(v0): finish registry law positive cluster guards

### DIFF
--- a/test/ci_registry_law_positive_cluster_manifest.test.mjs
+++ b/test/ci_registry_law_positive_cluster_manifest.test.mjs
@@ -1,0 +1,31 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+
+test("test:ci composition index includes pinned registry law positive cluster manifest and adjacent guard pair", () => {
+  const repo = process.cwd();
+  const indexPath = path.join(repo, "ci", "contracts", "test_ci_composition.json");
+  const index = JSON.parse(fs.readFileSync(indexPath, "utf8"));
+
+  assert.ok(index && typeof index === "object" && !Array.isArray(index), "expected composition object");
+  assert.ok(Array.isArray(index.items), "expected composition.items array");
+
+  const items = index.items;
+  const manifestPath = "ci/contracts/registry_law_positive_ci_cluster.json";
+
+  const manifestIdx = items.findIndex((item) => item?.kind === "manifest" && item?.path === manifestPath);
+  assert.notEqual(manifestIdx, -1, "expected registry law positive cluster manifest in composition index");
+
+  assert.deepEqual(
+    items.slice(manifestIdx, manifestIdx + 5),
+    [
+      { kind: "manifest", path: "ci/contracts/registry_law_positive_ci_cluster.json" },
+      { kind: "command", value: "node test/ci_registry_law_positive_cluster_manifest_file.test.mjs" },
+      { kind: "command", value: "node test/ci_registry_law_positive_cluster_manifest.test.mjs" },
+      { kind: "command", value: "node test/ci_registry_law_positive_manifest_file.test.mjs" },
+      { kind: "command", value: "node test/ci_registry_law_positive_manifest.test.mjs" }
+    ],
+    "expected registry law positive cluster manifest followed by its adjacent guard pair and legacy manifest guards"
+  );
+});

--- a/test/ci_registry_law_positive_cluster_manifest_file.test.mjs
+++ b/test/ci_registry_law_positive_cluster_manifest_file.test.mjs
@@ -1,0 +1,33 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+
+test("registry law positive cluster CI manifest file is well-formed, non-empty, unique, and node-test-only", () => {
+  const repo = process.cwd();
+  const manifestPath = path.join(repo, "ci", "contracts", "registry_law_positive_ci_cluster.json");
+
+  const raw = fs.readFileSync(manifestPath, "utf8");
+  let manifest;
+  assert.doesNotThrow(() => {
+    manifest = JSON.parse(raw);
+  }, "expected registry law positive cluster CI manifest to be valid JSON");
+
+  assert.ok(manifest && typeof manifest === "object" && !Array.isArray(manifest), "expected manifest object");
+  assert.ok(Array.isArray(manifest.cluster), "expected manifest.cluster array");
+  assert.ok(manifest.cluster.length > 0, "expected non-empty manifest.cluster");
+
+  const seen = new Set();
+  for (const entry of manifest.cluster) {
+    assert.equal(typeof entry, "string", "expected each manifest entry to be a string");
+    assert.notEqual(entry.trim(), "", "expected manifest entry to be non-empty");
+    assert.equal(entry, entry.trim(), "expected manifest entry without leading/trailing whitespace");
+    assert.match(
+      entry,
+      /^node test\/[A-Za-z0-9._/-]+\.test\.mjs$/,
+      "expected manifest entries to be node test/... .test.mjs commands only"
+    );
+    assert.ok(!seen.has(entry), `expected unique manifest entry: ${entry}`);
+    seen.add(entry);
+  }
+});


### PR DESCRIPTION
## Summary
- add the missing registry law positive cluster guard pair
- wire the existing registry law positive cluster manifest into the composition index adjacency contract
- keep package.json test:ci aligned with the composed index exactly

## Testing
- npm run test:one -- test/ci_registry_law_positive_cluster_manifest_file.test.mjs
- npm run test:one -- test/ci_registry_law_positive_cluster_manifest.test.mjs
- npm run test:one -- test/ci_registry_law_positive_manifest_file.test.mjs
- npm run test:one -- test/ci_registry_law_positive_manifest.test.mjs
- npm run test:one -- test/ci_test_ci_composition_file.test.mjs
- npm run test:one -- test/ci_test_ci_composition.test.mjs
- node .\ci\scripts\compose_test_ci_from_index.mjs
- npm run lint:fast
- npm run test:unit
- npm run dev:prepush:smart