### PR TITLE
test(v0): wire read-side handler delegation contracts into ci cluster

### DIFF
--- a/ci/contracts/handler_delegation_contracts_ci_cluster.json
+++ b/ci/contracts/handler_delegation_contracts_ci_cluster.json
@@ -3,6 +3,8 @@
   "cluster": [
     "node test/api_handlers_plan_session_delegation.test.mjs",
     "node test/api_handlers_start_session_delegation.test.mjs",
-    "node test/api_handlers_append_runtime_event_delegation.test.mjs"
+    "node test/api_handlers_append_runtime_event_delegation.test.mjs",
+    "node test/api_handlers_list_runtime_events_delegation.test.mjs",
+    "node test/api_handlers_get_session_state_delegation.test.mjs"
   ]
 }

--- a/test/ci_handler_delegation_contracts_cluster_manifest_file.test.mjs
+++ b/test/ci_handler_delegation_contracts_cluster_manifest_file.test.mjs
@@ -18,7 +18,7 @@ test("handler delegation contracts cluster manifest file is well-formed, non-emp
   assert.ok(manifest && typeof manifest === "object" && !Array.isArray(manifest), "expected manifest object");
   assert.equal(manifest.label, "handler delegation contracts ci cluster");
   assert.ok(Array.isArray(manifest.cluster), "expected manifest.cluster array");
-  assert.equal(manifest.cluster.length, 3, "expected exactly 3 handler delegation contract commands");
+  assert.equal(manifest.cluster.length, 5, "expected exactly 5 handler delegation contract commands");
 
   const seen = new Set();
   for (const cmd of manifest.cluster) {

--- a/test/ci_handler_delegation_contracts_manifest.test.mjs
+++ b/test/ci_handler_delegation_contracts_manifest.test.mjs
@@ -9,7 +9,9 @@ test("handler delegation contracts manifest remains present in composed test:ci 
   for (const cmd of [
     "node test/api_handlers_plan_session_delegation.test.mjs",
     "node test/api_handlers_start_session_delegation.test.mjs",
-    "node test/api_handlers_append_runtime_event_delegation.test.mjs"
+    "node test/api_handlers_append_runtime_event_delegation.test.mjs",
+    "node test/api_handlers_list_runtime_events_delegation.test.mjs",
+    "node test/api_handlers_get_session_state_delegation.test.mjs"
   ]) {
     assert.ok(commands.includes(cmd), `expected ${cmd} in composed test:ci command set`);
   }

--- a/test/ci_handler_delegation_contracts_manifest_file.test.mjs
+++ b/test/ci_handler_delegation_contracts_manifest_file.test.mjs
@@ -12,6 +12,8 @@ test("handler delegation contracts manifest file remains pinned to the expected 
   assert.deepEqual(manifest.cluster, [
     "node test/api_handlers_plan_session_delegation.test.mjs",
     "node test/api_handlers_start_session_delegation.test.mjs",
-    "node test/api_handlers_append_runtime_event_delegation.test.mjs"
+    "node test/api_handlers_append_runtime_event_delegation.test.mjs",
+    "node test/api_handlers_list_runtime_events_delegation.test.mjs",
+    "node test/api_handlers_get_session_state_delegation.test.mjs"
   ]);
 });


### PR DESCRIPTION
## Summary
- extend the handler delegation contracts CI cluster to include the read-side session handlers
- keep listRuntimeEvents and getSessionState delegation proofs inside the single-owner test:ci composition path
- complete routine CI coverage of the current sessions.handlers delegation surface

## Testing
- npm run test:one -- test/api_handlers_list_runtime_events_delegation.test.mjs
- npm run test:one -- test/api_handlers_get_session_state_delegation.test.mjs
- npm run test:one -- test/ci_handler_delegation_contracts_cluster_manifest_file.test.mjs
- npm run test:one -- test/ci_handler_delegation_contracts_cluster_manifest.test.mjs
- npm run test:one -- test/ci_handler_delegation_contracts_manifest_file.test.mjs
- npm run test:one -- test/ci_handler_delegation_contracts_manifest.test.mjs
- npm run test:one -- test/ci_test_ci_composition_file.test.mjs
- npm run test:one -- test/ci_test_ci_composition.test.mjs
- npm run lint:fast
- npm run dev:status