### PR TITLE
refactor(v0): extract block session read write services

### DIFF
--- a/src/api/block_session_query_service.ts
+++ b/src/api/block_session_query_service.ts
@@ -1,0 +1,17 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+// src/api/block_session_query_service.ts
+import { pool } from "../db/pool.js";
+
+export async function listBlockSessionsQuery(block_id: string) {
+  const r = await pool.query(
+    `
+    SELECT session_id, status, created_at, updated_at
+    FROM sessions
+    WHERE block_id = $1
+    ORDER BY created_at ASC
+    `,
+    [block_id]
+  );
+
+  return { block_id, sessions: r.rows };
+}

--- a/src/api/block_session_write_service.ts
+++ b/src/api/block_session_write_service.ts
@@ -1,0 +1,51 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+// src/api/block_session_write_service.ts
+import { pool } from "../db/pool.js";
+import { badRequest, notFound } from "./http_errors.js";
+
+function id(prefix: string): string {
+  return `${prefix}_${crypto.randomUUID().replace(/-/g, "")}`;
+}
+
+import crypto from "node:crypto";
+import type { Phase6SessionOutput } from "@kolosseum/engine/phases/phase6.js";
+
+export async function createSessionFromBlockMutation(
+  block_id: string,
+  planned_session: Phase6SessionOutput
+) {
+  if (!block_id) throw badRequest("Missing block_id");
+  if (!planned_session || typeof planned_session !== "object") {
+    throw badRequest("Missing planned_session");
+  }
+
+  const b = await pool.query(`SELECT block_id FROM blocks WHERE block_id = $1`, [block_id]);
+  if ((b.rowCount ?? 0) === 0) throw notFound("Block not found");
+
+  const session_id = id("s");
+  const plannedToStore = { ...planned_session, session_id };
+
+  await pool.query(
+    `
+    INSERT INTO sessions (session_id, status, planned_session, block_id)
+    VALUES ($1, 'created', $2::jsonb, $3)
+    `,
+    [session_id, JSON.stringify(plannedToStore), block_id]
+  );
+
+  try {
+    await pool.query(
+      `
+      INSERT INTO session_event_seq (session_id, next_seq)
+      VALUES ($1, 0)
+      ON CONFLICT (session_id) DO NOTHING
+      `,
+      [session_id]
+    );
+  } catch (e: unknown) {
+    const msg = e instanceof Error ? e.message : String(e);
+    if (!/relation .*session_event_seq.* does not exist/i.test(msg)) throw e;
+  }
+
+  return { session_id };
+}

--- a/src/api/blocks.handlers.ts
+++ b/src/api/blocks.handlers.ts
@@ -16,6 +16,8 @@ import { phase6ProduceSessionOutput } from "@kolosseum/engine/phases/phase6.js";
 import { validateWireRuntimeEvent } from "@kolosseum/engine/runtime/session_summary.js";
 
 import { badRequest, notFound, internalError } from "./http_errors.js";
+import { createSessionFromBlockMutation } from "./block_session_write_service.js";
+import { listBlockSessionsQuery } from "./block_session_query_service.js";
 
 type CompileBlockBody = {
   phase1_input: unknown;
@@ -396,40 +398,13 @@ export async function createSessionFromBlock(req: Request, res: Response) {
   const block_id = asString(req.params?.block_id);
   if (!block_id) throw badRequest("Missing block_id");
 
-  const planned = (req.body as any)?.planned_session as Phase6SessionOutput | undefined;
-  if (!planned || typeof planned !== "object") {
+  const planned_session = (req.body as any)?.planned_session as Phase6SessionOutput | undefined;
+  if (!planned_session || typeof planned_session !== "object") {
     throw badRequest("Missing planned_session");
   }
 
-  const b = await pool.query(`SELECT block_id FROM blocks WHERE block_id = $1`, [block_id]);
-  if ((b.rowCount ?? 0) === 0) throw notFound("Block not found");
-
-  const session_id = id("s");
-  const plannedToStore = { ...planned, session_id };
-
-  await pool.query(
-    `
-    INSERT INTO sessions (session_id, status, planned_session, block_id)
-    VALUES ($1, 'created', $2::jsonb, $3)
-    `,
-    [session_id, JSON.stringify(plannedToStore), block_id]
-  );
-
-  try {
-    await pool.query(
-      `
-      INSERT INTO session_event_seq (session_id, next_seq)
-      VALUES ($1, 0)
-      ON CONFLICT (session_id) DO NOTHING
-      `,
-      [session_id]
-    );
-  } catch (e: unknown) {
-    const msg = e instanceof Error ? e.message : String(e);
-    if (!/relation .*session_event_seq.* does not exist/i.test(msg)) throw e;
-  }
-
-  return res.status(201).json({ session_id });
+  const result = await createSessionFromBlockMutation(block_id, planned_session);
+  return res.status(201).json(result);
 }
 
 /**
@@ -439,15 +414,6 @@ export async function listBlockSessions(req: Request, res: Response) {
   const block_id = asString(req.params?.block_id);
   if (!block_id) throw badRequest("Missing block_id");
 
-  const r = await pool.query(
-    `
-    SELECT session_id, status, created_at, updated_at
-    FROM sessions
-    WHERE block_id = $1
-    ORDER BY created_at ASC
-    `,
-    [block_id]
-  );
-
-  return res.json({ block_id, sessions: r.rows });
+  const payload = await listBlockSessionsQuery(block_id);
+  return res.json(payload);
 }

--- a/test/api_block_session_query_service.contract.test.mjs
+++ b/test/api_block_session_query_service.contract.test.mjs
@@ -1,0 +1,54 @@
+import test, { mock } from "node:test";
+import assert from "node:assert/strict";
+
+const distPoolUrl = new URL("../dist/src/db/pool.js", import.meta.url).href;
+const distServiceUrl = new URL("../dist/src/api/block_session_query_service.js", import.meta.url).href;
+
+let poolCalls = [];
+let queryRows = [];
+
+function resetState() {
+  poolCalls = [];
+  queryRows = [
+    { session_id: "s1", status: "created", created_at: "t1", updated_at: "t1" },
+    { session_id: "s2", status: "in_progress", created_at: "t2", updated_at: "t3" }
+  ];
+}
+
+resetState();
+
+const pool = {
+  async query(sql, params) {
+    poolCalls.push({ sql: String(sql), params });
+    return { rowCount: queryRows.length, rows: queryRows };
+  }
+};
+
+mock.module(distPoolUrl, {
+  namedExports: { pool }
+});
+
+const { listBlockSessionsQuery } = await import(distServiceUrl);
+
+test("listBlockSessionsQuery returns ordered block sessions payload unchanged", async () => {
+  resetState();
+
+  const out = await listBlockSessionsQuery("b_list");
+
+  assert.equal(poolCalls.length, 1);
+  assert.match(poolCalls[0].sql, /SELECT session_id, status, created_at, updated_at/i);
+  assert.match(poolCalls[0].sql, /FROM sessions/i);
+  assert.match(poolCalls[0].sql, /WHERE block_id = \$1/i);
+  assert.match(poolCalls[0].sql, /ORDER BY created_at ASC/i);
+  assert.deepEqual(poolCalls[0].params, ["b_list"]);
+
+  assert.deepEqual(out, { block_id: "b_list", sessions: queryRows });
+});
+
+test("listBlockSessionsQuery returns empty sessions array when none exist", async () => {
+  resetState();
+  queryRows = [];
+
+  const out = await listBlockSessionsQuery("b_empty");
+  assert.deepEqual(out, { block_id: "b_empty", sessions: [] });
+});

--- a/test/api_block_session_write_service.contract.test.mjs
+++ b/test/api_block_session_write_service.contract.test.mjs
@@ -1,0 +1,89 @@
+import test, { mock } from "node:test";
+import assert from "node:assert/strict";
+
+const distPoolUrl = new URL("../dist/src/db/pool.js", import.meta.url).href;
+const distServiceUrl = new URL("../dist/src/api/block_session_write_service.js", import.meta.url).href;
+
+let poolState = {};
+
+function resetPoolState() {
+  poolState = {
+    queryCalls: [],
+    blockRows: [{ block_id: "b_existing" }],
+    insertSessionRows: [],
+    sessionEventSeqThrowsMissingRelation: false
+  };
+}
+
+resetPoolState();
+
+const pool = {
+  async query(sql, params) {
+    const text = String(sql);
+    poolState.queryCalls.push({ sql: text, params });
+
+    if (/SELECT block_id FROM blocks WHERE block_id = \$1/i.test(text)) {
+      return { rowCount: poolState.blockRows.length, rows: poolState.blockRows };
+    }
+
+    if (/INSERT INTO sessions/i.test(text)) {
+      poolState.insertSessionRows.push({ sql: text, params });
+      return { rowCount: 1, rows: [] };
+    }
+
+    if (/INSERT INTO session_event_seq/i.test(text)) {
+      if (poolState.sessionEventSeqThrowsMissingRelation) {
+        throw new Error('relation "session_event_seq" does not exist');
+      }
+      return { rowCount: 1, rows: [] };
+    }
+
+    return { rowCount: 0, rows: [] };
+  }
+};
+
+mock.module(distPoolUrl, {
+  namedExports: { pool }
+});
+
+const { createSessionFromBlockMutation } = await import(distServiceUrl);
+
+test("createSessionFromBlockMutation verifies block exists, inserts created session, initializes seq at 0, and returns session_id", async () => {
+  resetPoolState();
+
+  const planned = { exercises: [{ exercise_id: "ex1" }] };
+  const out = await createSessionFromBlockMutation("b_existing", planned);
+
+  assert.equal(typeof out.session_id, "string");
+  assert.match(out.session_id, /^s_[a-f0-9]{32}$/i);
+
+  assert.ok(poolState.queryCalls.some((x) => /SELECT block_id FROM blocks/i.test(x.sql)));
+  assert.ok(poolState.queryCalls.some((x) => /INSERT INTO sessions/i.test(x.sql)));
+  assert.ok(poolState.queryCalls.some((x) => /INSERT INTO session_event_seq/i.test(x.sql)));
+
+  const inserted = poolState.insertSessionRows.at(-1);
+  assert.ok(inserted, "expected session insert call");
+  assert.equal(inserted.params[2], "b_existing");
+
+  const stored = JSON.parse(inserted.params[1]);
+  assert.equal(stored.session_id, out.session_id);
+  assert.deepEqual(stored.exercises, planned.exercises);
+});
+
+test("createSessionFromBlockMutation throws 404 when block does not exist", async () => {
+  resetPoolState();
+  poolState.blockRows = [];
+
+  await assert.rejects(
+    () => createSessionFromBlockMutation("b_missing", { exercises: [] }),
+    /Block not found/
+  );
+});
+
+test("createSessionFromBlockMutation tolerates missing session_event_seq relation", async () => {
+  resetPoolState();
+  poolState.sessionEventSeqThrowsMissingRelation = true;
+
+  const out = await createSessionFromBlockMutation("b_existing", { exercises: [] });
+  assert.equal(typeof out.session_id, "string");
+});

--- a/test/api_session_event_seq_init_contract.test.mjs
+++ b/test/api_session_event_seq_init_contract.test.mjs
@@ -2,47 +2,22 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import fs from "node:fs";
 
-test("API persistence contract: session_event_seq is initialized at 0 (first allocated seq == 1)", () => {
-  const p = "src/api/blocks.handlers.ts";
-  const s = fs.readFileSync(p, "utf8");
+test("API persistence contract: session_event_seq is initialized at 0 at the remaining blocks.handlers compile-session init site", () => {
+  const src = fs.readFileSync("src/api/blocks.handlers.ts", "utf8");
 
-  // Allow: session_event_seq, public.session_event_seq, "session_event_seq", public."session_event_seq"
-  const tbl = String.raw`(?:(?:[a-zA-Z_][a-zA-Z0-9_]*\s*\.\s*)?"?session_event_seq"?)`;
-
-  // Require the canonical column list (this avoids accidental matches elsewhere)
-  const cols = String.raw`\(\s*session_id\s*,\s*next_seq\s*\)`;
-
-  // Allow $1 with optional parentheses and optional cast (e.g., $1::uuid)
-  const arg1 = String.raw`\(?\s*\$1(?:\s*::\s*[a-zA-Z_][a-zA-Z0-9_]*)?\s*\)?`;
-
-  // Allow 0/1 with optional cast (e.g., 0::int)
-  const v0 = String.raw`0(?:\s*::\s*[a-zA-Z_][a-zA-Z0-9_]*)?`;
-  const v1 = String.raw`1(?:\s*::\s*[a-zA-Z_][a-zA-Z0-9_]*)?`;
-
-  // Match the full init statement shape, tolerant of newlines/indentation
-  const reInit0 = new RegExp(
-    String.raw`INSERT\s+INTO\s+${tbl}\s*${cols}[\s\S]*?VALUES\s*\(\s*${arg1}\s*,\s*${v0}\s*\)`,
-    "gmi"
-  );
-
-  const reInit1 = new RegExp(
-    String.raw`INSERT\s+INTO\s+${tbl}\s*${cols}[\s\S]*?VALUES\s*\(\s*${arg1}\s*,\s*${v1}\s*\)`,
-    "gmi"
-  );
-
-  const init0 = s.match(reInit0) ?? [];
-  const init1 = s.match(reInit1) ?? [];
-
-  assert.equal(
-    init1.length,
-    0,
+  assert.doesNotMatch(
+    src,
+    /INSERT\s+INTO\s+session_event_seq[\s\S]*?VALUES\s*\(\$1,\s*1\)/g,
     "blocks.handlers.ts must not initialize session_event_seq.next_seq to 1 (it creates a seq gap)"
   );
 
-  // Two call sites expected (you showed two previously).
+  const init0 = src.match(
+    /INSERT\s+INTO\s+session_event_seq[\s\S]*?VALUES\s*\(\$1,\s*0\)/g
+  ) ?? [];
+
   assert.equal(
     init0.length,
-    2,
-    `blocks.handlers.ts must initialize session_event_seq.next_seq to 0 at both call sites (found ${init0.length})`
+    1,
+    `blocks.handlers.ts must initialize session_event_seq.next_seq to 0 at the remaining compile-session call site (found ${init0.length})`
   );
 });

--- a/test/ci_api_block_session_query_service_contract_wrapper.test.mjs
+++ b/test/ci_api_block_session_query_service_contract_wrapper.test.mjs
@@ -1,0 +1,24 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import path from "node:path";
+
+test("CI wrapper: block-session query service contract test passes with experimental module mocks", () => {
+  const repo = process.cwd();
+  const testFile = path.join(repo, "test", "api_block_session_query_service.contract.test.mjs");
+
+  const run = spawnSync(
+    process.execPath,
+    ["--experimental-test-module-mocks", "--test", testFile],
+    {
+      cwd: repo,
+      encoding: "utf8",
+      env: process.env
+    }
+  );
+
+  if ((run.stdout ?? "").trim()) process.stdout.write(run.stdout);
+  if ((run.stderr ?? "").trim()) process.stderr.write(run.stderr);
+
+  assert.equal(run.status, 0, `expected wrapper child process to pass (exit=${run.status})`);
+});

--- a/test/ci_api_block_session_write_service_contract_wrapper.test.mjs
+++ b/test/ci_api_block_session_write_service_contract_wrapper.test.mjs
@@ -1,0 +1,24 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import path from "node:path";
+
+test("CI wrapper: block-session write service contract test passes with experimental module mocks", () => {
+  const repo = process.cwd();
+  const testFile = path.join(repo, "test", "api_block_session_write_service.contract.test.mjs");
+
+  const run = spawnSync(
+    process.execPath,
+    ["--experimental-test-module-mocks", "--test", testFile],
+    {
+      cwd: repo,
+      encoding: "utf8",
+      env: process.env
+    }
+  );
+
+  if ((run.stdout ?? "").trim()) process.stdout.write(run.stdout);
+  if ((run.stderr ?? "").trim()) process.stderr.write(run.stderr);
+
+  assert.equal(run.status, 0, `expected wrapper child process to pass (exit=${run.status})`);
+});


### PR DESCRIPTION
## Summary
- extract block-session write logic from blocks.handlers into block_session_write_service
- extract block-session list query logic from blocks.handlers into block_session_query_service
- update the blocks.handlers seq-init source contract to reflect the remaining compile-session ownership site
- add wrapper coverage for the new block-session service contract tests using experimental module mocks

## Testing
- npm run build:fast
- npm run test:one -- test/api_session_event_seq_init_contract.test.mjs
- npm run test:one -- test/ci_api_block_session_write_service_contract_wrapper.test.mjs
- npm run test:one -- test/ci_api_block_session_query_service_contract_wrapper.test.mjs
- npm run lint:fast
- npm run dev:status