### PR TITLE
refactor(v0): extract session-events query service

### DIFF
--- a/src/api/session_events_query_service.ts
+++ b/src/api/session_events_query_service.ts
@@ -1,0 +1,15 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+// src/api/session_events_query_service.ts
+import { pool } from "../db/pool.js";
+
+export async function listRuntimeEventsQuery(session_id: string) {
+  const r = await pool.query(
+    `SELECT seq, event, created_at
+     FROM runtime_events
+     WHERE session_id = $1
+     ORDER BY seq ASC`,
+    [session_id]
+  );
+
+  return { session_id, events: r.rows };
+}

--- a/src/api/sessions.handlers.ts
+++ b/src/api/sessions.handlers.ts
@@ -26,6 +26,7 @@ import {
   startSessionMutation
 } from "./session_state_write_service.js";
 import { planSessionService } from "./plan_session_service.js";
+import { listRuntimeEventsQuery } from "./session_events_query_service.js";
 
 type JsonRecord = Record<string, unknown>;
 
@@ -70,15 +71,8 @@ export async function listRuntimeEvents(req: Request, res: Response) {
   const session_id = asString(req.params?.session_id);
   if (!session_id) throw badRequest("Missing session_id");
 
-  const r = await pool.query(
-    `SELECT seq, event, created_at
-     FROM runtime_events
-     WHERE session_id = $1
-     ORDER BY seq ASC`,
-    [session_id]
-  );
-
-  return res.json({ session_id, events: r.rows });
+  const payload = await listRuntimeEventsQuery(session_id);
+  return res.json(payload);
 }
 
 export async function getSessionState(req: Request, res: Response) {


### PR DESCRIPTION
## Summary
- extract runtime events query flow from sessions.handlers
- move events SELECT and payload shaping into session_events_query_service.ts
- keep handlers focused on HTTP request parsing and response shaping

## Testing
- npm run test:one -- test/health.version.test.mjs
- npm run test:one -- test/smoke_vertical_slice_plan_start_state.test.mjs
- npm run test:one -- test/api.state.cache_reset_http.regression.test.mjs
- npm run test:one -- test/api.return_skip.regression.test.mjs
- npm run test:one -- test/api.return_skip.persisted_replay.regression.test.mjs
- npm run lint:fast
- npm run dev:status