### PR TITLE
refactor(v0): extract session-state query service

### DIFF
--- a/src/api/session_state_query_service.ts
+++ b/src/api/session_state_query_service.ts
@@ -1,0 +1,53 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+// src/api/session_state_query_service.ts
+import { pool } from "../db/pool.js";
+
+import {
+  deriveTrace,
+  normalizeSummary
+} from "@kolosseum/engine/runtime/session_summary.js";
+
+import { notFound } from "./http_errors.js";
+import {
+  type PlannedSession,
+  ensureReturnDecisionContract,
+  loadSessionStateRow,
+  projectSessionStatePayload,
+  readCachedSessionState,
+  writeCachedSessionState
+} from "./session_state_read_model.js";
+
+export async function getSessionStateQuery(session_id: string) {
+  const cached = readCachedSessionState(session_id);
+  if (cached) return cached;
+
+  const client = await pool.connect();
+  try {
+    const row = await loadSessionStateRow(client, session_id);
+    if (!row) throw notFound("Session not found");
+
+    const planned = row.planned_session as PlannedSession;
+    const { summary: normalized, needsUpgrade } = normalizeSummary(planned as any, row.session_state_summary);
+
+    const upgraded = ensureReturnDecisionContract(normalized, deriveTrace);
+    const shouldPersist = needsUpgrade || upgraded.changed;
+
+    if (shouldPersist) {
+      await client.query(
+        `UPDATE sessions
+         SET session_state_summary = $2::jsonb,
+             updated_at = now()
+         WHERE session_id = $1`,
+        [session_id, JSON.stringify(upgraded.summary)]
+      );
+    }
+
+    const derivedTrace = deriveTrace(upgraded.summary as any) as any;
+    const payload = projectSessionStatePayload(session_id, planned, upgraded.summary, derivedTrace);
+
+    writeCachedSessionState(session_id, payload);
+    return payload;
+  } finally {
+    client.release();
+  }
+}

--- a/src/api/sessions.handlers.ts
+++ b/src/api/sessions.handlers.ts
@@ -1,25 +1,8 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 // src/api/sessions.handlers.ts
 import type { Request, Response } from "express";
-import { pool } from "../db/pool.js";
 
-import {
-  deriveTrace,
-  normalizeSummary
-} from "@kolosseum/engine/runtime/session_summary.js";
-
-import {
-  badRequest,
-  notFound
-} from "./http_errors.js";
-import {
-  type PlannedSession,
-  ensureReturnDecisionContract,
-  loadSessionStateRow,
-  projectSessionStatePayload,
-  readCachedSessionState,
-  writeCachedSessionState
-} from "./session_state_read_model.js";
+import { badRequest } from "./http_errors.js";
 import {
   appendRuntimeEventMutation,
   extractRawEventFromBody,
@@ -27,6 +10,7 @@ import {
 } from "./session_state_write_service.js";
 import { planSessionService } from "./plan_session_service.js";
 import { listRuntimeEventsQuery } from "./session_events_query_service.js";
+import { getSessionStateQuery } from "./session_state_query_service.js";
 
 type JsonRecord = Record<string, unknown>;
 
@@ -79,36 +63,6 @@ export async function getSessionState(req: Request, res: Response) {
   const session_id = asString(req.params?.session_id);
   if (!session_id) throw badRequest("Missing session_id");
 
-  const cached = readCachedSessionState(session_id);
-  if (cached) return res.json(cached);
-
-  const client = await pool.connect();
-  try {
-    const row = await loadSessionStateRow(client, session_id);
-    if (!row) throw notFound("Session not found");
-
-    const planned = row.planned_session as PlannedSession;
-    const { summary: normalized, needsUpgrade } = normalizeSummary(planned as any, row.session_state_summary);
-
-    const upgraded = ensureReturnDecisionContract(normalized, deriveTrace);
-    const shouldPersist = needsUpgrade || upgraded.changed;
-
-    if (shouldPersist) {
-      await client.query(
-        `UPDATE sessions
-         SET session_state_summary = $2::jsonb,
-             updated_at = now()
-         WHERE session_id = $1`,
-        [session_id, JSON.stringify(upgraded.summary)]
-      );
-    }
-
-    const derivedTrace = deriveTrace(upgraded.summary as any) as any;
-    const payload = projectSessionStatePayload(session_id, planned, upgraded.summary, derivedTrace);
-
-    writeCachedSessionState(session_id, payload);
-    return res.json(payload);
-  } finally {
-    client.release();
-  }
+  const payload = await getSessionStateQuery(session_id);
+  return res.json(payload);
 }


### PR DESCRIPTION
## Summary
- extract session state read/query flow from sessions.handlers
- move cache read/write, summary upgrade persistence, trace derivation, and payload projection orchestration into session_state_query_service.ts
- keep handlers focused on HTTP request parsing and response shaping

## Testing
- npm run test:one -- test/health.version.test.mjs
- npm run test:one -- test/smoke_vertical_slice_plan_start_state.test.mjs
- npm run test:one -- test/api.state.cache_reset_http.regression.test.mjs
- npm run test:one -- test/api.return_skip.regression.test.mjs
- npm run test:one -- test/api.return_skip.persisted_replay.regression.test.mjs
- npm run lint:fast
- npm run dev:status