### PR TITLE
test(v0): prove createSessionFromBlock executed handler paths without engine drift

### DIFF
--- a/ci/contracts/block_handler_delegation_contracts_ci_cluster.json
+++ b/ci/contracts/block_handler_delegation_contracts_ci_cluster.json
@@ -2,6 +2,7 @@
   "label": "block handler delegation contracts ci cluster",
   "cluster": [
     "node test/api_handlers_create_session_from_block_delegation.test.mjs",
-    "node test/api_handlers_list_block_sessions_delegation.test.mjs"
+    "node test/api_handlers_list_block_sessions_delegation.test.mjs",
+    "node test/ci_api_create_session_from_block_executed_handler_http_contract_wrapper.test.mjs"
   ]
 }

--- a/test/api_create_session_from_block_executed_handler_http_contract.test.mjs
+++ b/test/api_create_session_from_block_executed_handler_http_contract.test.mjs
@@ -1,0 +1,218 @@
+import test, { mock } from "node:test";
+import assert from "node:assert/strict";
+
+const distHttpErrorsUrl = new URL("../dist/src/api/http_errors.js", import.meta.url).href;
+const distBlockSessionWriteUrl = new URL("../dist/src/api/block_session_write_service.js", import.meta.url).href;
+const distCompileWriteUrl = new URL("../dist/src/api/block_compile_write_service.js", import.meta.url).href;
+const distBlockSessionQueryUrl = new URL("../dist/src/api/block_session_query_service.js", import.meta.url).href;
+const distDbPoolUrl = new URL("../dist/src/db/pool.js", import.meta.url).href;
+const distHandlerUrl = new URL("../dist/src/api/blocks.handlers.js", import.meta.url).href;
+
+function makeReq({ body = undefined, params = {}, query = {}, headers = {} } = {}) {
+  return {
+    body,
+    params,
+    query,
+    get(name) {
+      const key = String(name).toLowerCase();
+      return headers[key];
+    }
+  };
+}
+
+function makeRes() {
+  return {
+    statusCode: 200,
+    jsonBody: undefined,
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload) {
+      this.jsonBody = payload;
+      return this;
+    }
+  };
+}
+
+function installCommonMocks({ mutationResult, mutationError } = {}) {
+  mock.module(distHttpErrorsUrl, {
+    namedExports: {
+      badRequest(message, extras = undefined) {
+        const err = new Error(message);
+        err.status = 400;
+        err.extras = extras;
+        return err;
+      },
+      notFound(message, extras = undefined) {
+        const err = new Error(message);
+        err.status = 404;
+        err.extras = extras;
+        return err;
+      },
+      internalError(message, extras = undefined) {
+        const err = new Error(message);
+        err.status = 500;
+        err.extras = extras;
+        return err;
+      }
+    }
+  });
+
+  mock.module(distBlockSessionWriteUrl, {
+    namedExports: {
+      async createSessionFromBlockMutation(blockId, plannedSession) {
+        if (mutationError) {
+          throw mutationError;
+        }
+
+        return mutationResult ?? {
+          session_id: "s_123",
+          block_id: blockId,
+          planned_session: plannedSession
+        };
+      }
+    }
+  });
+
+  mock.module(distCompileWriteUrl, {
+    namedExports: {
+      async persistCompiledBlockAndMaybeCreateSession() {
+        throw new Error("not used in this test");
+      }
+    }
+  });
+
+  mock.module(distBlockSessionQueryUrl, {
+    namedExports: {
+      async listBlockSessionsQuery() {
+        throw new Error("not used in this test");
+      }
+    }
+  });
+
+  mock.module(distDbPoolUrl, {
+    namedExports: {
+      pool: {}
+    }
+  });
+}
+
+test("createSessionFromBlock executed path: returns 201 with delegated JSON payload when mutation succeeds", async () => {
+  mock.reset();
+  installCommonMocks({
+    mutationResult: {
+      session_id: "s_123",
+      block_id: "b_123",
+      planned_session: {
+        exercises: [
+          { exercise_id: "ex_a", sets: 3, status: "pending" }
+        ]
+      }
+    }
+  });
+
+  const { createSessionFromBlock } = await import(`${distHandlerUrl}?case=created`);
+  const req = makeReq({
+    params: {
+      block_id: "b_123"
+    },
+    body: {
+      planned_session: {
+        exercises: [
+          { exercise_id: "ex_a", sets: 3, status: "pending" }
+        ]
+      }
+    }
+  });
+  const res = makeRes();
+
+  await createSessionFromBlock(req, res);
+
+  assert.equal(res.statusCode, 201);
+  assert.deepEqual(res.jsonBody, {
+    session_id: "s_123",
+    block_id: "b_123",
+    planned_session: {
+      exercises: [
+        { exercise_id: "ex_a", sets: 3, status: "pending" }
+      ]
+    }
+  });
+});
+
+test("createSessionFromBlock executed path: missing block_id throws 400 badRequest", async () => {
+  mock.reset();
+  installCommonMocks();
+
+  const { createSessionFromBlock } = await import(`${distHandlerUrl}?case=missing_block_id`);
+  const req = makeReq({
+    body: {
+      planned_session: {
+        exercises: [
+          { exercise_id: "ex_a", sets: 3, status: "pending" }
+        ]
+      }
+    }
+  });
+  const res = makeRes();
+
+  await assert.rejects(
+    () => createSessionFromBlock(req, res),
+    (err) => err?.status === 400 && err?.message === "Missing block_id"
+  );
+});
+
+test("createSessionFromBlock executed path: missing planned_session throws 400 badRequest", async () => {
+  mock.reset();
+  installCommonMocks();
+
+  const { createSessionFromBlock } = await import(`${distHandlerUrl}?case=missing_planned_session`);
+  const req = makeReq({
+    params: {
+      block_id: "b_123"
+    },
+    body: {}
+  });
+  const res = makeRes();
+
+  await assert.rejects(
+    () => createSessionFromBlock(req, res),
+    (err) => err?.status === 400 && err?.message === "Missing planned_session"
+  );
+});
+
+test("createSessionFromBlock executed path: delegated mutation error preserves explicit error contract", async () => {
+  mock.reset();
+  installCommonMocks({
+    mutationError: Object.assign(new Error("Block not found"), {
+      status: 404,
+      extras: {
+        failure_token: "block_not_found"
+      }
+    })
+  });
+
+  const { createSessionFromBlock } = await import(`${distHandlerUrl}?case=delegated_not_found`);
+  const req = makeReq({
+    params: {
+      block_id: "b_missing"
+    },
+    body: {
+      planned_session: {
+        exercises: [
+          { exercise_id: "ex_a", sets: 3, status: "pending" }
+        ]
+      }
+    }
+  });
+  const res = makeRes();
+
+  await assert.rejects(
+    () => createSessionFromBlock(req, res),
+    (err) =>
+      err?.status === 404 &&
+      err?.message === "Block not found" &&
+      err?.extras?.failure_token === "block_not_found"
+  );
+});

--- a/test/ci_api_create_session_from_block_executed_handler_http_contract_wrapper.test.mjs
+++ b/test/ci_api_create_session_from_block_executed_handler_http_contract_wrapper.test.mjs
@@ -1,0 +1,29 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import path from "node:path";
+
+test("CI wrapper: createSessionFromBlock executed handler http contract test passes with experimental module mocks", () => {
+  const repo = process.cwd();
+  const target = path.join(repo, "test", "api_create_session_from_block_executed_handler_http_contract.test.mjs");
+
+  const out = spawnSync(
+    process.execPath,
+    [
+      "--experimental-test-module-mocks",
+      "--test",
+      target
+    ],
+    {
+      cwd: repo,
+      encoding: "utf8"
+    }
+  );
+
+  if (out.status !== 0) {
+    console.error(out.stdout);
+    console.error(out.stderr);
+  }
+
+  assert.equal(out.status, 0);
+});

--- a/test/ci_block_handler_delegation_contracts_cluster_manifest_file.test.mjs
+++ b/test/ci_block_handler_delegation_contracts_cluster_manifest_file.test.mjs
@@ -13,19 +13,17 @@ test("block handler delegation contracts cluster manifest file is well-formed, n
   let manifest;
   assert.doesNotThrow(() => {
     manifest = JSON.parse(raw);
-  }, "expected block handler delegation contracts cluster manifest to be valid JSON");
+  });
 
-  assert.ok(manifest && typeof manifest === "object" && !Array.isArray(manifest), "expected manifest object");
   assert.equal(manifest.label, "block handler delegation contracts ci cluster");
-  assert.ok(Array.isArray(manifest.cluster), "expected manifest.cluster array");
-  assert.equal(manifest.cluster.length, 2, "expected exactly 2 block handler delegation contract commands");
+  assert.ok(Array.isArray(manifest.cluster));
+  assert.equal(manifest.cluster.length, 3);
 
   const seen = new Set();
   for (const cmd of manifest.cluster) {
-    assert.equal(typeof cmd, "string", "expected command string");
-    assert.notEqual(cmd.trim(), "", "expected non-empty command");
-    assert.equal(cmd, cmd.trim(), "expected trimmed command");
-    assert.match(cmd, NODE_TEST_CMD_RE, "expected node test/... .test.mjs command");
+    assert.equal(typeof cmd, "string");
+    assert.equal(cmd, cmd.trim());
+    assert.match(cmd, NODE_TEST_CMD_RE);
     assert.ok(!seen.has(cmd), `expected unique command: ${cmd}`);
     seen.add(cmd);
   }

--- a/test/ci_block_handler_delegation_contracts_manifest.test.mjs
+++ b/test/ci_block_handler_delegation_contracts_manifest.test.mjs
@@ -8,7 +8,8 @@ test("block handler delegation contracts manifest remains present in composed te
 
   for (const cmd of [
     "node test/api_handlers_create_session_from_block_delegation.test.mjs",
-    "node test/api_handlers_list_block_sessions_delegation.test.mjs"
+    "node test/api_handlers_list_block_sessions_delegation.test.mjs",
+    "node test/ci_api_create_session_from_block_executed_handler_http_contract_wrapper.test.mjs"
   ]) {
     assert.ok(commands.includes(cmd), `expected ${cmd} in composed test:ci command set`);
   }

--- a/test/ci_block_handler_delegation_contracts_manifest_file.test.mjs
+++ b/test/ci_block_handler_delegation_contracts_manifest_file.test.mjs
@@ -11,6 +11,7 @@ test("block handler delegation contracts manifest file remains pinned to the exp
   assert.equal(manifest.label, "block handler delegation contracts ci cluster");
   assert.deepEqual(manifest.cluster, [
     "node test/api_handlers_create_session_from_block_delegation.test.mjs",
-    "node test/api_handlers_list_block_sessions_delegation.test.mjs"
+    "node test/api_handlers_list_block_sessions_delegation.test.mjs",
+    "node test/ci_api_create_session_from_block_executed_handler_http_contract_wrapper.test.mjs"
   ]);
 });


### PR DESCRIPTION
## Summary
- add executed-path HTTP contract coverage for createSessionFromBlock using module-mocked service seams
- prove createSessionFromBlock returns the expected 201 payload, missing block_id and planned_session failures, and delegated mutation error mapping without drift
- wire the executed-handler wrapper into the block-handler delegation contracts cluster and pin the manifest shape

## Testing
- node --experimental-test-module-mocks --test test/api_create_session_from_block_executed_handler_http_contract.test.mjs
- npm run test:one -- test/ci_api_create_session_from_block_executed_handler_http_contract_wrapper.test.mjs
- npm run test:one -- test/ci_block_handler_delegation_contracts_cluster_manifest_file.test.mjs
- npm run test:one -- test/ci_block_handler_delegation_contracts_manifest_file.test.mjs
- npm run test:one -- test/ci_block_handler_delegation_contracts_manifest.test.mjs
- npm run lint:fast