### PR TITLE
test(v0): wire service-boundary contracts into dev session api ci cluster

### DIFF
--- a/ci/contracts/dev_session_api_ci_cluster.json
+++ b/ci/contracts/dev_session_api_ci_cluster.json
@@ -1,6 +1,10 @@
 {
   "cluster": [
     "node test/dev_fast_clean_tree_negative.test.mjs",
-    "node test/api_session_event_seq_init_contract.test.mjs"
+    "node test/api_session_event_seq_init_contract.test.mjs",
+    "node test/ci_api_session_state_query_service_contract_wrapper.test.mjs",
+    "node test/ci_api_session_state_write_service_contract_wrapper.test.mjs",
+    "node test/ci_api_session_events_query_service_contract_wrapper.test.mjs",
+    "node test/ci_api_plan_session_service_contract_wrapper.test.mjs"
   ]
 }

--- a/test/ci_api_plan_session_service_contract_wrapper.test.mjs
+++ b/test/ci_api_plan_session_service_contract_wrapper.test.mjs
@@ -1,0 +1,25 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+
+function runWrapped(target) {
+  return spawnSync(
+    process.execPath,
+    ["--test", "--experimental-test-module-mocks", target],
+    {
+      cwd: process.cwd(),
+      encoding: "utf8"
+    }
+  );
+}
+
+test("CI wrapper: plan-session service contract test passes with experimental module mocks", () => {
+  const target = "test/api_plan_session_service.contract.test.mjs";
+  const r = runWrapped(target);
+
+  assert.equal(
+    r.status,
+    0,
+    `expected wrapped test to pass: ${target}\nstdout:\n${r.stdout ?? ""}\nstderr:\n${r.stderr ?? ""}`
+  );
+});

--- a/test/ci_api_session_events_query_service_contract_wrapper.test.mjs
+++ b/test/ci_api_session_events_query_service_contract_wrapper.test.mjs
@@ -1,0 +1,25 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+
+function runWrapped(target) {
+  return spawnSync(
+    process.execPath,
+    ["--test", "--experimental-test-module-mocks", target],
+    {
+      cwd: process.cwd(),
+      encoding: "utf8"
+    }
+  );
+}
+
+test("CI wrapper: session-events query service contract test passes with experimental module mocks", () => {
+  const target = "test/api_session_events_query_service.contract.test.mjs";
+  const r = runWrapped(target);
+
+  assert.equal(
+    r.status,
+    0,
+    `expected wrapped test to pass: ${target}\nstdout:\n${r.stdout ?? ""}\nstderr:\n${r.stderr ?? ""}`
+  );
+});

--- a/test/ci_api_session_state_query_service_contract_wrapper.test.mjs
+++ b/test/ci_api_session_state_query_service_contract_wrapper.test.mjs
@@ -1,0 +1,25 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+
+function runWrapped(target) {
+  return spawnSync(
+    process.execPath,
+    ["--test", "--experimental-test-module-mocks", target],
+    {
+      cwd: process.cwd(),
+      encoding: "utf8"
+    }
+  );
+}
+
+test("CI wrapper: session-state query service contract test passes with experimental module mocks", () => {
+  const target = "test/api_session_state_query_service.contract.test.mjs";
+  const r = runWrapped(target);
+
+  assert.equal(
+    r.status,
+    0,
+    `expected wrapped test to pass: ${target}\nstdout:\n${r.stdout ?? ""}\nstderr:\n${r.stderr ?? ""}`
+  );
+});

--- a/test/ci_api_session_state_write_service_contract_wrapper.test.mjs
+++ b/test/ci_api_session_state_write_service_contract_wrapper.test.mjs
@@ -1,0 +1,25 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+
+function runWrapped(target) {
+  return spawnSync(
+    process.execPath,
+    ["--test", "--experimental-test-module-mocks", target],
+    {
+      cwd: process.cwd(),
+      encoding: "utf8"
+    }
+  );
+}
+
+test("CI wrapper: session-state write service contract test passes with experimental module mocks", () => {
+  const target = "test/api_session_state_write_service.contract.test.mjs";
+  const r = runWrapped(target);
+
+  assert.equal(
+    r.status,
+    0,
+    `expected wrapped test to pass: ${target}\nstdout:\n${r.stdout ?? ""}\nstderr:\n${r.stderr ?? ""}`
+  );
+});


### PR DESCRIPTION
## Summary
- add the new session service-boundary contract tests to the dev session API CI cluster
- keep the existing composition single-owner flow unchanged by wiring through CI-safe wrapper tests
- ensure the new service seam protections are part of the permanent composed CI surface

## Testing
- npm run test:one -- test/ci_dev_session_api_cluster_manifest_file.test.mjs
- npm run test:one -- test/ci_dev_session_api_cluster_manifest.test.mjs
- npm run test:one -- test/ci_dev_session_api_manifest_file.test.mjs
- npm run test:one -- test/ci_dev_session_api_manifest.test.mjs
- npm run test:one -- test/ci_api_session_state_query_service_contract_wrapper.test.mjs
- npm run test:one -- test/ci_api_session_state_write_service_contract_wrapper.test.mjs
- npm run test:one -- test/ci_api_session_events_query_service_contract_wrapper.test.mjs
- npm run test:one -- test/ci_api_plan_session_service_contract_wrapper.test.mjs
- node --test --experimental-test-module-mocks test/api_session_state_query_service.contract.test.mjs
- node --test --experimental-test-module-mocks test/api_session_state_write_service.contract.test.mjs
- node --test --experimental-test-module-mocks test/api_session_events_query_service.contract.test.mjs
- node --test --experimental-test-module-mocks test/api_plan_session_service.contract.test.mjs
- npm run lint:fast
- npm run dev:status