### PR TITLE
test(v0): prove listBlockSessions executed handler paths without drift

### DIFF
--- a/ci/contracts/block_handler_delegation_contracts_ci_cluster.json
+++ b/ci/contracts/block_handler_delegation_contracts_ci_cluster.json
@@ -3,6 +3,7 @@
   "cluster": [
     "node test/api_handlers_create_session_from_block_delegation.test.mjs",
     "node test/api_handlers_list_block_sessions_delegation.test.mjs",
-    "node test/ci_api_create_session_from_block_executed_handler_http_contract_wrapper.test.mjs"
+    "node test/ci_api_create_session_from_block_executed_handler_http_contract_wrapper.test.mjs",
+    "node test/ci_api_list_block_sessions_executed_handler_http_contract_wrapper.test.mjs"
   ]
 }

--- a/test/api_list_block_sessions_executed_handler_http_contract.test.mjs
+++ b/test/api_list_block_sessions_executed_handler_http_contract.test.mjs
@@ -1,0 +1,175 @@
+import test, { mock } from "node:test";
+import assert from "node:assert/strict";
+
+const distHttpErrorsUrl = new URL("../dist/src/api/http_errors.js", import.meta.url).href;
+const distBlockSessionQueryUrl = new URL("../dist/src/api/block_session_query_service.js", import.meta.url).href;
+const distBlockSessionWriteUrl = new URL("../dist/src/api/block_session_write_service.js", import.meta.url).href;
+const distCompileWriteUrl = new URL("../dist/src/api/block_compile_write_service.js", import.meta.url).href;
+const distDbPoolUrl = new URL("../dist/src/db/pool.js", import.meta.url).href;
+const distHandlerUrl = new URL("../dist/src/api/blocks.handlers.js", import.meta.url).href;
+
+function makeReq({ body = undefined, params = {}, query = {}, headers = {} } = {}) {
+  return {
+    body,
+    params,
+    query,
+    get(name) {
+      const key = String(name).toLowerCase();
+      return headers[key];
+    }
+  };
+}
+
+function makeRes() {
+  return {
+    statusCode: 200,
+    jsonBody: undefined,
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload) {
+      this.jsonBody = payload;
+      return this;
+    }
+  };
+}
+
+function installCommonMocks({ queryResult, queryError } = {}) {
+  mock.module(distHttpErrorsUrl, {
+    namedExports: {
+      badRequest(message, extras = undefined) {
+        const err = new Error(message);
+        err.status = 400;
+        err.extras = extras;
+        return err;
+      },
+      notFound(message, extras = undefined) {
+        const err = new Error(message);
+        err.status = 404;
+        err.extras = extras;
+        return err;
+      },
+      internalError(message, extras = undefined) {
+        const err = new Error(message);
+        err.status = 500;
+        err.extras = extras;
+        return err;
+      }
+    }
+  });
+
+  mock.module(distBlockSessionQueryUrl, {
+    namedExports: {
+      async listBlockSessionsQuery(blockId) {
+        if (queryError) {
+          throw queryError;
+        }
+
+        return queryResult ?? {
+          block_id: blockId,
+          sessions: [
+            { session_id: "s_001", status: "active" },
+            { session_id: "s_002", status: "completed" }
+          ]
+        };
+      }
+    }
+  });
+
+  mock.module(distBlockSessionWriteUrl, {
+    namedExports: {
+      async createSessionFromBlockMutation() {
+        throw new Error("not used in this test");
+      }
+    }
+  });
+
+  mock.module(distCompileWriteUrl, {
+    namedExports: {
+      async persistCompiledBlockAndMaybeCreateSession() {
+        throw new Error("not used in this test");
+      }
+    }
+  });
+
+  mock.module(distDbPoolUrl, {
+    namedExports: {
+      pool: {}
+    }
+  });
+}
+
+test("listBlockSessions executed path: returns 200 with delegated JSON payload when query succeeds", async () => {
+  mock.reset();
+  installCommonMocks({
+    queryResult: {
+      block_id: "b_123",
+      sessions: [
+        { session_id: "s_001", status: "active" },
+        { session_id: "s_002", status: "completed" }
+      ]
+    }
+  });
+
+  const { listBlockSessions } = await import(`${distHandlerUrl}?case=ok`);
+  const req = makeReq({
+    params: {
+      block_id: "b_123"
+    }
+  });
+  const res = makeRes();
+
+  await listBlockSessions(req, res);
+
+  assert.equal(res.statusCode, 200);
+  assert.deepEqual(res.jsonBody, {
+    block_id: "b_123",
+    sessions: [
+      { session_id: "s_001", status: "active" },
+      { session_id: "s_002", status: "completed" }
+    ]
+  });
+});
+
+test("listBlockSessions executed path: missing block_id throws 400 badRequest", async () => {
+  mock.reset();
+  installCommonMocks();
+
+  const { listBlockSessions } = await import(`${distHandlerUrl}?case=missing_block_id`);
+  const req = makeReq();
+  const res = makeRes();
+
+  await assert.rejects(
+    () => listBlockSessions(req, res),
+    (err) => err?.status === 400 && err?.message === "Missing block_id"
+  );
+});
+
+test("listBlockSessions executed path: delegated not-found error preserves explicit error contract", async () => {
+  mock.reset();
+  installCommonMocks({
+    queryError: Object.assign(new Error("Block not found"), {
+      status: 404,
+      extras: {
+        failure_token: "block_not_found"
+      }
+    })
+  });
+
+  const { listBlockSessions } = await import(`${distHandlerUrl}?case=not_found`);
+  const req = makeReq({
+    params: {
+      block_id: "b_missing"
+    }
+  });
+  const res = makeRes();
+
+  await assert.rejects(
+    () => listBlockSessions(req, res),
+    (err) =>
+      err?.status === 404 &&
+      err?.message === "Block not found" &&
+      err?.extras?.failure_token === "block_not_found"
+  );
+});

--- a/test/ci_api_list_block_sessions_executed_handler_http_contract_wrapper.test.mjs
+++ b/test/ci_api_list_block_sessions_executed_handler_http_contract_wrapper.test.mjs
@@ -1,0 +1,29 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import path from "node:path";
+
+test("CI wrapper: listBlockSessions executed handler http contract test passes with experimental module mocks", () => {
+  const repo = process.cwd();
+  const target = path.join(repo, "test", "api_list_block_sessions_executed_handler_http_contract.test.mjs");
+
+  const out = spawnSync(
+    process.execPath,
+    [
+      "--experimental-test-module-mocks",
+      "--test",
+      target
+    ],
+    {
+      cwd: repo,
+      encoding: "utf8"
+    }
+  );
+
+  if (out.status !== 0) {
+    console.error(out.stdout);
+    console.error(out.stderr);
+  }
+
+  assert.equal(out.status, 0);
+});

--- a/test/ci_block_handler_delegation_contracts_cluster_manifest_file.test.mjs
+++ b/test/ci_block_handler_delegation_contracts_cluster_manifest_file.test.mjs
@@ -17,7 +17,7 @@ test("block handler delegation contracts cluster manifest file is well-formed, n
 
   assert.equal(manifest.label, "block handler delegation contracts ci cluster");
   assert.ok(Array.isArray(manifest.cluster));
-  assert.equal(manifest.cluster.length, 3);
+  assert.equal(manifest.cluster.length, 4);
 
   const seen = new Set();
   for (const cmd of manifest.cluster) {

--- a/test/ci_block_handler_delegation_contracts_manifest.test.mjs
+++ b/test/ci_block_handler_delegation_contracts_manifest.test.mjs
@@ -9,7 +9,8 @@ test("block handler delegation contracts manifest remains present in composed te
   for (const cmd of [
     "node test/api_handlers_create_session_from_block_delegation.test.mjs",
     "node test/api_handlers_list_block_sessions_delegation.test.mjs",
-    "node test/ci_api_create_session_from_block_executed_handler_http_contract_wrapper.test.mjs"
+    "node test/ci_api_create_session_from_block_executed_handler_http_contract_wrapper.test.mjs",
+    "node test/ci_api_list_block_sessions_executed_handler_http_contract_wrapper.test.mjs"
   ]) {
     assert.ok(commands.includes(cmd), `expected ${cmd} in composed test:ci command set`);
   }

--- a/test/ci_block_handler_delegation_contracts_manifest_file.test.mjs
+++ b/test/ci_block_handler_delegation_contracts_manifest_file.test.mjs
@@ -12,6 +12,7 @@ test("block handler delegation contracts manifest file remains pinned to the exp
   assert.deepEqual(manifest.cluster, [
     "node test/api_handlers_create_session_from_block_delegation.test.mjs",
     "node test/api_handlers_list_block_sessions_delegation.test.mjs",
-    "node test/ci_api_create_session_from_block_executed_handler_http_contract_wrapper.test.mjs"
+    "node test/ci_api_create_session_from_block_executed_handler_http_contract_wrapper.test.mjs",
+    "node test/ci_api_list_block_sessions_executed_handler_http_contract_wrapper.test.mjs"
   ]);
 });


### PR DESCRIPTION
## Summary
- add executed-path HTTP contract coverage for listBlockSessions using module-mocked query seams
- prove listBlockSessions returns the expected 200 payload, missing block_id failure, and delegated not-found mapping without drift
- wire the executed-handler wrapper into the block-handler delegation contracts cluster and pin the manifest shape

## Testing
- node --experimental-test-module-mocks --test test/api_list_block_sessions_executed_handler_http_contract.test.mjs
- npm run test:one -- test/ci_api_list_block_sessions_executed_handler_http_contract_wrapper.test.mjs
- npm run test:one -- test/ci_block_handler_delegation_contracts_cluster_manifest_file.test.mjs
- npm run test:one -- test/ci_block_handler_delegation_contracts_manifest_file.test.mjs
- npm run test:one -- test/ci_block_handler_delegation_contracts_manifest.test.mjs
- npm run lint:fast