### PR TITLE
test(v0): wire handler delegation contracts into ci cluster

### DIFF
--- a/ci/contracts/handler_delegation_contracts_ci_cluster.json
+++ b/ci/contracts/handler_delegation_contracts_ci_cluster.json
@@ -1,0 +1,8 @@
+{
+  "label": "handler delegation contracts ci cluster",
+  "cluster": [
+    "node test/api_handlers_plan_session_delegation.test.mjs",
+    "node test/api_handlers_start_session_delegation.test.mjs",
+    "node test/api_handlers_append_runtime_event_delegation.test.mjs"
+  ]
+}

--- a/ci/contracts/test_ci_composition.json
+++ b/ci/contracts/test_ci_composition.json
@@ -203,6 +203,26 @@
     {
       "kind": "command",
       "value": "node test/ci_compile_runtime_trace_manifest.test.mjs"
+    },
+    {
+      "kind": "manifest",
+      "path": "ci/contracts/handler_delegation_contracts_ci_cluster.json"
+    },
+    {
+      "kind": "command",
+      "value": "node test/ci_handler_delegation_contracts_cluster_manifest_file.test.mjs"
+    },
+    {
+      "kind": "command",
+      "value": "node test/ci_handler_delegation_contracts_cluster_manifest.test.mjs"
+    },
+    {
+      "kind": "command",
+      "value": "node test/ci_handler_delegation_contracts_manifest_file.test.mjs"
+    },
+    {
+      "kind": "command",
+      "value": "node test/ci_handler_delegation_contracts_manifest.test.mjs"
     }
   ]
 }

--- a/test/ci_handler_delegation_contracts_cluster_manifest.test.mjs
+++ b/test/ci_handler_delegation_contracts_cluster_manifest.test.mjs
@@ -1,0 +1,32 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+
+test("test:ci composition index includes pinned handler delegation contracts cluster manifest and adjacent guard pair", () => {
+  const repo = process.cwd();
+  const indexPath = path.join(repo, "ci", "contracts", "test_ci_composition.json");
+  const index = JSON.parse(fs.readFileSync(indexPath, "utf8"));
+
+  const manifestPath = "ci/contracts/handler_delegation_contracts_ci_cluster.json";
+  const manifestIdx = index.items.findIndex(
+    (item) => item && item.kind === "manifest" && item.path === manifestPath
+  );
+
+  assert.notEqual(manifestIdx, -1, "expected handler delegation contracts cluster manifest in composition index");
+
+  assert.deepEqual(index.items.slice(manifestIdx, manifestIdx + 3), [
+    {
+      kind: "manifest",
+      path: "ci/contracts/handler_delegation_contracts_ci_cluster.json"
+    },
+    {
+      kind: "command",
+      value: "node test/ci_handler_delegation_contracts_cluster_manifest_file.test.mjs"
+    },
+    {
+      kind: "command",
+      value: "node test/ci_handler_delegation_contracts_cluster_manifest.test.mjs"
+    }
+  ]);
+});

--- a/test/ci_handler_delegation_contracts_cluster_manifest_file.test.mjs
+++ b/test/ci_handler_delegation_contracts_cluster_manifest_file.test.mjs
@@ -1,0 +1,32 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+
+const NODE_TEST_CMD_RE = /^node test\/[A-Za-z0-9._/-]+\.test\.mjs$/;
+
+test("handler delegation contracts cluster manifest file is well-formed, non-empty, unique, and node-test-only", () => {
+  const repo = process.cwd();
+  const manifestPath = path.join(repo, "ci", "contracts", "handler_delegation_contracts_ci_cluster.json");
+  const raw = fs.readFileSync(manifestPath, "utf8");
+
+  let manifest;
+  assert.doesNotThrow(() => {
+    manifest = JSON.parse(raw);
+  }, "expected handler delegation contracts cluster manifest to be valid JSON");
+
+  assert.ok(manifest && typeof manifest === "object" && !Array.isArray(manifest), "expected manifest object");
+  assert.equal(manifest.label, "handler delegation contracts ci cluster");
+  assert.ok(Array.isArray(manifest.cluster), "expected manifest.cluster array");
+  assert.equal(manifest.cluster.length, 3, "expected exactly 3 handler delegation contract commands");
+
+  const seen = new Set();
+  for (const cmd of manifest.cluster) {
+    assert.equal(typeof cmd, "string", "expected command string");
+    assert.notEqual(cmd.trim(), "", "expected non-empty command");
+    assert.equal(cmd, cmd.trim(), "expected trimmed command");
+    assert.match(cmd, NODE_TEST_CMD_RE, "expected node test/... .test.mjs command");
+    assert.ok(!seen.has(cmd), `expected unique command: ${cmd}`);
+    seen.add(cmd);
+  }
+});

--- a/test/ci_handler_delegation_contracts_manifest.test.mjs
+++ b/test/ci_handler_delegation_contracts_manifest.test.mjs
@@ -1,0 +1,16 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { composeTestCiFromIndex } from "../ci/scripts/compose_test_ci_from_index.mjs";
+
+test("handler delegation contracts manifest remains present in composed test:ci command set", () => {
+  const repo = process.cwd();
+  const { commands } = composeTestCiFromIndex(repo);
+
+  for (const cmd of [
+    "node test/api_handlers_plan_session_delegation.test.mjs",
+    "node test/api_handlers_start_session_delegation.test.mjs",
+    "node test/api_handlers_append_runtime_event_delegation.test.mjs"
+  ]) {
+    assert.ok(commands.includes(cmd), `expected ${cmd} in composed test:ci command set`);
+  }
+});

--- a/test/ci_handler_delegation_contracts_manifest_file.test.mjs
+++ b/test/ci_handler_delegation_contracts_manifest_file.test.mjs
@@ -1,0 +1,17 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+
+test("handler delegation contracts manifest file remains pinned to the expected handler delegation contract tests", () => {
+  const repo = process.cwd();
+  const manifestPath = path.join(repo, "ci", "contracts", "handler_delegation_contracts_ci_cluster.json");
+  const manifest = JSON.parse(fs.readFileSync(manifestPath, "utf8"));
+
+  assert.equal(manifest.label, "handler delegation contracts ci cluster");
+  assert.deepEqual(manifest.cluster, [
+    "node test/api_handlers_plan_session_delegation.test.mjs",
+    "node test/api_handlers_start_session_delegation.test.mjs",
+    "node test/api_handlers_append_runtime_event_delegation.test.mjs"
+  ]);
+});


### PR DESCRIPTION
## Summary
- add a dedicated handler delegation contracts cluster manifest to the single-owner test:ci composition index
- pin the handler delegation manifest with adjacent composition/index guard tests
- keep the extracted session handler delegation seam in routine v0 CI coverage

## Testing
- npm run test:one -- test/api_handlers_plan_session_delegation.test.mjs
- npm run test:one -- test/api_handlers_start_session_delegation.test.mjs
- npm run test:one -- test/api_handlers_append_runtime_event_delegation.test.mjs
- npm run test:one -- test/ci_handler_delegation_contracts_cluster_manifest_file.test.mjs
- npm run test:one -- test/ci_handler_delegation_contracts_cluster_manifest.test.mjs
- npm run test:one -- test/ci_handler_delegation_contracts_manifest_file.test.mjs
- npm run test:one -- test/ci_handler_delegation_contracts_manifest.test.mjs
- npm run test:one -- test/ci_test_ci_composition_file.test.mjs
- npm run test:one -- test/ci_test_ci_composition.test.mjs
- npm run lint:fast
- npm run dev:status