### PR TITLE
test(v0): prove compile block http behaviour contracts at handler boundary

### DIFF
--- a/ci/contracts/compile_block_persistence_delegation_contracts_ci_cluster.json
+++ b/ci/contracts/compile_block_persistence_delegation_contracts_ci_cluster.json
@@ -4,6 +4,11 @@
     "node test/api_handlers_compile_block_persistence_delegation.test.mjs",
     "node test/api_handlers_compile_block_persistence_args_contract.test.mjs",
     "node test/api_handlers_compile_block_response_contract.test.mjs",
+    "node test/api_handlers_compile_block_missing_phase1_input_contract.test.mjs",
+    "node test/api_handlers_compile_block_phase_failure_mapping_contract.test.mjs",
+    "node test/api_handlers_compile_block_create_session_response_contract.test.mjs",
+    "node test/api_handlers_compile_block_runtime_event_error_contract.test.mjs",
+    "node test/api_handlers_compile_block_response_allowlist_contract.test.mjs",
     "node test/ci_api_block_compile_write_service_contract_wrapper.test.mjs"
   ]
 }

--- a/test/api_handlers_compile_block_create_session_response_contract.test.mjs
+++ b/test/api_handlers_compile_block_create_session_response_contract.test.mjs
@@ -1,0 +1,28 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+
+test("compileBlock source contract: create_session branch preserves 201 semantics and optional session_id emission", () => {
+  const repo = process.cwd();
+  const file = path.join(repo, "src", "api", "blocks.handlers.ts");
+  const src = fs.readFileSync(file, "utf8");
+
+  assert.match(
+    src,
+    /const\s+create_session\s*=\s*asBoolQuery\(\(req\.query as any\)\?\.create_session\);/,
+    "expected compileBlock to derive create_session from the querystring"
+  );
+
+  assert.match(
+    src,
+    /const\s+status\s*=\s*create_session\s*\?\s*201\s*:\s*\(persisted\.created_block\s*\?\s*201\s*:\s*200\);/,
+    "expected create_session=true to force 201 regardless of created_block"
+  );
+
+  assert.match(
+    src,
+    /if\s*\(persisted\.session_id\)\s*payload\.session_id\s*=\s*persisted\.session_id;/,
+    "expected compileBlock to emit session_id only when persistence returned one"
+  );
+});

--- a/test/api_handlers_compile_block_missing_phase1_input_contract.test.mjs
+++ b/test/api_handlers_compile_block_missing_phase1_input_contract.test.mjs
@@ -1,0 +1,22 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+
+test("compileBlock source contract: missing phase1_input fails fast with badRequest before any engine phase work", () => {
+  const repo = process.cwd();
+  const file = path.join(repo, "src", "api", "blocks.handlers.ts");
+  const src = fs.readFileSync(file, "utf8");
+
+  assert.match(
+    src,
+    /if\s*\(!Object\.prototype\.hasOwnProperty\.call\(body,\s*"phase1_input"\)\)\s*\{\s*throw badRequest\("Missing phase1_input"\);\s*\}/,
+    "expected compileBlock to reject missing phase1_input with badRequest('Missing phase1_input')"
+  );
+
+  assert.match(
+    src,
+    /throw badRequest\("Missing phase1_input"\);[\s\S]*const\s+p1\s*=\s*phase1Validate\(body\.phase1_input\);/,
+    "expected missing phase1_input guard to run before phase1Validate(body.phase1_input)"
+  );
+});

--- a/test/api_handlers_compile_block_phase_failure_mapping_contract.test.mjs
+++ b/test/api_handlers_compile_block_phase_failure_mapping_contract.test.mjs
@@ -1,0 +1,46 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+
+test("compileBlock source contract: phase failure branches preserve explicit badRequest failure-token mapping", () => {
+  const repo = process.cwd();
+  const file = path.join(repo, "src", "api", "blocks.handlers.ts");
+  const src = fs.readFileSync(file, "utf8");
+
+  assert.match(
+    src,
+    /if\s*\(!p1\.ok\)\s*\{\s*throw badRequest\("Phase 1 failed",\s*\{\s*failure_token:\s*p1\.failure_token,\s*details:\s*p1\.details\s*\}\);\s*\}/,
+    "expected Phase 1 failure branch to preserve failure_token/details mapping"
+  );
+
+  assert.match(
+    src,
+    /if\s*\(!p2\.ok\)\s*\{\s*throw badRequest\("Phase 2 failed",\s*\{\s*failure_token:\s*p2\.failure_token,\s*details:\s*p2\.details\s*\}\);\s*\}/,
+    "expected Phase 2 failure branch to preserve failure_token/details mapping"
+  );
+
+  assert.match(
+    src,
+    /if\s*\(!p3\.ok\)\s*\{\s*throw badRequest\("Phase 3 failed",\s*\{\s*failure_token:\s*p3\.failure_token,\s*details:\s*p3\.details\s*\}\);\s*\}/,
+    "expected Phase 3 failure branch to preserve failure_token/details mapping"
+  );
+
+  assert.match(
+    src,
+    /if\s*\(!p4\.ok\)\s*\{\s*throw badRequest\("Phase 4 failed",\s*\{\s*failure_token:\s*p4\.failure_token,\s*details:\s*p4\.details\s*\}\);\s*\}/,
+    "expected Phase 4 failure branch to preserve failure_token/details mapping"
+  );
+
+  assert.match(
+    src,
+    /if\s*\(!p6\.ok\)\s*\{\s*throw badRequest\("Phase 6 failed",\s*\{\s*failure_token:\s*p6\.failure_token,\s*details:\s*p6\.details\s*\}\);\s*\}/,
+    "expected Phase 6 failure branch to preserve failure_token/details mapping"
+  );
+
+  assert.match(
+    src,
+    /if\s*\(apply_phase5\)\s*\{\s*throw badRequest\("Phase 5 compile not implemented",\s*\{\s*failure_token:\s*"phase5_compile_not_implemented"\s*\}\);\s*\}/,
+    "expected apply_phase5 branch to preserve the explicit phase5_compile_not_implemented contract"
+  );
+});

--- a/test/api_handlers_compile_block_response_allowlist_contract.test.mjs
+++ b/test/api_handlers_compile_block_response_allowlist_contract.test.mjs
@@ -1,0 +1,52 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+
+test("compileBlock source contract: response allowlist stays stable after persistence delegation", () => {
+  const repo = process.cwd();
+  const file = path.join(repo, "src", "api", "blocks.handlers.ts");
+  const src = fs.readFileSync(file, "utf8");
+
+  assert.match(
+    src,
+    /const\s+payload:\s*any\s*=\s*\{[\s\S]*block_id:\s*persisted\.persisted_block_id,[\s\S]*engine_version,[\s\S]*canonical_hash,[\s\S]*planned_session:\s*planned_session_applied,[\s\S]*runtime_trace:\s*runtime_trace_from_engine[\s\S]*\};/,
+    "expected compileBlock payload allowlist to stay limited to block_id, engine_version, canonical_hash, planned_session, and runtime_trace"
+  );
+
+  assert.doesNotMatch(
+    src,
+    /const\s+payload:\s*any\s*=\s*\{[\s\S]*phase1_input[\s\S]*\};/,
+    "compileBlock response payload must not leak phase1_input"
+  );
+
+  assert.doesNotMatch(
+    src,
+    /const\s+payload:\s*any\s*=\s*\{[\s\S]*phase2_canonical_payload[\s\S]*\};/,
+    "compileBlock response payload must not leak phase2_canonical_payload"
+  );
+
+  assert.doesNotMatch(
+    src,
+    /const\s+payload:\s*any\s*=\s*\{[\s\S]*phase3_output[\s\S]*\};/,
+    "compileBlock response payload must not leak phase3_output"
+  );
+
+  assert.doesNotMatch(
+    src,
+    /const\s+payload:\s*any\s*=\s*\{[\s\S]*phase4_program[\s\S]*\};/,
+    "compileBlock response payload must not leak phase4_program"
+  );
+
+  assert.doesNotMatch(
+    src,
+    /const\s+payload:\s*any\s*=\s*\{[\s\S]*phase5_adjustments[\s\S]*\};/,
+    "compileBlock response payload must not leak phase5_adjustments"
+  );
+
+  assert.doesNotMatch(
+    src,
+    /const\s+payload:\s*any\s*=\s*\{[\s\S]*runtime_state[\s\S]*\};/,
+    "compileBlock response payload must not leak raw runtime_state"
+  );
+});

--- a/test/api_handlers_compile_block_runtime_event_error_contract.test.mjs
+++ b/test/api_handlers_compile_block_runtime_event_error_contract.test.mjs
@@ -1,0 +1,46 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+
+test("compileBlock source contract: runtime event validation and apply failures preserve explicit error contracts", () => {
+  const repo = process.cwd();
+  const file = path.join(repo, "src", "api", "blocks.handlers.ts");
+  const src = fs.readFileSync(file, "utf8");
+
+  assert.match(
+    src,
+    /if\s*\(!Array\.isArray\(raw\)\)\s*throw badRequest\("Invalid runtime_events\/events \(expected array\)"\);/,
+    "expected non-array runtime_events/events to be rejected with the explicit badRequest contract"
+  );
+
+  assert.match(
+    src,
+    /throw badRequest\("Invalid runtime_events\/events \(event failed validation\)",\s*\{\s*index:\s*i\s*\}\);/,
+    "expected invalid runtime event objects to preserve indexed badRequest validation feedback"
+  );
+
+  assert.match(
+    src,
+    /if\s*\(msg\.startsWith\("PHASE6_RUNTIME_AWAIT_RETURN_DECISION"\)\)\s*\{\s*throw badRequest\("Runtime event rejected \(await return decision\)",\s*\{[\s\S]*failure_token:\s*"phase6_runtime_await_return_decision"[\s\S]*cause:\s*msg[\s\S]*\}\);\s*\}/,
+    "expected await-return-decision engine failure to map to explicit badRequest contract"
+  );
+
+  assert.match(
+    src,
+    /if\s*\(msg\.startsWith\("PHASE6_RUNTIME_UNKNOWN_EVENT"\)\)\s*\{\s*throw badRequest\("Runtime event rejected \(unknown event type\)",\s*\{[\s\S]*failure_token:\s*"phase6_runtime_unknown_event"[\s\S]*cause:\s*msg[\s\S]*\}\);\s*\}/,
+    "expected unknown-event engine failure to map to explicit badRequest contract"
+  );
+
+  assert.match(
+    src,
+    /if\s*\(msg\.startsWith\("PHASE6_RUNTIME_INVALID_EVENT"\)\)\s*\{\s*throw badRequest\("Runtime event rejected \(invalid event shape\)",\s*\{[\s\S]*failure_token:\s*"phase6_runtime_invalid_event"[\s\S]*cause:\s*msg[\s\S]*\}\);\s*\}/,
+    "expected invalid-event engine failure to map to explicit badRequest contract"
+  );
+
+  assert.match(
+    src,
+    /throw internalError\("Runtime apply failed \(unexpected engine error\)",\s*\{\s*cause:\s*msg\s*\}\);/,
+    "expected unexpected runtime apply failures to map to internalError with cause"
+  );
+});

--- a/test/ci_compile_block_persistence_delegation_contracts_cluster_manifest_file.test.mjs
+++ b/test/ci_compile_block_persistence_delegation_contracts_cluster_manifest_file.test.mjs
@@ -18,7 +18,7 @@ test("compile block persistence delegation contracts cluster manifest file is we
   assert.ok(manifest && typeof manifest === "object" && !Array.isArray(manifest), "expected manifest object");
   assert.equal(manifest.label, "compile block persistence delegation contracts ci cluster");
   assert.ok(Array.isArray(manifest.cluster), "expected manifest.cluster array");
-  assert.equal(manifest.cluster.length, 4, "expected exactly 4 compile block persistence delegation contract commands");
+  assert.equal(manifest.cluster.length, 9, "expected exactly 9 compile block persistence delegation contract commands");
 
   const seen = new Set();
   for (const cmd of manifest.cluster) {

--- a/test/ci_compile_block_persistence_delegation_contracts_manifest.test.mjs
+++ b/test/ci_compile_block_persistence_delegation_contracts_manifest.test.mjs
@@ -10,6 +10,11 @@ test("compile block persistence delegation contracts manifest remains present in
     "node test/api_handlers_compile_block_persistence_delegation.test.mjs",
     "node test/api_handlers_compile_block_persistence_args_contract.test.mjs",
     "node test/api_handlers_compile_block_response_contract.test.mjs",
+    "node test/api_handlers_compile_block_missing_phase1_input_contract.test.mjs",
+    "node test/api_handlers_compile_block_phase_failure_mapping_contract.test.mjs",
+    "node test/api_handlers_compile_block_create_session_response_contract.test.mjs",
+    "node test/api_handlers_compile_block_runtime_event_error_contract.test.mjs",
+    "node test/api_handlers_compile_block_response_allowlist_contract.test.mjs",
     "node test/ci_api_block_compile_write_service_contract_wrapper.test.mjs"
   ]) {
     assert.ok(commands.includes(cmd), `expected ${cmd} in composed test:ci command set`);

--- a/test/ci_compile_block_persistence_delegation_contracts_manifest_file.test.mjs
+++ b/test/ci_compile_block_persistence_delegation_contracts_manifest_file.test.mjs
@@ -13,6 +13,11 @@ test("compile block persistence delegation contracts manifest file remains pinne
     "node test/api_handlers_compile_block_persistence_delegation.test.mjs",
     "node test/api_handlers_compile_block_persistence_args_contract.test.mjs",
     "node test/api_handlers_compile_block_response_contract.test.mjs",
+    "node test/api_handlers_compile_block_missing_phase1_input_contract.test.mjs",
+    "node test/api_handlers_compile_block_phase_failure_mapping_contract.test.mjs",
+    "node test/api_handlers_compile_block_create_session_response_contract.test.mjs",
+    "node test/api_handlers_compile_block_runtime_event_error_contract.test.mjs",
+    "node test/api_handlers_compile_block_response_allowlist_contract.test.mjs",
     "node test/ci_api_block_compile_write_service_contract_wrapper.test.mjs"
   ]);
 });


### PR DESCRIPTION
## Summary
- prove compileBlock preserves the missing-input, phase-failure, create-session, runtime-event, and response-allowlist contracts at the handler boundary
- extend the compile-block persistence delegation CI cluster to pin the stronger handler-behaviour contract coverage
- keep the seam locked while shifting coverage toward externally visible handler behaviour

## Testing
- npm run test:one -- test/api_handlers_compile_block_missing_phase1_input_contract.test.mjs
- npm run test:one -- test/api_handlers_compile_block_phase_failure_mapping_contract.test.mjs
- npm run test:one -- test/api_handlers_compile_block_create_session_response_contract.test.mjs
- npm run test:one -- test/api_handlers_compile_block_runtime_event_error_contract.test.mjs
- npm run test:one -- test/api_handlers_compile_block_response_allowlist_contract.test.mjs
- npm run test:one -- test/api_handlers_compile_block_persistence_delegation.test.mjs
- npm run test:one -- test/api_handlers_compile_block_persistence_args_contract.test.mjs
- npm run test:one -- test/api_handlers_compile_block_response_contract.test.mjs
- npm run test:one -- test/ci_compile_block_persistence_delegation_contracts_cluster_manifest_file.test.mjs
- npm run test:one -- test/ci_compile_block_persistence_delegation_contracts_manifest_file.test.mjs
- npm run test:one -- test/ci_compile_block_persistence_delegation_contracts_manifest.test.mjs
- npm run test:one -- test/ci_test_ci_composition_file.test.mjs
- npm run test:one -- test/ci_test_ci_composition.test.mjs
- npm run lint:fast
- npm run dev:status