### PR TITLE
test(v0): prove session handlers delegate to extracted services without contract drift

### DIFF
--- a/test/api_handlers_append_runtime_event_delegation.test.mjs
+++ b/test/api_handlers_append_runtime_event_delegation.test.mjs
@@ -1,0 +1,46 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+
+test("sessions.handlers source contract: appendRuntimeEvent extracts raw body event, delegates once, and returns 201", () => {
+  const repo = process.cwd();
+  const file = path.join(repo, "src", "api", "sessions.handlers.ts");
+  const src = fs.readFileSync(file, "utf8");
+
+  assert.match(
+    src,
+    /import\s*\{[\s\S]*\bappendRuntimeEventMutation\b[\s\S]*\bextractRawEventFromBody\b[\s\S]*\}\s*from\s*"\.\/session_state_write_service\.js"/,
+    "expected handler to import appendRuntimeEventMutation and extractRawEventFromBody from extracted write service"
+  );
+
+  assert.match(
+    src,
+    /const\s+session_id\s*=\s*asString\(req\.params\?\.session_id\);/,
+    "expected appendRuntimeEvent to read params.session_id"
+  );
+
+  assert.match(
+    src,
+    /if\s*\(!session_id\)\s*throw\s+badRequest\("Missing session_id"\);/,
+    "expected appendRuntimeEvent to preserve missing session_id guard"
+  );
+
+  assert.match(
+    src,
+    /const\s+raw\s*=\s*extractRawEventFromBody\(req\.body\);/,
+    "expected appendRuntimeEvent to normalize request body through extractRawEventFromBody"
+  );
+
+  assert.match(
+    src,
+    /const\s+result\s*=\s*await\s+appendRuntimeEventMutation\(session_id,\s*raw\);/,
+    "expected appendRuntimeEvent to delegate to appendRuntimeEventMutation(session_id, raw)"
+  );
+
+  assert.match(
+    src,
+    /return\s+res\.status\(201\)\.json\(result\);/,
+    "expected appendRuntimeEvent to preserve 201 JSON response contract"
+  );
+});

--- a/test/api_handlers_get_session_state_delegation.test.mjs
+++ b/test/api_handlers_get_session_state_delegation.test.mjs
@@ -1,0 +1,40 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+
+test("sessions.handlers source contract: getSessionState delegates params.session_id to getSessionStateQuery and preserves JSON payload", () => {
+  const repo = process.cwd();
+  const file = path.join(repo, "src", "api", "sessions.handlers.ts");
+  const src = fs.readFileSync(file, "utf8");
+
+  assert.match(
+    src,
+    /import\s*\{\s*getSessionStateQuery\s*\}\s*from\s*"\.\/session_state_query_service\.js"/,
+    "expected handler to import getSessionStateQuery from extracted query service"
+  );
+
+  assert.match(
+    src,
+    /const\s+session_id\s*=\s*asString\(req\.params\?\.session_id\);/,
+    "expected getSessionState to read params.session_id"
+  );
+
+  assert.match(
+    src,
+    /if\s*\(!session_id\)\s*throw\s+badRequest\("Missing session_id"\);/,
+    "expected getSessionState to preserve missing session_id guard"
+  );
+
+  assert.match(
+    src,
+    /const\s+payload\s*=\s*await\s+getSessionStateQuery\(session_id\);/,
+    "expected getSessionState to delegate to getSessionStateQuery(session_id)"
+  );
+
+  assert.match(
+    src,
+    /return\s+res\.json\(payload\);/,
+    "expected getSessionState to preserve direct JSON response contract"
+  );
+});

--- a/test/api_handlers_list_runtime_events_delegation.test.mjs
+++ b/test/api_handlers_list_runtime_events_delegation.test.mjs
@@ -1,0 +1,40 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+
+test("sessions.handlers source contract: listRuntimeEvents delegates params.session_id to listRuntimeEventsQuery and preserves JSON payload", () => {
+  const repo = process.cwd();
+  const file = path.join(repo, "src", "api", "sessions.handlers.ts");
+  const src = fs.readFileSync(file, "utf8");
+
+  assert.match(
+    src,
+    /import\s*\{\s*listRuntimeEventsQuery\s*\}\s*from\s*"\.\/session_events_query_service\.js"/,
+    "expected handler to import listRuntimeEventsQuery from extracted events query service"
+  );
+
+  assert.match(
+    src,
+    /const\s+session_id\s*=\s*asString\(req\.params\?\.session_id\);/,
+    "expected listRuntimeEvents to read params.session_id"
+  );
+
+  assert.match(
+    src,
+    /if\s*\(!session_id\)\s*throw\s+badRequest\("Missing session_id"\);/,
+    "expected listRuntimeEvents to preserve missing session_id guard"
+  );
+
+  assert.match(
+    src,
+    /const\s+payload\s*=\s*await\s+listRuntimeEventsQuery\(session_id\);/,
+    "expected listRuntimeEvents to delegate to listRuntimeEventsQuery(session_id)"
+  );
+
+  assert.match(
+    src,
+    /return\s+res\.json\(payload\);/,
+    "expected listRuntimeEvents to preserve direct JSON response contract"
+  );
+});

--- a/test/api_handlers_plan_session_delegation.test.mjs
+++ b/test/api_handlers_plan_session_delegation.test.mjs
@@ -1,0 +1,34 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+
+test("sessions.handlers source contract: planSession delegates body.input ?? body to planSessionService and returns 200", () => {
+  const repo = process.cwd();
+  const file = path.join(repo, "src", "api", "sessions.handlers.ts");
+  const src = fs.readFileSync(file, "utf8");
+
+  assert.match(
+    src,
+    /import\s*\{\s*planSessionService\s*\}\s*from\s*"\.\/plan_session_service\.js"/,
+    "expected handler to import planSessionService from extracted service module"
+  );
+
+  assert.match(
+    src,
+    /if\s*\(isRecord\(bodyUnknown\)\)\s*input\s*=\s*\(bodyUnknown as any\)\.input\s*\?\?\s*bodyUnknown;/s,
+    "expected planSession to unwrap body.input ?? body"
+  );
+
+  assert.match(
+    src,
+    /const\s+out\s*=\s*await\s+planSessionService\(input\);/s,
+    "expected planSession to delegate to planSessionService(input)"
+  );
+
+  assert.match(
+    src,
+    /return\s+res\.status\(200\)\.json\(out\);/,
+    "expected planSession to preserve 200 JSON response contract"
+  );
+});

--- a/test/api_handlers_start_session_delegation.test.mjs
+++ b/test/api_handlers_start_session_delegation.test.mjs
@@ -1,0 +1,40 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+
+test("sessions.handlers source contract: startSession delegates params.session_id to startSessionMutation and returns 200", () => {
+  const repo = process.cwd();
+  const file = path.join(repo, "src", "api", "sessions.handlers.ts");
+  const src = fs.readFileSync(file, "utf8");
+
+  assert.match(
+    src,
+    /import\s*\{[\s\S]*\bstartSessionMutation\b[\s\S]*\}\s*from\s*"\.\/session_state_write_service\.js"/,
+    "expected handler to import startSessionMutation from extracted write service"
+  );
+
+  assert.match(
+    src,
+    /const\s+session_id\s*=\s*asString\(req\.params\?\.session_id\);/,
+    "expected startSession to read params.session_id"
+  );
+
+  assert.match(
+    src,
+    /if\s*\(!session_id\)\s*throw\s+badRequest\("Missing session_id"\);/,
+    "expected startSession to preserve missing session_id guard"
+  );
+
+  assert.match(
+    src,
+    /const\s+result\s*=\s*await\s+startSessionMutation\(session_id\);/,
+    "expected startSession to delegate to startSessionMutation(session_id)"
+  );
+
+  assert.match(
+    src,
+    /return\s+res\.status\(200\)\.json\(result\);/,
+    "expected startSession to preserve 200 JSON response contract"
+  );
+});


### PR DESCRIPTION
## Summary
- add handler-level delegation contract tests for the extracted session services
- prove sessions.handlers continues to call the extracted plan-session, write, state-query, and events-query services without contract drift
- lock the handler seam before moving further into engine-facing delivery

## Testing
- npm run test:one -- test/api_handlers_plan_session_delegation.test.mjs
- npm run test:one -- test/api_handlers_start_session_delegation.test.mjs
- npm run test:one -- test/api_handlers_append_runtime_event_delegation.test.mjs
- npm run test:one -- test/api_handlers_get_session_state_delegation.test.mjs
- npm run test:one -- test/api_handlers_list_runtime_events_delegation.test.mjs
- npm run lint:fast
- npm run dev:status