### PR TITLE
test(v0): wire block session handler delegation contracts into ci cluster

### DIFF
--- a/ci/contracts/block_handler_delegation_contracts_ci_cluster.json
+++ b/ci/contracts/block_handler_delegation_contracts_ci_cluster.json
@@ -1,0 +1,7 @@
+{
+  "label": "block handler delegation contracts ci cluster",
+  "cluster": [
+    "node test/api_handlers_create_session_from_block_delegation.test.mjs",
+    "node test/api_handlers_list_block_sessions_delegation.test.mjs"
+  ]
+}

--- a/ci/contracts/test_ci_composition.json
+++ b/ci/contracts/test_ci_composition.json
@@ -1,228 +1,248 @@
 {
-  "items": [
-    {
-      "kind": "manifest",
-      "path": "ci/contracts/core_smoke_ci_cluster.json"
-    },
-    {
-      "kind": "command",
-      "value": "node test/ci_core_smoke_cluster_manifest_file.test.mjs"
-    },
-    {
-      "kind": "command",
-      "value": "node test/ci_core_smoke_cluster_manifest.test.mjs"
-    },
-    {
-      "kind": "command",
-      "value": "node test/ci_core_smoke_manifest_file.test.mjs"
-    },
-    {
-      "kind": "command",
-      "value": "node test/ci_core_smoke_manifest.test.mjs"
-    },
-    {
-      "kind": "command",
-      "value": "node test/ci_test_ci_composition_file.test.mjs"
-    },
-    {
-      "kind": "command",
-      "value": "node test/ci_test_ci_composition.test.mjs"
-    },
-    {
-      "kind": "manifest",
-      "path": "ci/contracts/plan_registry_contract_ci_cluster.json"
-    },
-    {
-      "kind": "command",
-      "value": "node test/ci_plan_registry_contract_manifest_file.test.mjs"
-    },
-    {
-      "kind": "command",
-      "value": "node test/ci_plan_registry_contract_manifest.test.mjs"
-    },
-    {
-      "kind": "manifest",
-      "path": "ci/contracts/registry_law_negative_ci_cluster.json"
-    },
-    {
-      "kind": "command",
-      "value": "node test/ci_registry_law_negative_cluster_manifest_file.test.mjs"
-    },
-    {
-      "kind": "command",
-      "value": "node test/ci_registry_law_negative_cluster_manifest.test.mjs"
-    },
-    {
-      "kind": "command",
-      "value": "node test/ci_registry_law_negative_manifest_file.test.mjs"
-    },
-    {
-      "kind": "command",
-      "value": "node test/ci_registry_law_negative_manifest.test.mjs"
-    },
-    {
-      "kind": "manifest",
-      "path": "ci/contracts/registry_law_positive_ci_cluster.json"
-    },
-    {
-      "kind": "command",
-      "value": "node test/ci_registry_law_positive_cluster_manifest_file.test.mjs"
-    },
-    {
-      "kind": "command",
-      "value": "node test/ci_registry_law_positive_cluster_manifest.test.mjs"
-    },
-    {
-      "kind": "command",
-      "value": "node test/ci_registry_law_positive_manifest_file.test.mjs"
-    },
-    {
-      "kind": "command",
-      "value": "node test/ci_registry_law_positive_manifest.test.mjs"
-    },
-    {
-      "kind": "manifest",
-      "path": "ci/contracts/phase1_docs_ci_cluster.json"
-    },
-    {
-      "kind": "command",
-      "value": "node test/ci_phase1_docs_cluster_manifest_file.test.mjs"
-    },
-    {
-      "kind": "command",
-      "value": "node test/ci_phase1_docs_cluster_manifest.test.mjs"
-    },
-    {
-      "kind": "command",
-      "value": "node test/ci_phase1_docs_manifest_file.test.mjs"
-    },
-    {
-      "kind": "command",
-      "value": "node test/ci_phase1_docs_manifest.test.mjs"
-    },
-    {
-      "kind": "manifest",
-      "path": "ci/contracts/split_invariant_normalize_ci_cluster.json"
-    },
-    {
-      "kind": "command",
-      "value": "node test/ci_split_invariant_normalize_cluster_manifest_file.test.mjs"
-    },
-    {
-      "kind": "command",
-      "value": "node test/ci_split_invariant_normalize_cluster_manifest.test.mjs"
-    },
-    {
-      "kind": "command",
-      "value": "node test/ci_split_invariant_normalize_manifest_file.test.mjs"
-    },
-    {
-      "kind": "command",
-      "value": "node test/ci_split_invariant_normalize_manifest.test.mjs"
-    },
-    {
-      "kind": "command",
-      "value": "node test/ci_ban_set_content_utf8_guard_outfile_negative.test.mjs"
-    },
-    {
-      "kind": "manifest",
-      "path": "ci/contracts/canonical_hash_api_ci_cluster.json"
-    },
-    {
-      "kind": "command",
-      "value": "node test/ci_canonical_hash_api_cluster_manifest_file.test.mjs"
-    },
-    {
-      "kind": "command",
-      "value": "node test/ci_canonical_hash_api_cluster_manifest.test.mjs"
-    },
-    {
-      "kind": "command",
-      "value": "node test/ci_canonical_hash_api_manifest_file.test.mjs"
-    },
-    {
-      "kind": "command",
-      "value": "node test/ci_canonical_hash_api_manifest.test.mjs"
-    },
-    {
-      "kind": "manifest",
-      "path": "ci/contracts/dev_session_api_ci_cluster.json"
-    },
-    {
-      "kind": "command",
-      "value": "node test/ci_dev_session_api_cluster_manifest_file.test.mjs"
-    },
-    {
-      "kind": "command",
-      "value": "node test/ci_dev_session_api_cluster_manifest.test.mjs"
-    },
-    {
-      "kind": "command",
-      "value": "node test/ci_dev_session_api_manifest_file.test.mjs"
-    },
-    {
-      "kind": "command",
-      "value": "node test/ci_dev_session_api_manifest.test.mjs"
-    },
-    {
-      "kind": "manifest",
-      "path": "ci/contracts/runtime_trace_return_gate_ci_cluster.json"
-    },
-    {
-      "kind": "command",
-      "value": "node test/ci_runtime_trace_return_gate_cluster_manifest_file.test.mjs"
-    },
-    {
-      "kind": "command",
-      "value": "node test/ci_runtime_trace_return_gate_cluster_manifest.test.mjs"
-    },
-    {
-      "kind": "command",
-      "value": "node test/ci_runtime_trace_return_gate_manifest_file.test.mjs"
-    },
-    {
-      "kind": "command",
-      "value": "node test/ci_runtime_trace_return_gate_manifest.test.mjs"
-    },
-    {
-      "kind": "manifest",
-      "path": "ci/contracts/compile_runtime_trace_ci_cluster.json"
-    },
-    {
-      "kind": "command",
-      "value": "node test/ci_compile_runtime_trace_cluster_manifest_file.test.mjs"
-    },
-    {
-      "kind": "command",
-      "value": "node test/ci_compile_runtime_trace_cluster_manifest.test.mjs"
-    },
-    {
-      "kind": "command",
-      "value": "node test/ci_compile_runtime_trace_manifest_file.test.mjs"
-    },
-    {
-      "kind": "command",
-      "value": "node test/ci_compile_runtime_trace_manifest.test.mjs"
-    },
-    {
-      "kind": "manifest",
-      "path": "ci/contracts/handler_delegation_contracts_ci_cluster.json"
-    },
-    {
-      "kind": "command",
-      "value": "node test/ci_handler_delegation_contracts_cluster_manifest_file.test.mjs"
-    },
-    {
-      "kind": "command",
-      "value": "node test/ci_handler_delegation_contracts_cluster_manifest.test.mjs"
-    },
-    {
-      "kind": "command",
-      "value": "node test/ci_handler_delegation_contracts_manifest_file.test.mjs"
-    },
-    {
-      "kind": "command",
-      "value": "node test/ci_handler_delegation_contracts_manifest.test.mjs"
-    }
-  ]
+    "items":  [
+                  {
+                      "kind":  "manifest",
+                      "path":  "ci/contracts/core_smoke_ci_cluster.json"
+                  },
+                  {
+                      "kind":  "command",
+                      "value":  "node test/ci_core_smoke_cluster_manifest_file.test.mjs"
+                  },
+                  {
+                      "kind":  "command",
+                      "value":  "node test/ci_core_smoke_cluster_manifest.test.mjs"
+                  },
+                  {
+                      "kind":  "command",
+                      "value":  "node test/ci_core_smoke_manifest_file.test.mjs"
+                  },
+                  {
+                      "kind":  "command",
+                      "value":  "node test/ci_core_smoke_manifest.test.mjs"
+                  },
+                  {
+                      "kind":  "command",
+                      "value":  "node test/ci_test_ci_composition_file.test.mjs"
+                  },
+                  {
+                      "kind":  "command",
+                      "value":  "node test/ci_test_ci_composition.test.mjs"
+                  },
+                  {
+                      "kind":  "manifest",
+                      "path":  "ci/contracts/plan_registry_contract_ci_cluster.json"
+                  },
+                  {
+                      "kind":  "command",
+                      "value":  "node test/ci_plan_registry_contract_manifest_file.test.mjs"
+                  },
+                  {
+                      "kind":  "command",
+                      "value":  "node test/ci_plan_registry_contract_manifest.test.mjs"
+                  },
+                  {
+                      "kind":  "manifest",
+                      "path":  "ci/contracts/registry_law_negative_ci_cluster.json"
+                  },
+                  {
+                      "kind":  "command",
+                      "value":  "node test/ci_registry_law_negative_cluster_manifest_file.test.mjs"
+                  },
+                  {
+                      "kind":  "command",
+                      "value":  "node test/ci_registry_law_negative_cluster_manifest.test.mjs"
+                  },
+                  {
+                      "kind":  "command",
+                      "value":  "node test/ci_registry_law_negative_manifest_file.test.mjs"
+                  },
+                  {
+                      "kind":  "command",
+                      "value":  "node test/ci_registry_law_negative_manifest.test.mjs"
+                  },
+                  {
+                      "kind":  "manifest",
+                      "path":  "ci/contracts/registry_law_positive_ci_cluster.json"
+                  },
+                  {
+                      "kind":  "command",
+                      "value":  "node test/ci_registry_law_positive_cluster_manifest_file.test.mjs"
+                  },
+                  {
+                      "kind":  "command",
+                      "value":  "node test/ci_registry_law_positive_cluster_manifest.test.mjs"
+                  },
+                  {
+                      "kind":  "command",
+                      "value":  "node test/ci_registry_law_positive_manifest_file.test.mjs"
+                  },
+                  {
+                      "kind":  "command",
+                      "value":  "node test/ci_registry_law_positive_manifest.test.mjs"
+                  },
+                  {
+                      "kind":  "manifest",
+                      "path":  "ci/contracts/phase1_docs_ci_cluster.json"
+                  },
+                  {
+                      "kind":  "command",
+                      "value":  "node test/ci_phase1_docs_cluster_manifest_file.test.mjs"
+                  },
+                  {
+                      "kind":  "command",
+                      "value":  "node test/ci_phase1_docs_cluster_manifest.test.mjs"
+                  },
+                  {
+                      "kind":  "command",
+                      "value":  "node test/ci_phase1_docs_manifest_file.test.mjs"
+                  },
+                  {
+                      "kind":  "command",
+                      "value":  "node test/ci_phase1_docs_manifest.test.mjs"
+                  },
+                  {
+                      "kind":  "manifest",
+                      "path":  "ci/contracts/split_invariant_normalize_ci_cluster.json"
+                  },
+                  {
+                      "kind":  "command",
+                      "value":  "node test/ci_split_invariant_normalize_cluster_manifest_file.test.mjs"
+                  },
+                  {
+                      "kind":  "command",
+                      "value":  "node test/ci_split_invariant_normalize_cluster_manifest.test.mjs"
+                  },
+                  {
+                      "kind":  "command",
+                      "value":  "node test/ci_split_invariant_normalize_manifest_file.test.mjs"
+                  },
+                  {
+                      "kind":  "command",
+                      "value":  "node test/ci_split_invariant_normalize_manifest.test.mjs"
+                  },
+                  {
+                      "kind":  "command",
+                      "value":  "node test/ci_ban_set_content_utf8_guard_outfile_negative.test.mjs"
+                  },
+                  {
+                      "kind":  "manifest",
+                      "path":  "ci/contracts/canonical_hash_api_ci_cluster.json"
+                  },
+                  {
+                      "kind":  "command",
+                      "value":  "node test/ci_canonical_hash_api_cluster_manifest_file.test.mjs"
+                  },
+                  {
+                      "kind":  "command",
+                      "value":  "node test/ci_canonical_hash_api_cluster_manifest.test.mjs"
+                  },
+                  {
+                      "kind":  "command",
+                      "value":  "node test/ci_canonical_hash_api_manifest_file.test.mjs"
+                  },
+                  {
+                      "kind":  "command",
+                      "value":  "node test/ci_canonical_hash_api_manifest.test.mjs"
+                  },
+                  {
+                      "kind":  "manifest",
+                      "path":  "ci/contracts/dev_session_api_ci_cluster.json"
+                  },
+                  {
+                      "kind":  "command",
+                      "value":  "node test/ci_dev_session_api_cluster_manifest_file.test.mjs"
+                  },
+                  {
+                      "kind":  "command",
+                      "value":  "node test/ci_dev_session_api_cluster_manifest.test.mjs"
+                  },
+                  {
+                      "kind":  "command",
+                      "value":  "node test/ci_dev_session_api_manifest_file.test.mjs"
+                  },
+                  {
+                      "kind":  "command",
+                      "value":  "node test/ci_dev_session_api_manifest.test.mjs"
+                  },
+                  {
+                      "kind":  "manifest",
+                      "path":  "ci/contracts/runtime_trace_return_gate_ci_cluster.json"
+                  },
+                  {
+                      "kind":  "command",
+                      "value":  "node test/ci_runtime_trace_return_gate_cluster_manifest_file.test.mjs"
+                  },
+                  {
+                      "kind":  "command",
+                      "value":  "node test/ci_runtime_trace_return_gate_cluster_manifest.test.mjs"
+                  },
+                  {
+                      "kind":  "command",
+                      "value":  "node test/ci_runtime_trace_return_gate_manifest_file.test.mjs"
+                  },
+                  {
+                      "kind":  "command",
+                      "value":  "node test/ci_runtime_trace_return_gate_manifest.test.mjs"
+                  },
+                  {
+                      "kind":  "manifest",
+                      "path":  "ci/contracts/compile_runtime_trace_ci_cluster.json"
+                  },
+                  {
+                      "kind":  "command",
+                      "value":  "node test/ci_compile_runtime_trace_cluster_manifest_file.test.mjs"
+                  },
+                  {
+                      "kind":  "command",
+                      "value":  "node test/ci_compile_runtime_trace_cluster_manifest.test.mjs"
+                  },
+                  {
+                      "kind":  "command",
+                      "value":  "node test/ci_compile_runtime_trace_manifest_file.test.mjs"
+                  },
+                  {
+                      "kind":  "command",
+                      "value":  "node test/ci_compile_runtime_trace_manifest.test.mjs"
+                  },
+                  {
+                      "kind":  "manifest",
+                      "path":  "ci/contracts/block_handler_delegation_contracts_ci_cluster.json"
+                  },
+                  {
+                      "kind":  "command",
+                      "value":  "node test/ci_block_handler_delegation_contracts_cluster_manifest_file.test.mjs"
+                  },
+                  {
+                      "kind":  "command",
+                      "value":  "node test/ci_block_handler_delegation_contracts_cluster_manifest.test.mjs"
+                  },
+                  {
+                      "kind":  "command",
+                      "value":  "node test/ci_block_handler_delegation_contracts_manifest_file.test.mjs"
+                  },
+                  {
+                      "kind":  "command",
+                      "value":  "node test/ci_block_handler_delegation_contracts_manifest.test.mjs"
+                  },
+                  {
+                      "kind":  "manifest",
+                      "path":  "ci/contracts/handler_delegation_contracts_ci_cluster.json"
+                  },
+                  {
+                      "kind":  "command",
+                      "value":  "node test/ci_handler_delegation_contracts_cluster_manifest_file.test.mjs"
+                  },
+                  {
+                      "kind":  "command",
+                      "value":  "node test/ci_handler_delegation_contracts_cluster_manifest.test.mjs"
+                  },
+                  {
+                      "kind":  "command",
+                      "value":  "node test/ci_handler_delegation_contracts_manifest_file.test.mjs"
+                  },
+                  {
+                      "kind":  "command",
+                      "value":  "node test/ci_handler_delegation_contracts_manifest.test.mjs"
+                  }
+              ]
 }

--- a/test/api_handlers_create_session_from_block_delegation.test.mjs
+++ b/test/api_handlers_create_session_from_block_delegation.test.mjs
@@ -1,0 +1,46 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+
+test("blocks.handlers source contract: createSessionFromBlock delegates block_id + planned_session to createSessionFromBlockMutation and returns 201", () => {
+  const repo = process.cwd();
+  const file = path.join(repo, "src", "api", "blocks.handlers.ts");
+  const src = fs.readFileSync(file, "utf8");
+
+  assert.match(
+    src,
+    /import\s*\{\s*createSessionFromBlockMutation\s*\}\s*from\s*"\.\/block_session_write_service\.js"/,
+    "expected handler to import createSessionFromBlockMutation from extracted block session write service"
+  );
+
+  assert.match(
+    src,
+    /export\s+async\s+function\s+createSessionFromBlock\s*\(\s*req:\s*Request\s*,\s*res:\s*Response\s*\)/,
+    "expected createSessionFromBlock handler to exist"
+  );
+
+  assert.match(
+    src,
+    /const\s+block_id\s*=\s*asString\(req\.params\?\.block_id\);/,
+    "expected createSessionFromBlock to read block_id from req.params.block_id"
+  );
+
+  assert.match(
+    src,
+    /const\s+planned_session\s*=\s*\(req\.body\s+as\s+any\)\?\.planned_session\s+as\s+Phase6SessionOutput\s+\|\s+undefined;/,
+    "expected createSessionFromBlock to read planned_session from req.body.planned_session"
+  );
+
+  assert.match(
+    src,
+    /const\s+result\s*=\s*await\s+createSessionFromBlockMutation\(block_id,\s*planned_session\);/,
+    "expected createSessionFromBlock to delegate to createSessionFromBlockMutation(block_id, planned_session)"
+  );
+
+  assert.match(
+    src,
+    /return\s+res\.status\(201\)\.json\(result\);/,
+    "expected createSessionFromBlock to preserve 201 JSON response"
+  );
+});

--- a/test/api_handlers_list_block_sessions_delegation.test.mjs
+++ b/test/api_handlers_list_block_sessions_delegation.test.mjs
@@ -1,0 +1,40 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+
+test("blocks.handlers source contract: listBlockSessions delegates block_id to listBlockSessionsQuery and preserves JSON payload", () => {
+  const repo = process.cwd();
+  const file = path.join(repo, "src", "api", "blocks.handlers.ts");
+  const src = fs.readFileSync(file, "utf8");
+
+  assert.match(
+    src,
+    /import\s*\{\s*listBlockSessionsQuery\s*\}\s*from\s*"\.\/block_session_query_service\.js"/,
+    "expected handler to import listBlockSessionsQuery from extracted block session query service"
+  );
+
+  assert.match(
+    src,
+    /export\s+async\s+function\s+listBlockSessions\s*\(\s*req:\s*Request\s*,\s*res:\s*Response\s*\)/,
+    "expected listBlockSessions handler to exist"
+  );
+
+  assert.match(
+    src,
+    /const\s+block_id\s*=\s*asString\(req\.params\?\.block_id\);/,
+    "expected listBlockSessions to read block_id from req.params.block_id"
+  );
+
+  assert.match(
+    src,
+    /const\s+payload\s*=\s*await\s+listBlockSessionsQuery\(block_id\);/,
+    "expected listBlockSessions to delegate to listBlockSessionsQuery(block_id)"
+  );
+
+  assert.match(
+    src,
+    /return\s+res\.json\(payload\);/,
+    "expected listBlockSessions to preserve JSON payload response"
+  );
+});

--- a/test/ci_block_handler_delegation_contracts_cluster_manifest.test.mjs
+++ b/test/ci_block_handler_delegation_contracts_cluster_manifest.test.mjs
@@ -1,0 +1,16 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+test("test:ci composition index includes pinned block handler delegation contracts cluster manifest and adjacent guard pair", () => {
+  const repo = process.cwd();
+  const p = path.join(repo, "ci", "contracts", "test_ci_composition.json");
+  const src = readFileSync(p, "utf8");
+
+  assert.match(
+    src,
+    /ci\/contracts\/block_handler_delegation_contracts_ci_cluster\.json/,
+    "expected test:ci composition index to include block handler delegation contracts cluster manifest"
+  );
+});

--- a/test/ci_block_handler_delegation_contracts_cluster_manifest_file.test.mjs
+++ b/test/ci_block_handler_delegation_contracts_cluster_manifest_file.test.mjs
@@ -1,0 +1,32 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+
+const NODE_TEST_CMD_RE = /^node test\/[A-Za-z0-9._/-]+\.test\.mjs$/;
+
+test("block handler delegation contracts cluster manifest file is well-formed, non-empty, unique, and node-test-only", () => {
+  const repo = process.cwd();
+  const manifestPath = path.join(repo, "ci", "contracts", "block_handler_delegation_contracts_ci_cluster.json");
+  const raw = fs.readFileSync(manifestPath, "utf8");
+
+  let manifest;
+  assert.doesNotThrow(() => {
+    manifest = JSON.parse(raw);
+  }, "expected block handler delegation contracts cluster manifest to be valid JSON");
+
+  assert.ok(manifest && typeof manifest === "object" && !Array.isArray(manifest), "expected manifest object");
+  assert.equal(manifest.label, "block handler delegation contracts ci cluster");
+  assert.ok(Array.isArray(manifest.cluster), "expected manifest.cluster array");
+  assert.equal(manifest.cluster.length, 2, "expected exactly 2 block handler delegation contract commands");
+
+  const seen = new Set();
+  for (const cmd of manifest.cluster) {
+    assert.equal(typeof cmd, "string", "expected command string");
+    assert.notEqual(cmd.trim(), "", "expected non-empty command");
+    assert.equal(cmd, cmd.trim(), "expected trimmed command");
+    assert.match(cmd, NODE_TEST_CMD_RE, "expected node test/... .test.mjs command");
+    assert.ok(!seen.has(cmd), `expected unique command: ${cmd}`);
+    seen.add(cmd);
+  }
+});

--- a/test/ci_block_handler_delegation_contracts_manifest.test.mjs
+++ b/test/ci_block_handler_delegation_contracts_manifest.test.mjs
@@ -1,0 +1,15 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { composeTestCiFromIndex } from "../ci/scripts/compose_test_ci_from_index.mjs";
+
+test("block handler delegation contracts manifest remains present in composed test:ci command set", () => {
+  const repo = process.cwd();
+  const { commands } = composeTestCiFromIndex(repo);
+
+  for (const cmd of [
+    "node test/api_handlers_create_session_from_block_delegation.test.mjs",
+    "node test/api_handlers_list_block_sessions_delegation.test.mjs"
+  ]) {
+    assert.ok(commands.includes(cmd), `expected ${cmd} in composed test:ci command set`);
+  }
+});

--- a/test/ci_block_handler_delegation_contracts_manifest_file.test.mjs
+++ b/test/ci_block_handler_delegation_contracts_manifest_file.test.mjs
@@ -1,0 +1,16 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+
+test("block handler delegation contracts manifest file remains pinned to the expected handler delegation contract tests", () => {
+  const repo = process.cwd();
+  const manifestPath = path.join(repo, "ci", "contracts", "block_handler_delegation_contracts_ci_cluster.json");
+  const manifest = JSON.parse(fs.readFileSync(manifestPath, "utf8"));
+
+  assert.equal(manifest.label, "block handler delegation contracts ci cluster");
+  assert.deepEqual(manifest.cluster, [
+    "node test/api_handlers_create_session_from_block_delegation.test.mjs",
+    "node test/api_handlers_list_block_sessions_delegation.test.mjs"
+  ]);
+});


### PR DESCRIPTION
## Summary
- add source-contract delegation tests for createSessionFromBlock and listBlockSessions in blocks.handlers
- wire a dedicated block handler delegation cluster into the single-owner test:ci composition index
- pin manifest-file and manifest-presence coverage for the new block handler delegation contract cluster

## Testing
- npm run test:one -- test/api_handlers_create_session_from_block_delegation.test.mjs
- npm run test:one -- test/api_handlers_list_block_sessions_delegation.test.mjs
- npm run test:one -- test/ci_block_handler_delegation_contracts_cluster_manifest_file.test.mjs
- npm run test:one -- test/ci_block_handler_delegation_contracts_cluster_manifest.test.mjs
- npm run test:one -- test/ci_block_handler_delegation_contracts_manifest_file.test.mjs
- npm run test:one -- test/ci_block_handler_delegation_contracts_manifest.test.mjs
- npm run test:one -- test/ci_test_ci_composition_file.test.mjs
- npm run test:one -- test/ci_test_ci_composition.test.mjs
- npm run lint:fast
- npm run dev:status