### PR TITLE
test(v0): prove compile block executed handler paths without engine drift

### DIFF
--- a/ci/contracts/compile_block_persistence_delegation_contracts_ci_cluster.json
+++ b/ci/contracts/compile_block_persistence_delegation_contracts_ci_cluster.json
@@ -9,6 +9,7 @@
     "node test/api_handlers_compile_block_create_session_response_contract.test.mjs",
     "node test/api_handlers_compile_block_runtime_event_error_contract.test.mjs",
     "node test/api_handlers_compile_block_response_allowlist_contract.test.mjs",
+    "node test/ci_api_compile_block_executed_handler_http_contract_wrapper.test.mjs",
     "node test/ci_api_block_compile_write_service_contract_wrapper.test.mjs"
   ]
 }

--- a/test/api_compile_block_executed_handler_http_contract.test.mjs
+++ b/test/api_compile_block_executed_handler_http_contract.test.mjs
@@ -1,0 +1,320 @@
+import test, { mock } from "node:test";
+import assert from "node:assert/strict";
+
+const distHttpErrorsUrl = new URL("../dist/src/api/http_errors.js", import.meta.url).href;
+const distCanonicalHashUrl = new URL("../dist/src/api/canonical_hash.js", import.meta.url).href;
+const distCompileWriteUrl = new URL("../dist/src/api/block_compile_write_service.js", import.meta.url).href;
+const distBlockSessionWriteUrl = new URL("../dist/src/api/block_session_write_service.js", import.meta.url).href;
+const distBlockSessionQueryUrl = new URL("../dist/src/api/block_session_query_service.js", import.meta.url).href;
+const distDbPoolUrl = new URL("../dist/src/db/pool.js", import.meta.url).href;
+const distHandlerUrl = new URL("../dist/src/api/blocks.handlers.js", import.meta.url).href;
+
+const PHASE1_SPEC = "@kolosseum/engine/phases/phase1.js";
+const PHASE2_SPEC = "@kolosseum/engine/phases/phase2.js";
+const PHASE3_SPEC = "@kolosseum/engine/phases/phase3.js";
+const PHASE4_SPEC = "@kolosseum/engine/phases/phase4.js";
+const PHASE6_SPEC = "@kolosseum/engine/phases/phase6.js";
+const SESSION_SUMMARY_SPEC = "@kolosseum/engine/runtime/session_summary.js";
+const APPLY_RUNTIME_EVENT_SPEC = "@kolosseum/engine/runtime/apply_runtime_event.js";
+
+function makeReq({ body = undefined, query = {}, headers = {} } = {}) {
+  return {
+    body,
+    query,
+    get(name) {
+      const key = String(name).toLowerCase();
+      return headers[key];
+    }
+  };
+}
+
+function makeRes() {
+  return {
+    statusCode: 200,
+    jsonBody: undefined,
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload) {
+      this.jsonBody = payload;
+      return this;
+    }
+  };
+}
+
+function installCommonMocks({
+  persistedResult,
+  phase1Result,
+  runtimeState,
+  runtimeApplyErrorMessage
+} = {}) {
+  mock.module(distHttpErrorsUrl, {
+    namedExports: {
+      badRequest(message, extras = undefined) {
+        const err = new Error(message);
+        err.status = 400;
+        err.extras = extras;
+        return err;
+      },
+      notFound(message, extras = undefined) {
+        const err = new Error(message);
+        err.status = 404;
+        err.extras = extras;
+        return err;
+      },
+      internalError(message, extras = undefined) {
+        const err = new Error(message);
+        err.status = 500;
+        err.extras = extras;
+        return err;
+      }
+    }
+  });
+
+  mock.module(distCanonicalHashUrl, {
+    namedExports: {
+      selectCanonicalHash() {
+        return { canonical_hash: "canon_hash_selected" };
+      }
+    }
+  });
+
+  mock.module(PHASE1_SPEC, {
+    namedExports: {
+      phase1Validate() {
+        return phase1Result ?? {
+          ok: true,
+          canonical_input: {
+            activity: "powerlifting",
+            constraints: { timebox_minutes: 60 }
+          }
+        };
+      }
+    }
+  });
+
+  mock.module(PHASE2_SPEC, {
+    namedExports: {
+      phase2CanonicaliseAndHash(canonical_input) {
+        return {
+          ok: true,
+          phase2: {
+            phase2_canonical_json: JSON.stringify(canonical_input),
+            phase2_hash: "phase2_hash_123",
+            canonical_input_hash: "canonical_input_hash_123"
+          }
+        };
+      }
+    }
+  });
+
+  mock.module(PHASE3_SPEC, {
+    namedExports: {
+      phase3ResolveConstraintsAndLoadRegistries() {
+        return {
+          ok: true,
+          phase3: {
+            constraints: { timebox_minutes: 60 }
+          }
+        };
+      }
+    }
+  });
+
+  mock.module(PHASE4_SPEC, {
+    namedExports: {
+      phase4AssembleProgram() {
+        return {
+          ok: true,
+          program: { program_id: "program_powerlifting_v1" }
+        };
+      }
+    }
+  });
+
+  mock.module(PHASE6_SPEC, {
+    namedExports: {
+      phase6ProduceSessionOutput() {
+        return {
+          ok: true,
+          session: {
+            exercises: [
+              { exercise_id: "ex_a", sets: 3 },
+              { exercise_id: "ex_b", sets: 2 }
+            ]
+          }
+        };
+      }
+    }
+  });
+
+  mock.module(SESSION_SUMMARY_SPEC, {
+    namedExports: {
+      validateWireRuntimeEvent(event) {
+        return event;
+      }
+    }
+  });
+
+  mock.module(APPLY_RUNTIME_EVENT_SPEC, {
+    namedExports: {
+      applyRuntimeEvents() {
+        if (runtimeApplyErrorMessage) {
+          throw new Error(runtimeApplyErrorMessage);
+        }
+
+        return runtimeState ?? {
+          remaining_ids: ["ex_b"],
+          completed_ids: new Set(["ex_a"]),
+          dropped_ids: new Set(),
+          return_decision_required: false,
+          return_decision_options: [],
+          runtime_trace: {
+            remaining_ids: ["ex_b"],
+            completed_ids: ["ex_a"],
+            dropped_ids: [],
+            return_decision_required: false,
+            return_decision_options: []
+          }
+        };
+      }
+    }
+  });
+
+  mock.module(distCompileWriteUrl, {
+    namedExports: {
+      async persistCompiledBlockAndMaybeCreateSession() {
+        return persistedResult ?? {
+          persisted_block_id: "b_123",
+          created_block: true
+        };
+      }
+    }
+  });
+
+  mock.module(distBlockSessionWriteUrl, {
+    namedExports: {
+      async createSessionFromBlockMutation() {
+        throw new Error("not used in this test");
+      }
+    }
+  });
+
+  mock.module(distBlockSessionQueryUrl, {
+    namedExports: {
+      async listBlockSessionsQuery() {
+        throw new Error("not used in this test");
+      }
+    }
+  });
+
+  mock.module(distDbPoolUrl, {
+    namedExports: {
+      pool: {}
+    }
+  });
+}
+
+test("compileBlock executed path: returns 201 with block payload when persistence creates block", async () => {
+  mock.reset();
+  installCommonMocks();
+
+  const { compileBlock } = await import(`${distHandlerUrl}?case=created`);
+  const req = makeReq({
+    body: {
+      phase1_input: { activity: "powerlifting" }
+    }
+  });
+  const res = makeRes();
+
+  await compileBlock(req, res);
+
+  assert.equal(res.statusCode, 201);
+  assert.deepEqual(res.jsonBody, {
+    block_id: "b_123",
+    engine_version: "EB2-1.0.0",
+    canonical_hash: "canon_hash_selected",
+    planned_session: {
+      exercises: [
+        { exercise_id: "ex_a", sets: 3, status: "completed" },
+        { exercise_id: "ex_b", sets: 2, status: "pending" }
+      ]
+    },
+    runtime_trace: {
+      remaining_ids: ["ex_b"],
+      completed_ids: ["ex_a"],
+      dropped_ids: [],
+      return_decision_required: false,
+      return_decision_options: []
+    }
+  });
+});
+
+test("compileBlock executed path: returns 201 and session_id when create_session=true", async () => {
+  mock.reset();
+  installCommonMocks({
+    persistedResult: {
+      persisted_block_id: "b_existing",
+      created_block: false,
+      session_id: "s_123"
+    }
+  });
+
+  const { compileBlock } = await import(`${distHandlerUrl}?case=create_session`);
+  const req = makeReq({
+    body: {
+      phase1_input: { activity: "powerlifting" }
+    },
+    query: {
+      create_session: "true"
+    }
+  });
+  const res = makeRes();
+
+  await compileBlock(req, res);
+
+  assert.equal(res.statusCode, 201);
+  assert.equal(res.jsonBody.block_id, "b_existing");
+  assert.equal(res.jsonBody.session_id, "s_123");
+});
+
+test("compileBlock executed path: missing phase1_input throws 400 badRequest", async () => {
+  mock.reset();
+  installCommonMocks();
+
+  const { compileBlock } = await import(`${distHandlerUrl}?case=missing_phase1`);
+  const req = makeReq({
+    body: {}
+  });
+  const res = makeRes();
+
+  await assert.rejects(
+    () => compileBlock(req, res),
+    (err) => err?.status === 400 && err?.message === "Missing phase1_input"
+  );
+});
+
+test("compileBlock executed path: runtime await-return-decision failure maps to explicit 400 token", async () => {
+  mock.reset();
+  installCommonMocks({
+    runtimeApplyErrorMessage: "PHASE6_RUNTIME_AWAIT_RETURN_DECISION: blocked"
+  });
+
+  const { compileBlock } = await import(`${distHandlerUrl}?case=runtime_await_return`);
+  const req = makeReq({
+    body: {
+      phase1_input: { activity: "powerlifting" },
+      runtime_events: [{ type: "RETURN_CONTINUE" }]
+    }
+  });
+  const res = makeRes();
+
+  await assert.rejects(
+    () => compileBlock(req, res),
+    (err) =>
+      err?.status === 400 &&
+      err?.message === "Runtime event rejected (await return decision)" &&
+      err?.extras?.failure_token === "phase6_runtime_await_return_decision"
+  );
+});

--- a/test/ci_api_compile_block_executed_handler_http_contract_wrapper.test.mjs
+++ b/test/ci_api_compile_block_executed_handler_http_contract_wrapper.test.mjs
@@ -1,0 +1,29 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import path from "node:path";
+
+test("CI wrapper: compileBlock executed handler http contract test passes with experimental module mocks", () => {
+  const repo = process.cwd();
+  const target = path.join(repo, "test", "api_compile_block_executed_handler_http_contract.test.mjs");
+
+  const out = spawnSync(
+    process.execPath,
+    [
+      "--experimental-test-module-mocks",
+      "--test",
+      target
+    ],
+    {
+      cwd: repo,
+      encoding: "utf8"
+    }
+  );
+
+  if (out.status !== 0) {
+    console.error(out.stdout);
+    console.error(out.stderr);
+  }
+
+  assert.equal(out.status, 0);
+});

--- a/test/ci_compile_block_persistence_delegation_contracts_cluster_manifest_file.test.mjs
+++ b/test/ci_compile_block_persistence_delegation_contracts_cluster_manifest_file.test.mjs
@@ -13,19 +13,17 @@ test("compile block persistence delegation contracts cluster manifest file is we
   let manifest;
   assert.doesNotThrow(() => {
     manifest = JSON.parse(raw);
-  }, "expected compile block persistence delegation contracts cluster manifest to be valid JSON");
+  });
 
-  assert.ok(manifest && typeof manifest === "object" && !Array.isArray(manifest), "expected manifest object");
   assert.equal(manifest.label, "compile block persistence delegation contracts ci cluster");
-  assert.ok(Array.isArray(manifest.cluster), "expected manifest.cluster array");
-  assert.equal(manifest.cluster.length, 9, "expected exactly 9 compile block persistence delegation contract commands");
+  assert.ok(Array.isArray(manifest.cluster));
+  assert.equal(manifest.cluster.length, 10);
 
   const seen = new Set();
   for (const cmd of manifest.cluster) {
-    assert.equal(typeof cmd, "string", "expected command string");
-    assert.notEqual(cmd.trim(), "", "expected non-empty command");
-    assert.equal(cmd, cmd.trim(), "expected trimmed command");
-    assert.match(cmd, NODE_TEST_CMD_RE, "expected node test/... .test.mjs command");
+    assert.equal(typeof cmd, "string");
+    assert.equal(cmd, cmd.trim());
+    assert.match(cmd, NODE_TEST_CMD_RE);
     assert.ok(!seen.has(cmd), `expected unique command: ${cmd}`);
     seen.add(cmd);
   }

--- a/test/ci_compile_block_persistence_delegation_contracts_manifest.test.mjs
+++ b/test/ci_compile_block_persistence_delegation_contracts_manifest.test.mjs
@@ -15,6 +15,7 @@ test("compile block persistence delegation contracts manifest remains present in
     "node test/api_handlers_compile_block_create_session_response_contract.test.mjs",
     "node test/api_handlers_compile_block_runtime_event_error_contract.test.mjs",
     "node test/api_handlers_compile_block_response_allowlist_contract.test.mjs",
+    "node test/ci_api_compile_block_executed_handler_http_contract_wrapper.test.mjs",
     "node test/ci_api_block_compile_write_service_contract_wrapper.test.mjs"
   ]) {
     assert.ok(commands.includes(cmd), `expected ${cmd} in composed test:ci command set`);

--- a/test/ci_compile_block_persistence_delegation_contracts_manifest_file.test.mjs
+++ b/test/ci_compile_block_persistence_delegation_contracts_manifest_file.test.mjs
@@ -18,6 +18,7 @@ test("compile block persistence delegation contracts manifest file remains pinne
     "node test/api_handlers_compile_block_create_session_response_contract.test.mjs",
     "node test/api_handlers_compile_block_runtime_event_error_contract.test.mjs",
     "node test/api_handlers_compile_block_response_allowlist_contract.test.mjs",
+    "node test/ci_api_compile_block_executed_handler_http_contract_wrapper.test.mjs",
     "node test/ci_api_block_compile_write_service_contract_wrapper.test.mjs"
   ]);
 });


### PR DESCRIPTION
## Summary
- add executed-path HTTP contract coverage for compileBlock using module-mocked engine/runtime seams
- prove compileBlock returns the expected 201 payloads, missing phase1_input failure, and await-return-decision runtime failure mapping without engine drift
- wire the executed-handler wrapper into the compile-block persistence delegation contracts cluster and pin the manifest shape

## Testing
- node --experimental-test-module-mocks --test test/api_compile_block_executed_handler_http_contract.test.mjs
- npm run test:one -- test/ci_api_compile_block_executed_handler_http_contract_wrapper.test.mjs
- npm run test:one -- test/ci_compile_block_persistence_delegation_contracts_cluster_manifest_file.test.mjs
- npm run test:one -- test/ci_compile_block_persistence_delegation_contracts_manifest_file.test.mjs
- npm run test:one -- test/ci_compile_block_persistence_delegation_contracts_manifest.test.mjs
- npm run lint:fast