### PR TITLE
test(v0): prove compile block preserves persistence seam and response contract

### DIFF
--- a/ci/contracts/compile_block_persistence_delegation_contracts_ci_cluster.json
+++ b/ci/contracts/compile_block_persistence_delegation_contracts_ci_cluster.json
@@ -2,6 +2,8 @@
   "label": "compile block persistence delegation contracts ci cluster",
   "cluster": [
     "node test/api_handlers_compile_block_persistence_delegation.test.mjs",
+    "node test/api_handlers_compile_block_persistence_args_contract.test.mjs",
+    "node test/api_handlers_compile_block_response_contract.test.mjs",
     "node test/ci_api_block_compile_write_service_contract_wrapper.test.mjs"
   ]
 }

--- a/test/api_handlers_compile_block_persistence_args_contract.test.mjs
+++ b/test/api_handlers_compile_block_persistence_args_contract.test.mjs
@@ -1,0 +1,86 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+
+test("blocks.handlers source contract: compileBlock delegates the full plain-args persistence seam without engine recompute drift", () => {
+  const repo = process.cwd();
+  const file = path.join(repo, "src", "api", "blocks.handlers.ts");
+  const src = fs.readFileSync(file, "utf8");
+
+  assert.match(
+    src,
+    /const\s+phase2_canonical_payload\s*=\s*\{\s*[\s\S]*phase2_canonical_json:\s*p2\.phase2\.phase2_canonical_json,\s*[\s\S]*phase2_hash:\s*p2\.phase2\.phase2_hash,\s*[\s\S]*canonical_input_hash:\s*p2\.phase2\.canonical_input_hash[\s\S]*\}/,
+    "expected compileBlock to shape phase2_canonical_payload once before persistence delegation"
+  );
+
+  const callMatch = src.match(
+    /persistCompiledBlockAndMaybeCreateSession\(\s*\{[\s\S]*?\}\s*\)/m
+  );
+
+  assert.ok(callMatch, "expected compileBlock to call persistCompiledBlockAndMaybeCreateSession({...})");
+
+  const callSrc = callMatch[0];
+
+  assert.match(
+    callSrc,
+    /engine_version/,
+    "expected persistence seam to include engine_version"
+  );
+  assert.match(
+    callSrc,
+    /canonical_hash/,
+    "expected persistence seam to include canonical_hash"
+  );
+  assert.match(
+    callSrc,
+    /canonical_input/,
+    "expected persistence seam to include canonical_input"
+  );
+  assert.match(
+    callSrc,
+    /phase2_canonical_payload/,
+    "expected persistence seam to include phase2_canonical_payload"
+  );
+  assert.match(
+    callSrc,
+    /phase3_output:\s*p3\.phase3/,
+    "expected persistence seam to include phase3_output: p3.phase3"
+  );
+  assert.match(
+    callSrc,
+    /phase4_program:\s*p4\.program/,
+    "expected persistence seam to include phase4_program: p4.program"
+  );
+  assert.match(
+    callSrc,
+    /phase5_adjustments/,
+    "expected persistence seam to include phase5_adjustments"
+  );
+  assert.match(
+    callSrc,
+    /planned_session_from_engine/,
+    "expected persistence seam to include planned_session_from_engine"
+  );
+  assert.match(
+    callSrc,
+    /create_session/,
+    "expected persistence seam to include create_session"
+  );
+
+  assert.doesNotMatch(
+    callSrc,
+    /phase1_input/,
+    "compileBlock must not pass raw phase1_input into the persistence seam"
+  );
+  assert.doesNotMatch(
+    callSrc,
+    /runtime_state/,
+    "compileBlock must not pass runtime_state into the persistence seam"
+  );
+  assert.doesNotMatch(
+    callSrc,
+    /planned_session_applied/,
+    "compileBlock must not pass response-shaped planned_session_applied into the persistence seam"
+  );
+});

--- a/test/api_handlers_compile_block_response_contract.test.mjs
+++ b/test/api_handlers_compile_block_response_contract.test.mjs
@@ -1,0 +1,40 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+
+test("blocks.handlers source contract: compileBlock preserves delegated persistence response contract without drift", () => {
+  const repo = process.cwd();
+  const file = path.join(repo, "src", "api", "blocks.handlers.ts");
+  const src = fs.readFileSync(file, "utf8");
+
+  assert.match(
+    src,
+    /const\s+persisted\s*=\s*await\s+persistCompiledBlockAndMaybeCreateSession\(/,
+    "expected compileBlock to source its persistence result from persistCompiledBlockAndMaybeCreateSession(...)"
+  );
+
+  assert.match(
+    src,
+    /const\s+status\s*=\s*create_session\s*\?\s*201\s*:\s*\(persisted\.created_block\s*\?\s*201\s*:\s*200\);/,
+    "expected compileBlock to preserve 201\/200 response status mapping from delegated persistence result"
+  );
+
+  assert.match(
+    src,
+    /const\s+payload:\s*any\s*=\s*\{[\s\S]*block_id:\s*persisted\.persisted_block_id,[\s\S]*engine_version,[\s\S]*canonical_hash,[\s\S]*planned_session:\s*planned_session_applied,[\s\S]*runtime_trace:\s*runtime_trace_from_engine[\s\S]*\};/,
+    "expected compileBlock response payload to preserve block_id, engine_version, canonical_hash, planned_session, and runtime_trace after delegation"
+  );
+
+  assert.match(
+    src,
+    /if\s*\(persisted\.session_id\)\s*payload\.session_id\s*=\s*persisted\.session_id;/,
+    "expected compileBlock to preserve optional persisted.session_id in the response payload"
+  );
+
+  assert.match(
+    src,
+    /return\s+res\.status\(status\)\.json\(payload\);/,
+    "expected compileBlock to preserve status+json response emission after delegation"
+  );
+});

--- a/test/ci_compile_block_persistence_delegation_contracts_cluster_manifest_file.test.mjs
+++ b/test/ci_compile_block_persistence_delegation_contracts_cluster_manifest_file.test.mjs
@@ -18,7 +18,7 @@ test("compile block persistence delegation contracts cluster manifest file is we
   assert.ok(manifest && typeof manifest === "object" && !Array.isArray(manifest), "expected manifest object");
   assert.equal(manifest.label, "compile block persistence delegation contracts ci cluster");
   assert.ok(Array.isArray(manifest.cluster), "expected manifest.cluster array");
-  assert.equal(manifest.cluster.length, 2, "expected exactly 2 compile block persistence delegation contract commands");
+  assert.equal(manifest.cluster.length, 4, "expected exactly 4 compile block persistence delegation contract commands");
 
   const seen = new Set();
   for (const cmd of manifest.cluster) {

--- a/test/ci_compile_block_persistence_delegation_contracts_manifest.test.mjs
+++ b/test/ci_compile_block_persistence_delegation_contracts_manifest.test.mjs
@@ -8,6 +8,8 @@ test("compile block persistence delegation contracts manifest remains present in
 
   for (const cmd of [
     "node test/api_handlers_compile_block_persistence_delegation.test.mjs",
+    "node test/api_handlers_compile_block_persistence_args_contract.test.mjs",
+    "node test/api_handlers_compile_block_response_contract.test.mjs",
     "node test/ci_api_block_compile_write_service_contract_wrapper.test.mjs"
   ]) {
     assert.ok(commands.includes(cmd), `expected ${cmd} in composed test:ci command set`);

--- a/test/ci_compile_block_persistence_delegation_contracts_manifest_file.test.mjs
+++ b/test/ci_compile_block_persistence_delegation_contracts_manifest_file.test.mjs
@@ -11,6 +11,8 @@ test("compile block persistence delegation contracts manifest file remains pinne
   assert.equal(manifest.label, "compile block persistence delegation contracts ci cluster");
   assert.deepEqual(manifest.cluster, [
     "node test/api_handlers_compile_block_persistence_delegation.test.mjs",
+    "node test/api_handlers_compile_block_persistence_args_contract.test.mjs",
+    "node test/api_handlers_compile_block_response_contract.test.mjs",
     "node test/ci_api_block_compile_write_service_contract_wrapper.test.mjs"
   ]);
 });


### PR DESCRIPTION
## Summary
- prove compileBlock preserves the delegated persistence seam without arg drift
- prove compileBlock preserves response status and payload shaping after persistence delegation
- extend the compile-block persistence delegation CI cluster to pin the stronger source-contract coverage

## Testing
- npm run test:one -- test/api_handlers_compile_block_persistence_delegation.test.mjs
- npm run test:one -- test/api_handlers_compile_block_persistence_args_contract.test.mjs
- npm run test:one -- test/api_handlers_compile_block_response_contract.test.mjs
- npm run test:one -- test/ci_compile_block_persistence_delegation_contracts_cluster_manifest_file.test.mjs
- npm run test:one -- test/ci_compile_block_persistence_delegation_contracts_cluster_manifest.test.mjs
- npm run test:one -- test/ci_compile_block_persistence_delegation_contracts_manifest_file.test.mjs
- npm run test:one -- test/ci_compile_block_persistence_delegation_contracts_manifest.test.mjs
- npm run test:one -- test/ci_test_ci_composition_file.test.mjs
- npm run test:one -- test/ci_test_ci_composition.test.mjs
- npm run lint:fast
- npm run dev:status