### PR TITLE
refactor(v0): extract compile block persistence write service

### DIFF
--- a/ci/contracts/compile_block_persistence_delegation_contracts_ci_cluster.json
+++ b/ci/contracts/compile_block_persistence_delegation_contracts_ci_cluster.json
@@ -1,0 +1,7 @@
+{
+  "label": "compile block persistence delegation contracts ci cluster",
+  "cluster": [
+    "node test/api_handlers_compile_block_persistence_delegation.test.mjs",
+    "node test/ci_api_block_compile_write_service_contract_wrapper.test.mjs"
+  ]
+}

--- a/ci/contracts/test_ci_composition.json
+++ b/ci/contracts/test_ci_composition.json
@@ -206,6 +206,26 @@
                   },
                   {
                       "kind":  "manifest",
+                      "path":  "ci/contracts/compile_block_persistence_delegation_contracts_ci_cluster.json"
+                  },
+                  {
+                      "kind":  "command",
+                      "value":  "node test/ci_compile_block_persistence_delegation_contracts_cluster_manifest_file.test.mjs"
+                  },
+                  {
+                      "kind":  "command",
+                      "value":  "node test/ci_compile_block_persistence_delegation_contracts_cluster_manifest.test.mjs"
+                  },
+                  {
+                      "kind":  "command",
+                      "value":  "node test/ci_compile_block_persistence_delegation_contracts_manifest_file.test.mjs"
+                  },
+                  {
+                      "kind":  "command",
+                      "value":  "node test/ci_compile_block_persistence_delegation_contracts_manifest.test.mjs"
+                  },
+                  {
+                      "kind":  "manifest",
                       "path":  "ci/contracts/block_handler_delegation_contracts_ci_cluster.json"
                   },
                   {

--- a/src/api/block_compile_write_service.ts
+++ b/src/api/block_compile_write_service.ts
@@ -1,0 +1,114 @@
+// src/api/block_compile_write_service.ts
+import crypto from "node:crypto";
+import { pool } from "../db/pool.js";
+
+type PersistCompileBlockArgs = {
+  engine_version: string;
+  canonical_hash: string;
+  canonical_input: unknown;
+  phase2_canonical_payload: unknown;
+  phase3_output: unknown;
+  phase4_program: unknown;
+  phase5_adjustments: unknown[];
+  planned_session_from_engine: unknown;
+  create_session: boolean;
+};
+
+function id(prefix: string): string {
+  return `${prefix}_${crypto.randomUUID().replace(/-/g, "")}`;
+}
+
+function asString(v: unknown): string | undefined {
+  return typeof v === "string" && v.length > 0 ? v : undefined;
+}
+
+export async function persistCompiledBlockAndMaybeCreateSession(args: PersistCompileBlockArgs) {
+  const client = await pool.connect();
+  try {
+    await client.query("BEGIN");
+
+    const new_block_id = id("b");
+
+    const br = await client.query(
+      `
+      INSERT INTO blocks (
+        block_id,
+        engine_version,
+        canonical_hash,
+        phase1_input,
+        phase2_canonical,
+        phase3_output,
+        phase4_program,
+        phase5_adjustments
+      )
+      VALUES ($1,$2,$3,$4::jsonb,$5::jsonb,$6::jsonb,$7::jsonb,$8::jsonb)
+      ON CONFLICT (canonical_hash) DO UPDATE
+      SET
+        engine_version = EXCLUDED.engine_version,
+        phase1_input = EXCLUDED.phase1_input,
+        phase2_canonical = EXCLUDED.phase2_canonical,
+        phase3_output = EXCLUDED.phase3_output,
+        phase4_program = EXCLUDED.phase4_program,
+        phase5_adjustments = EXCLUDED.phase5_adjustments
+      RETURNING block_id
+      `,
+      [
+        new_block_id,
+        args.engine_version,
+        args.canonical_hash,
+        JSON.stringify(args.canonical_input),
+        JSON.stringify(args.phase2_canonical_payload),
+        JSON.stringify(args.phase3_output),
+        JSON.stringify(args.phase4_program),
+        JSON.stringify(args.phase5_adjustments)
+      ]
+    );
+
+    const persisted_block_id = asString(br.rows?.[0]?.block_id) ?? new_block_id;
+    const created_block = persisted_block_id === new_block_id;
+
+    let session_id: string | undefined;
+
+    if (args.create_session) {
+      session_id = id("s");
+      const plannedToStore = { ...(args.planned_session_from_engine as any), session_id };
+
+      await client.query(
+        `
+        INSERT INTO sessions (session_id, status, planned_session, block_id)
+        VALUES ($1, 'created', $2::jsonb, $3)
+        `,
+        [session_id, JSON.stringify(plannedToStore), persisted_block_id]
+      );
+
+      try {
+        await client.query(
+          `
+          INSERT INTO session_event_seq (session_id, next_seq)
+          VALUES ($1, 0)
+          ON CONFLICT (session_id) DO NOTHING
+          `,
+          [session_id]
+        );
+      } catch (e: unknown) {
+        const msg = e instanceof Error ? e.message : String(e);
+        if (!/relation .*session_event_seq.* does not exist/i.test(msg)) throw e;
+      }
+    }
+
+    await client.query("COMMIT");
+
+    return {
+      persisted_block_id,
+      created_block,
+      session_id
+    };
+  } catch (err: unknown) {
+    try {
+      await client.query("ROLLBACK");
+    } catch {}
+    throw err;
+  } finally {
+    client.release();
+  }
+}

--- a/src/api/blocks.handlers.ts
+++ b/src/api/blocks.handlers.ts
@@ -18,6 +18,7 @@ import { validateWireRuntimeEvent } from "@kolosseum/engine/runtime/session_summ
 import { badRequest, notFound, internalError } from "./http_errors.js";
 import { createSessionFromBlockMutation } from "./block_session_write_service.js";
 import { listBlockSessionsQuery } from "./block_session_query_service.js";
+import { persistCompiledBlockAndMaybeCreateSession } from "./block_compile_write_service.js";
 
 type CompileBlockBody = {
   phase1_input: unknown;
@@ -250,107 +251,36 @@ export async function compileBlock(req: Request, res: Response) {
     })
   };
 
-  const client = await pool.connect();
-  try {
-    await client.query("BEGIN");
+  const phase2_canonical_payload = {
+    phase2_canonical_json: p2.phase2.phase2_canonical_json,
+    phase2_hash: p2.phase2.phase2_hash,
+    canonical_input_hash: p2.phase2.canonical_input_hash
+  };
 
-    const new_block_id = id("b");
+  const persisted = await persistCompiledBlockAndMaybeCreateSession({
+    engine_version,
+    canonical_hash,
+    canonical_input,
+    phase2_canonical_payload,
+    phase3_output: p3.phase3,
+    phase4_program: p4.program,
+    phase5_adjustments,
+    planned_session_from_engine,
+    create_session
+  });
 
-    const phase2_canonical_payload = {
-      phase2_canonical_json: p2.phase2.phase2_canonical_json,
-      phase2_hash: p2.phase2.phase2_hash,
-      canonical_input_hash: p2.phase2.canonical_input_hash
-    };
+  const status = create_session ? 201 : (persisted.created_block ? 201 : 200);
 
-    const br = await client.query(
-      `
-      INSERT INTO blocks (
-        block_id,
-        engine_version,
-        canonical_hash,
-        phase1_input,
-        phase2_canonical,
-        phase3_output,
-        phase4_program,
-        phase5_adjustments
-      )
-      VALUES ($1,$2,$3,$4::jsonb,$5::jsonb,$6::jsonb,$7::jsonb,$8::jsonb)
-      ON CONFLICT (canonical_hash) DO UPDATE
-      SET
-        engine_version = EXCLUDED.engine_version,
-        phase1_input = EXCLUDED.phase1_input,
-        phase2_canonical = EXCLUDED.phase2_canonical,
-        phase3_output = EXCLUDED.phase3_output,
-        phase4_program = EXCLUDED.phase4_program,
-        phase5_adjustments = EXCLUDED.phase5_adjustments
-      RETURNING block_id
-      `,
-      [
-        new_block_id,
-        engine_version,
-        canonical_hash,
-        JSON.stringify(canonical_input),
-        JSON.stringify(phase2_canonical_payload),
-        JSON.stringify(p3.phase3),
-        JSON.stringify(p4.program),
-        JSON.stringify(phase5_adjustments)
-      ]
-    );
+  const payload: any = {
+    block_id: persisted.persisted_block_id,
+    engine_version,
+    canonical_hash,
+    planned_session: planned_session_applied,
+    runtime_trace: runtime_trace_from_engine
+  };
+  if (persisted.session_id) payload.session_id = persisted.session_id;
 
-    const persisted_block_id = asString(br.rows?.[0]?.block_id) ?? new_block_id;
-    const created_block = persisted_block_id === new_block_id;
-
-    let session_id: string | undefined;
-
-    if (create_session) {
-      session_id = id("s");
-      const plannedToStore = { ...planned_session_from_engine, session_id };
-
-      await client.query(
-        `
-        INSERT INTO sessions (session_id, status, planned_session, block_id)
-        VALUES ($1, 'created', $2::jsonb, $3)
-        `,
-        [session_id, JSON.stringify(plannedToStore), persisted_block_id]
-      );
-
-      try {
-        await client.query(
-          `
-          INSERT INTO session_event_seq (session_id, next_seq)
-          VALUES ($1, 0)
-          ON CONFLICT (session_id) DO NOTHING
-          `,
-          [session_id]
-        );
-      } catch (e: unknown) {
-        const msg = e instanceof Error ? e.message : String(e);
-        if (!/relation .*session_event_seq.* does not exist/i.test(msg)) throw e;
-      }
-    }
-
-    await client.query("COMMIT");
-
-    const status = create_session ? 201 : (created_block ? 201 : 200);
-
-    const payload: any = {
-      block_id: persisted_block_id,
-      engine_version,
-      canonical_hash,
-      planned_session: planned_session_applied,
-      runtime_trace: runtime_trace_from_engine
-    };
-    if (session_id) payload.session_id = session_id;
-
-    return res.status(status).json(payload);
-  } catch (err: unknown) {
-    try {
-      await client.query("ROLLBACK");
-    } catch {}
-    throw err;
-  } finally {
-    client.release();
-  }
+  return res.status(status).json(payload);
 }
 
 /**

--- a/test/api_block_compile_write_service.contract.test.mjs
+++ b/test/api_block_compile_write_service.contract.test.mjs
@@ -1,0 +1,183 @@
+import test, { mock } from "node:test";
+import assert from "node:assert/strict";
+
+const distPoolUrl = new URL("../dist/src/db/pool.js", import.meta.url).href;
+const distServiceUrl = new URL("../dist/src/api/block_compile_write_service.js", import.meta.url).href;
+
+let state = {};
+
+function resetState() {
+  state = {
+    connectCalls: 0,
+    releaseCalls: 0,
+    queries: [],
+    returningBlockId: null,
+    mirrorInsertedBlockIdOnReturn: false,
+    sessionEventSeqThrowsMissingRelation: false,
+    failAfterBegin: null
+  };
+}
+
+resetState();
+
+const client = {
+  async query(sql, params) {
+    const text = String(sql);
+    state.queries.push({ sql: text, params });
+
+    if (state.failAfterBegin && state.failAfterBegin.test(text)) {
+      throw new Error("forced write failure");
+    }
+
+    if (/INSERT INTO blocks/i.test(text) && state.mirrorInsertedBlockIdOnReturn) {
+      state.returningBlockId = params?.[0] ?? null;
+    }
+
+    if (/RETURNING block_id/i.test(text)) {
+      return {
+        rowCount: 1,
+        rows: [{ block_id: state.returningBlockId }]
+      };
+    }
+
+    return { rowCount: 1, rows: [] };
+  },
+  release() {
+    state.releaseCalls += 1;
+  }
+};
+
+const pool = {
+  async connect() {
+    state.connectCalls += 1;
+    return {
+      query: async (sql, params) => {
+        if (
+          state.sessionEventSeqThrowsMissingRelation &&
+          /INSERT INTO session_event_seq/i.test(String(sql))
+        ) {
+          throw new Error('relation "session_event_seq" does not exist');
+        }
+        return client.query(sql, params);
+      },
+      release: () => client.release()
+    };
+  }
+};
+
+mock.module(distPoolUrl, {
+  namedExports: { pool }
+});
+
+const { persistCompiledBlockAndMaybeCreateSession } = await import(distServiceUrl);
+
+function makeArgs(overrides = {}) {
+  return {
+    engine_version: "EB2-1.0.0",
+    canonical_hash: "hash_123",
+    canonical_input: { activity: "powerlifting" },
+    phase2_canonical_payload: { phase2_hash: "phase2_hash_123" },
+    phase3_output: { constraints: {} },
+    phase4_program: { program_id: "p1" },
+    phase5_adjustments: [],
+    planned_session_from_engine: { exercises: [{ exercise_id: "ex1" }] },
+    create_session: false,
+    ...overrides
+  };
+}
+
+test("persistCompiledBlockAndMaybeCreateSession upserts block and returns created_block=true when RETURNING block_id matches generated id", async () => {
+  resetState();
+  state.mirrorInsertedBlockIdOnReturn = true;
+
+  const out = await persistCompiledBlockAndMaybeCreateSession(makeArgs());
+
+  assert.equal(state.connectCalls, 1);
+  assert.equal(state.releaseCalls, 1);
+  assert.equal(out.persisted_block_id, state.returningBlockId);
+  assert.equal(out.created_block, true);
+  assert.equal(out.session_id, undefined);
+
+  assert.match(state.queries[0].sql, /BEGIN/i);
+  assert.ok(state.queries.some((x) => /INSERT INTO blocks/i.test(x.sql)));
+  assert.ok(state.queries.some((x) => /COMMIT/i.test(x.sql)));
+
+  const insert = state.queries.find((x) => /INSERT INTO blocks/i.test(x.sql));
+  assert.ok(insert, "expected block insert query");
+  assert.match(insert.params[0], /^b_[a-f0-9]{32}$/i);
+  assert.equal(insert.params[1], "EB2-1.0.0");
+  assert.equal(insert.params[2], "hash_123");
+  assert.deepEqual(JSON.parse(insert.params[3]), { activity: "powerlifting" });
+  assert.deepEqual(JSON.parse(insert.params[4]), { phase2_hash: "phase2_hash_123" });
+  assert.deepEqual(JSON.parse(insert.params[5]), { constraints: {} });
+  assert.deepEqual(JSON.parse(insert.params[6]), { program_id: "p1" });
+  assert.deepEqual(JSON.parse(insert.params[7]), []);
+});
+
+test("persistCompiledBlockAndMaybeCreateSession creates session and initializes session_event_seq when create_session=true", async () => {
+  resetState();
+  state.mirrorInsertedBlockIdOnReturn = true;
+
+  const out = await persistCompiledBlockAndMaybeCreateSession(
+    makeArgs({ create_session: true })
+  );
+
+  assert.equal(out.persisted_block_id, state.returningBlockId);
+  assert.equal(out.created_block, true);
+  assert.equal(typeof out.session_id, "string");
+  assert.match(out.session_id, /^s_[a-f0-9]{32}$/i);
+
+  const sessionInsert = state.queries.find((x) => /INSERT INTO sessions/i.test(x.sql));
+  assert.ok(sessionInsert, "expected session insert query");
+  assert.equal(sessionInsert.params[0], out.session_id);
+  assert.equal(sessionInsert.params[2], out.persisted_block_id);
+
+  const stored = JSON.parse(sessionInsert.params[1]);
+  assert.equal(stored.session_id, out.session_id);
+  assert.deepEqual(stored.exercises, [{ exercise_id: "ex1" }]);
+
+  const seqInit = state.queries.find((x) => /INSERT INTO session_event_seq/i.test(x.sql));
+  assert.ok(seqInit, "expected session_event_seq init query");
+  assert.deepEqual(seqInit.params, [out.session_id]);
+});
+
+test("persistCompiledBlockAndMaybeCreateSession returns created_block=false when returning block_id differs from generated id", async () => {
+  resetState();
+  state.returningBlockId = "b_existing";
+
+  const out = await persistCompiledBlockAndMaybeCreateSession(makeArgs());
+
+  assert.equal(out.persisted_block_id, "b_existing");
+  assert.equal(out.created_block, false);
+  assert.equal(out.session_id, undefined);
+});
+
+test("persistCompiledBlockAndMaybeCreateSession tolerates missing session_event_seq relation", async () => {
+  resetState();
+  state.returningBlockId = "b_existing";
+  state.sessionEventSeqThrowsMissingRelation = true;
+
+  const out = await persistCompiledBlockAndMaybeCreateSession(
+    makeArgs({ create_session: true })
+  );
+
+  assert.equal(out.persisted_block_id, "b_existing");
+  assert.equal(out.created_block, false);
+  assert.equal(typeof out.session_id, "string");
+  assert.match(out.session_id, /^s_[a-f0-9]{32}$/i);
+});
+
+test("persistCompiledBlockAndMaybeCreateSession rolls back and releases client when write fails", async () => {
+  resetState();
+  state.returningBlockId = "b_existing";
+  state.failAfterBegin = /INSERT INTO blocks/i;
+
+  await assert.rejects(
+    () => persistCompiledBlockAndMaybeCreateSession(makeArgs()),
+    /forced write failure/
+  );
+
+  assert.ok(state.queries.some((x) => /BEGIN/i.test(x.sql)));
+  assert.ok(state.queries.some((x) => /ROLLBACK/i.test(x.sql)));
+  assert.equal(state.releaseCalls, 1);
+});

--- a/test/api_handlers_compile_block_persistence_delegation.test.mjs
+++ b/test/api_handlers_compile_block_persistence_delegation.test.mjs
@@ -1,0 +1,46 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+
+test("blocks.handlers source contract: compileBlock delegates transactional persistence to persistCompiledBlockAndMaybeCreateSession and preserves response shaping", () => {
+  const repo = process.cwd();
+  const file = path.join(repo, "src", "api", "blocks.handlers.ts");
+  const src = fs.readFileSync(file, "utf8");
+
+  assert.match(
+    src,
+    /import\s*\{\s*persistCompiledBlockAndMaybeCreateSession\s*\}\s*from\s*"\.\/block_compile_write_service\.js"/,
+    "expected handler to import persistCompiledBlockAndMaybeCreateSession from extracted compile write service"
+  );
+
+  assert.match(
+    src,
+    /const\s+phase2_canonical_payload\s*=\s*\{/,
+    "expected compileBlock to shape phase2_canonical_payload before delegating"
+  );
+
+  assert.match(
+    src,
+    /const\s+persisted\s*=\s*await\s+persistCompiledBlockAndMaybeCreateSession\(\s*\{[\s\S]*engine_version,[\s\S]*canonical_hash,[\s\S]*canonical_input,[\s\S]*phase2_canonical_payload,[\s\S]*phase3_output:\s*p3\.phase3,[\s\S]*phase4_program:\s*p4\.program,[\s\S]*phase5_adjustments,[\s\S]*planned_session_from_engine,[\s\S]*create_session[\s\S]*\}\s*\)/,
+    "expected compileBlock to delegate persistence inputs to persistCompiledBlockAndMaybeCreateSession(...)"
+  );
+
+  assert.match(
+    src,
+    /const\s+status\s*=\s*create_session\s*\?\s*201\s*:\s*\(persisted\.created_block\s*\?\s*201\s*:\s*200\);/,
+    "expected compileBlock to preserve status shaping from delegated persistence result"
+  );
+
+  assert.match(
+    src,
+    /block_id:\s*persisted\.persisted_block_id,/,
+    "expected compileBlock response to use persisted.persisted_block_id"
+  );
+
+  assert.match(
+    src,
+    /if\s*\(persisted\.session_id\)\s*payload\.session_id\s*=\s*persisted\.session_id;/,
+    "expected compileBlock response to preserve optional persisted.session_id"
+  );
+});

--- a/test/api_session_event_seq_init_contract.test.mjs
+++ b/test/api_session_event_seq_init_contract.test.mjs
@@ -2,13 +2,13 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import fs from "node:fs";
 
-test("API persistence contract: session_event_seq is initialized at 0 at the remaining blocks.handlers compile-session init site", () => {
-  const src = fs.readFileSync("src/api/blocks.handlers.ts", "utf8");
+test("API persistence contract: session_event_seq is initialized at 0 in block_compile_write_service for compile-session creation", () => {
+  const src = fs.readFileSync("src/api/block_compile_write_service.ts", "utf8");
 
   assert.doesNotMatch(
     src,
     /INSERT\s+INTO\s+session_event_seq[\s\S]*?VALUES\s*\(\$1,\s*1\)/g,
-    "blocks.handlers.ts must not initialize session_event_seq.next_seq to 1 (it creates a seq gap)"
+    "block_compile_write_service.ts must not initialize session_event_seq.next_seq to 1 (it creates a seq gap)"
   );
 
   const init0 = src.match(
@@ -18,6 +18,6 @@ test("API persistence contract: session_event_seq is initialized at 0 at the rem
   assert.equal(
     init0.length,
     1,
-    `blocks.handlers.ts must initialize session_event_seq.next_seq to 0 at the remaining compile-session call site (found ${init0.length})`
+    `block_compile_write_service.ts must initialize session_event_seq.next_seq to 0 at the compile-session call site (found ${init0.length})`
   );
 });

--- a/test/ci_api_block_compile_write_service_contract_wrapper.test.mjs
+++ b/test/ci_api_block_compile_write_service_contract_wrapper.test.mjs
@@ -1,0 +1,24 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import path from "node:path";
+
+test("CI wrapper: compile-block write service contract test passes with experimental module mocks", () => {
+  const repo = process.cwd();
+  const testFile = path.join(repo, "test", "api_block_compile_write_service.contract.test.mjs");
+
+  const run = spawnSync(
+    process.execPath,
+    ["--experimental-test-module-mocks", "--test", testFile],
+    {
+      cwd: repo,
+      encoding: "utf8",
+      env: process.env
+    }
+  );
+
+  if ((run.stdout ?? "").trim()) process.stdout.write(run.stdout);
+  if ((run.stderr ?? "").trim()) process.stderr.write(run.stderr);
+
+  assert.equal(run.status, 0, `expected wrapper child process to pass (exit=${run.status})`);
+});

--- a/test/ci_compile_block_persistence_delegation_contracts_cluster_manifest.test.mjs
+++ b/test/ci_compile_block_persistence_delegation_contracts_cluster_manifest.test.mjs
@@ -1,0 +1,16 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+test("test:ci composition index includes pinned compile block persistence delegation contracts cluster manifest", () => {
+  const repo = process.cwd();
+  const p = path.join(repo, "ci", "contracts", "test_ci_composition.json");
+  const src = readFileSync(p, "utf8");
+
+  assert.match(
+    src,
+    /ci\/contracts\/compile_block_persistence_delegation_contracts_ci_cluster\.json/,
+    "expected test:ci composition index to include compile block persistence delegation contracts cluster manifest"
+  );
+});

--- a/test/ci_compile_block_persistence_delegation_contracts_cluster_manifest_file.test.mjs
+++ b/test/ci_compile_block_persistence_delegation_contracts_cluster_manifest_file.test.mjs
@@ -1,0 +1,32 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+
+const NODE_TEST_CMD_RE = /^node test\/[A-Za-z0-9._/-]+\.test\.mjs$/;
+
+test("compile block persistence delegation contracts cluster manifest file is well-formed, non-empty, unique, and node-test-only", () => {
+  const repo = process.cwd();
+  const manifestPath = path.join(repo, "ci", "contracts", "compile_block_persistence_delegation_contracts_ci_cluster.json");
+  const raw = fs.readFileSync(manifestPath, "utf8");
+
+  let manifest;
+  assert.doesNotThrow(() => {
+    manifest = JSON.parse(raw);
+  }, "expected compile block persistence delegation contracts cluster manifest to be valid JSON");
+
+  assert.ok(manifest && typeof manifest === "object" && !Array.isArray(manifest), "expected manifest object");
+  assert.equal(manifest.label, "compile block persistence delegation contracts ci cluster");
+  assert.ok(Array.isArray(manifest.cluster), "expected manifest.cluster array");
+  assert.equal(manifest.cluster.length, 2, "expected exactly 2 compile block persistence delegation contract commands");
+
+  const seen = new Set();
+  for (const cmd of manifest.cluster) {
+    assert.equal(typeof cmd, "string", "expected command string");
+    assert.notEqual(cmd.trim(), "", "expected non-empty command");
+    assert.equal(cmd, cmd.trim(), "expected trimmed command");
+    assert.match(cmd, NODE_TEST_CMD_RE, "expected node test/... .test.mjs command");
+    assert.ok(!seen.has(cmd), `expected unique command: ${cmd}`);
+    seen.add(cmd);
+  }
+});

--- a/test/ci_compile_block_persistence_delegation_contracts_manifest.test.mjs
+++ b/test/ci_compile_block_persistence_delegation_contracts_manifest.test.mjs
@@ -1,0 +1,15 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { composeTestCiFromIndex } from "../ci/scripts/compose_test_ci_from_index.mjs";
+
+test("compile block persistence delegation contracts manifest remains present in composed test:ci command set", () => {
+  const repo = process.cwd();
+  const { commands } = composeTestCiFromIndex(repo);
+
+  for (const cmd of [
+    "node test/api_handlers_compile_block_persistence_delegation.test.mjs",
+    "node test/ci_api_block_compile_write_service_contract_wrapper.test.mjs"
+  ]) {
+    assert.ok(commands.includes(cmd), `expected ${cmd} in composed test:ci command set`);
+  }
+});

--- a/test/ci_compile_block_persistence_delegation_contracts_manifest_file.test.mjs
+++ b/test/ci_compile_block_persistence_delegation_contracts_manifest_file.test.mjs
@@ -1,0 +1,16 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+
+test("compile block persistence delegation contracts manifest file remains pinned to the expected contract tests", () => {
+  const repo = process.cwd();
+  const manifestPath = path.join(repo, "ci", "contracts", "compile_block_persistence_delegation_contracts_ci_cluster.json");
+  const manifest = JSON.parse(fs.readFileSync(manifestPath, "utf8"));
+
+  assert.equal(manifest.label, "compile block persistence delegation contracts ci cluster");
+  assert.deepEqual(manifest.cluster, [
+    "node test/api_handlers_compile_block_persistence_delegation.test.mjs",
+    "node test/ci_api_block_compile_write_service_contract_wrapper.test.mjs"
+  ]);
+});


### PR DESCRIPTION
## Summary
- extract compile-block transactional persistence into block_compile_write_service
- keep compileBlock responsible for phase execution and response shaping while delegating persistence through a tight plain-args seam
- move the compile-session seq-init source contract to the extracted compile write service ownership site
- add compile-block write service contract coverage, handler delegation coverage, and a dedicated CI cluster wired into the single-owner test:ci composition index

## Testing
- npm run test:one -- test/api_block_compile_write_service.contract.test.mjs
- npm run test:one -- test/ci_api_block_compile_write_service_contract_wrapper.test.mjs
- npm run test:one -- test/api_session_event_seq_init_contract.test.mjs
- npm run build:fast
- npm run lint:fast
- npm run dev:status