### PR TITLE
test(v0): compose test ci integration from index

### DIFF
--- a/ci/contracts/test_ci_integration_api_regression_cluster_manifest.json
+++ b/ci/contracts/test_ci_integration_api_regression_cluster_manifest.json
@@ -1,0 +1,7 @@
+{
+  "label": "test:ci:integration api regression cluster",
+  "commands": [
+    "node test/api.return_gate.regression.test.mjs",
+    "node test/api.blocks_compile_apply_unknown_maps_500.regression.test.mjs"
+  ]
+}

--- a/ci/contracts/test_ci_integration_composition.json
+++ b/ci/contracts/test_ci_integration_composition.json
@@ -1,0 +1,20 @@
+{
+  "items": [
+    {
+      "id": "api_regression_cluster",
+      "manifest": "ci/contracts/test_ci_integration_api_regression_cluster_manifest.json",
+      "guards": [
+        "node test/ci_test_ci_integration_api_regression_cluster_manifest_file.test.mjs",
+        "node test/ci_test_ci_integration_api_regression_cluster_manifest.test.mjs"
+      ]
+    },
+    {
+      "id": "vertical_slice_cluster",
+      "manifest": "ci/contracts/test_ci_integration_vertical_slice_cluster_manifest.json",
+      "guards": [
+        "node test/ci_test_ci_integration_vertical_slice_cluster_manifest_file.test.mjs",
+        "node test/ci_test_ci_integration_vertical_slice_cluster_manifest.test.mjs"
+      ]
+    }
+  ]
+}

--- a/ci/contracts/test_ci_integration_vertical_slice_cluster_manifest.json
+++ b/ci/contracts/test_ci_integration_vertical_slice_cluster_manifest.json
@@ -1,0 +1,9 @@
+{
+  "label": "test:ci:integration vertical slice cluster",
+  "commands": [
+    "node test/smoke_vertical_slice_plan_start_state.test.mjs",
+    "node test/vertical_slice.api_http_return_gate.e2e.test.mjs",
+    "node test/vertical_slice.api_http_complete_step.e2e.test.mjs",
+    "node test/vertical_slice.api_http_unknown_engine_error_500.e2e.test.mjs"
+  ]
+}

--- a/ci/scripts/compose_test_ci_integration_from_index.mjs
+++ b/ci/scripts/compose_test_ci_integration_from_index.mjs
@@ -1,0 +1,84 @@
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const repoRoot = path.resolve(__dirname, "..", "..");
+
+export const TEST_CI_INTEGRATION_COMPOSITION_PATH = "ci/contracts/test_ci_integration_composition.json";
+
+function readJson(relativePath) {
+  const fullPath = path.resolve(repoRoot, relativePath);
+  return JSON.parse(fs.readFileSync(fullPath, "utf8"));
+}
+
+function assertNodeTestOnly(command, context) {
+  if (typeof command !== "string" || !command.startsWith("node test/") || !command.endsWith(".test.mjs")) {
+    throw new Error(`${context}: expected node-test-only command, got ${JSON.stringify(command)}`);
+  }
+}
+
+export function composeTestCiIntegrationCommands() {
+  const index = readJson(TEST_CI_INTEGRATION_COMPOSITION_PATH);
+  if (!index || typeof index !== "object" || Array.isArray(index)) {
+    throw new Error("expected composition object");
+  }
+  if (!Array.isArray(index.items) || index.items.length === 0) {
+    throw new Error("expected non-empty composition.items");
+  }
+
+  const commands = [];
+  const seen = new Set();
+
+  for (const [itemIndex, item] of index.items.entries()) {
+    if (!item || typeof item !== "object" || Array.isArray(item)) {
+      throw new Error(`composition.items[${itemIndex}]: expected object`);
+    }
+    if (typeof item.id !== "string" || item.id.length === 0) {
+      throw new Error(`composition.items[${itemIndex}]: expected non-empty id`);
+    }
+    if (typeof item.manifest !== "string" || item.manifest.length === 0) {
+      throw new Error(`composition.items[${itemIndex}]: expected non-empty manifest`);
+    }
+    if (!Array.isArray(item.guards) || item.guards.length !== 2) {
+      throw new Error(`composition.items[${itemIndex}]: expected exactly 2 guard commands`);
+    }
+
+    for (const [guardIndex, guardCommand] of item.guards.entries()) {
+      assertNodeTestOnly(guardCommand, `composition.items[${itemIndex}].guards[${guardIndex}]`);
+      if (seen.has(guardCommand)) {
+        throw new Error(`duplicate command detected: ${guardCommand}`);
+      }
+      seen.add(guardCommand);
+      commands.push(guardCommand);
+    }
+
+    const manifest = readJson(item.manifest);
+    if (!manifest || typeof manifest !== "object" || Array.isArray(manifest)) {
+      throw new Error(`manifest ${item.manifest}: expected object`);
+    }
+    if (!Array.isArray(manifest.commands) || manifest.commands.length === 0) {
+      throw new Error(`manifest ${item.manifest}: expected non-empty commands array`);
+    }
+
+    for (const [commandIndex, command] of manifest.commands.entries()) {
+      assertNodeTestOnly(command, `${item.manifest}.commands[${commandIndex}]`);
+      if (seen.has(command)) {
+        throw new Error(`duplicate command detected: ${command}`);
+      }
+      seen.add(command);
+      commands.push(command);
+    }
+  }
+
+  return commands;
+}
+
+export function composeTestCiIntegrationCommandString() {
+  return composeTestCiIntegrationCommands().join(" && ");
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === __filename) {
+  console.log(composeTestCiIntegrationCommandString());
+}

--- a/ci/scripts/run_test_ci_integration_from_index.mjs
+++ b/ci/scripts/run_test_ci_integration_from_index.mjs
@@ -1,0 +1,8 @@
+import { execSync } from "node:child_process";
+import { composeTestCiIntegrationCommands } from "./compose_test_ci_integration_from_index.mjs";
+
+const commands = composeTestCiIntegrationCommands();
+
+for (const command of commands) {
+  execSync(command, { stdio: "inherit" });
+}

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "start": "node dist/src/main.js",
     "test": "node ci/guards/clean_tree_guard.mjs && npm run build && node --test --test-concurrency=1",
     "test:ci": "node ci/scripts/run_test_ci_from_index.mjs",
-    "test:ci:integration": "node test/smoke_vertical_slice_plan_start_state.test.mjs && node test/api.return_gate.regression.test.mjs && node test/api.blocks_compile_apply_unknown_maps_500.regression.test.mjs && node test/vertical_slice.api_http_return_gate.e2e.test.mjs && node test/vertical_slice.api_http_complete_step.e2e.test.mjs && node test/vertical_slice.api_http_unknown_engine_error_500.e2e.test.mjs",
+    "test:ci:integration": "node ci/scripts/run_test_ci_integration_from_index.mjs",
     "test:ci:all": "npm run test:ci && npm run test:ci:integration",
     "test:one": "node --test",
     "test:renderer": "node --test test/session_text_render.test.mjs",

--- a/test/ci_test_ci_integration_api_regression_cluster_manifest.test.mjs
+++ b/test/ci_test_ci_integration_api_regression_cluster_manifest.test.mjs
@@ -1,0 +1,19 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import test from "node:test";
+
+test("test:ci:integration composition index includes pinned api regression cluster manifest and adjacent guard pair", () => {
+  const raw = fs.readFileSync("ci/contracts/test_ci_integration_composition.json", "utf8");
+  const index = JSON.parse(raw);
+
+  const item = index.items.find((entry) => entry.id === "api_regression_cluster");
+  assert.ok(item, "expected api_regression_cluster item");
+  assert.equal(
+    item.manifest,
+    "ci/contracts/test_ci_integration_api_regression_cluster_manifest.json"
+  );
+  assert.deepEqual(item.guards, [
+    "node test/ci_test_ci_integration_api_regression_cluster_manifest_file.test.mjs",
+    "node test/ci_test_ci_integration_api_regression_cluster_manifest.test.mjs"
+  ]);
+});

--- a/test/ci_test_ci_integration_api_regression_cluster_manifest_file.test.mjs
+++ b/test/ci_test_ci_integration_api_regression_cluster_manifest_file.test.mjs
@@ -1,0 +1,21 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import test from "node:test";
+
+test("test:ci:integration api regression cluster manifest file is well-formed, non-empty, unique, and node-test-only", () => {
+  const manifestPath = "ci/contracts/test_ci_integration_api_regression_cluster_manifest.json";
+  const raw = fs.readFileSync(manifestPath, "utf8");
+  const manifest = JSON.parse(raw);
+
+  assert.ok(manifest && typeof manifest === "object" && !Array.isArray(manifest), "expected manifest object");
+  assert.equal(manifest.label, "test:ci:integration api regression cluster");
+  assert.ok(Array.isArray(manifest.commands), "expected manifest.commands array");
+  assert.ok(manifest.commands.length > 0, "expected non-empty manifest.commands");
+
+  const uniqueCommands = new Set(manifest.commands);
+  assert.equal(uniqueCommands.size, manifest.commands.length, "expected unique manifest.commands");
+
+  for (const command of manifest.commands) {
+    assert.match(command, /^node test\/.+\.test\.mjs$/, `expected node-test-only command: ${command}`);
+  }
+});

--- a/test/ci_test_ci_integration_composition.test.mjs
+++ b/test/ci_test_ci_integration_composition.test.mjs
@@ -1,0 +1,33 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import pkg from "../package.json" with { type: "json" };
+import {
+  composeTestCiIntegrationCommandString,
+  composeTestCiIntegrationCommands
+} from "../ci/scripts/compose_test_ci_integration_from_index.mjs";
+
+test("package.json test:ci:integration is single-owner and resolves from deterministic composition index", () => {
+  assert.equal(
+    pkg.scripts["test:ci:integration"],
+    "node ci/scripts/run_test_ci_integration_from_index.mjs"
+  );
+
+  const commands = composeTestCiIntegrationCommands();
+  assert.deepEqual(commands, [
+    "node test/ci_test_ci_integration_api_regression_cluster_manifest_file.test.mjs",
+    "node test/ci_test_ci_integration_api_regression_cluster_manifest.test.mjs",
+    "node test/api.return_gate.regression.test.mjs",
+    "node test/api.blocks_compile_apply_unknown_maps_500.regression.test.mjs",
+    "node test/ci_test_ci_integration_vertical_slice_cluster_manifest_file.test.mjs",
+    "node test/ci_test_ci_integration_vertical_slice_cluster_manifest.test.mjs",
+    "node test/smoke_vertical_slice_plan_start_state.test.mjs",
+    "node test/vertical_slice.api_http_return_gate.e2e.test.mjs",
+    "node test/vertical_slice.api_http_complete_step.e2e.test.mjs",
+    "node test/vertical_slice.api_http_unknown_engine_error_500.e2e.test.mjs"
+  ]);
+
+  assert.equal(
+    composeTestCiIntegrationCommandString(),
+    commands.join(" && ")
+  );
+});

--- a/test/ci_test_ci_integration_composition_file.test.mjs
+++ b/test/ci_test_ci_integration_composition_file.test.mjs
@@ -1,0 +1,38 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import test from "node:test";
+import {
+  TEST_CI_INTEGRATION_COMPOSITION_PATH,
+  composeTestCiIntegrationCommands
+} from "../ci/scripts/compose_test_ci_integration_from_index.mjs";
+
+test("test:ci:integration composition file is well-formed and expands to unique node-test-only commands", () => {
+  const raw = fs.readFileSync(TEST_CI_INTEGRATION_COMPOSITION_PATH, "utf8");
+  const index = JSON.parse(raw);
+
+  assert.ok(index && typeof index === "object" && !Array.isArray(index), "expected composition object");
+  assert.ok(Array.isArray(index.items), "expected composition.items array");
+  assert.ok(index.items.length > 0, "expected non-empty composition.items");
+
+  for (const item of index.items) {
+    assert.equal(typeof item.id, "string", "expected item.id");
+    assert.equal(typeof item.manifest, "string", "expected item.manifest");
+    assert.ok(fs.existsSync(path.resolve(item.manifest)), `expected manifest to exist: ${item.manifest}`);
+    assert.ok(Array.isArray(item.guards), `expected guards array for ${item.id}`);
+    assert.equal(item.guards.length, 2, `expected adjacent guard pair for ${item.id}`);
+    for (const command of item.guards) {
+      assert.match(command, /^node test\/.+\.test\.mjs$/, `expected node-test-only guard command: ${command}`);
+    }
+  }
+
+  const commands = composeTestCiIntegrationCommands();
+  assert.ok(commands.length > 0, "expected non-empty composed commands");
+
+  const uniqueCommands = new Set(commands);
+  assert.equal(uniqueCommands.size, commands.length, "expected unique composed commands");
+
+  for (const command of commands) {
+    assert.match(command, /^node test\/.+\.test\.mjs$/, `expected node-test-only command: ${command}`);
+  }
+});

--- a/test/ci_test_ci_integration_vertical_slice_cluster_manifest.test.mjs
+++ b/test/ci_test_ci_integration_vertical_slice_cluster_manifest.test.mjs
@@ -1,0 +1,19 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import test from "node:test";
+
+test("test:ci:integration composition index includes pinned vertical slice cluster manifest and adjacent guard pair", () => {
+  const raw = fs.readFileSync("ci/contracts/test_ci_integration_composition.json", "utf8");
+  const index = JSON.parse(raw);
+
+  const item = index.items.find((entry) => entry.id === "vertical_slice_cluster");
+  assert.ok(item, "expected vertical_slice_cluster item");
+  assert.equal(
+    item.manifest,
+    "ci/contracts/test_ci_integration_vertical_slice_cluster_manifest.json"
+  );
+  assert.deepEqual(item.guards, [
+    "node test/ci_test_ci_integration_vertical_slice_cluster_manifest_file.test.mjs",
+    "node test/ci_test_ci_integration_vertical_slice_cluster_manifest.test.mjs"
+  ]);
+});

--- a/test/ci_test_ci_integration_vertical_slice_cluster_manifest_file.test.mjs
+++ b/test/ci_test_ci_integration_vertical_slice_cluster_manifest_file.test.mjs
@@ -1,0 +1,21 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import test from "node:test";
+
+test("test:ci:integration vertical slice cluster manifest file is well-formed, non-empty, unique, and node-test-only", () => {
+  const manifestPath = "ci/contracts/test_ci_integration_vertical_slice_cluster_manifest.json";
+  const raw = fs.readFileSync(manifestPath, "utf8");
+  const manifest = JSON.parse(raw);
+
+  assert.ok(manifest && typeof manifest === "object" && !Array.isArray(manifest), "expected manifest object");
+  assert.equal(manifest.label, "test:ci:integration vertical slice cluster");
+  assert.ok(Array.isArray(manifest.commands), "expected manifest.commands array");
+  assert.ok(manifest.commands.length > 0, "expected non-empty manifest.commands");
+
+  const uniqueCommands = new Set(manifest.commands);
+  assert.equal(uniqueCommands.size, manifest.commands.length, "expected unique manifest.commands");
+
+  for (const command of manifest.commands) {
+    assert.match(command, /^node test\/.+\.test\.mjs$/, `expected node-test-only command: ${command}`);
+  }
+});


### PR DESCRIPTION
## Summary
- move test:ci:integration to a single-owner runner backed by a deterministic composition index
- pin api regression and vertical-slice integration clusters through committed manifests
- add composition and cluster guard tests for integration CI ordering and coverage

## Testing
- node test/ci_test_ci_integration_composition_file.test.mjs
- node test/ci_test_ci_integration_composition.test.mjs
- node test/ci_test_ci_integration_api_regression_cluster_manifest_file.test.mjs
- node test/ci_test_ci_integration_api_regression_cluster_manifest.test.mjs
- node test/ci_test_ci_integration_vertical_slice_cluster_manifest_file.test.mjs
- node test/ci_test_ci_integration_vertical_slice_cluster_manifest.test.mjs
- npm run test:ci:integration
- npm run green