### PR TITLE
test(v0): prove getSessionState executed handler paths without drift

### DIFF
--- a/ci/contracts/dev_session_api_ci_cluster.json
+++ b/ci/contracts/dev_session_api_ci_cluster.json
@@ -6,6 +6,7 @@
     "node test/ci_api_session_state_write_service_contract_wrapper.test.mjs",
     "node test/ci_api_session_events_query_service_contract_wrapper.test.mjs",
     "node test/ci_api_plan_session_service_contract_wrapper.test.mjs",
-    "node test/ci_api_append_runtime_event_executed_handler_http_contract_wrapper.test.mjs"
+    "node test/ci_api_append_runtime_event_executed_handler_http_contract_wrapper.test.mjs",
+    "node test/ci_api_get_session_state_executed_handler_http_contract_wrapper.test.mjs"
   ]
 }

--- a/test/api_get_session_state_executed_handler_http_contract.test.mjs
+++ b/test/api_get_session_state_executed_handler_http_contract.test.mjs
@@ -1,0 +1,186 @@
+import test, { mock } from "node:test";
+import assert from "node:assert/strict";
+
+const distHttpErrorsUrl = new URL("../dist/src/api/http_errors.js", import.meta.url).href;
+const distSessionStateWriteUrl = new URL("../dist/src/api/session_state_write_service.js", import.meta.url).href;
+const distPlanSessionServiceUrl = new URL("../dist/src/api/plan_session_service.js", import.meta.url).href;
+const distSessionEventsQueryUrl = new URL("../dist/src/api/session_events_query_service.js", import.meta.url).href;
+const distSessionStateQueryUrl = new URL("../dist/src/api/session_state_query_service.js", import.meta.url).href;
+const distHandlerUrl = new URL("../dist/src/api/sessions.handlers.js", import.meta.url).href;
+
+function makeReq({ body = undefined, params = {}, query = {}, headers = {} } = {}) {
+  return {
+    body,
+    params,
+    query,
+    get(name) {
+      const key = String(name).toLowerCase();
+      return headers[key];
+    }
+  };
+}
+
+function makeRes() {
+  return {
+    statusCode: 200,
+    jsonBody: undefined,
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload) {
+      this.jsonBody = payload;
+      return this;
+    }
+  };
+}
+
+function installCommonMocks({ queryResult, queryError } = {}) {
+  mock.module(distHttpErrorsUrl, {
+    namedExports: {
+      badRequest(message, extras = undefined) {
+        const err = new Error(message);
+        err.status = 400;
+        err.extras = extras;
+        return err;
+      },
+      notFound(message, extras = undefined) {
+        const err = new Error(message);
+        err.status = 404;
+        err.extras = extras;
+        return err;
+      },
+      internalError(message, extras = undefined) {
+        const err = new Error(message);
+        err.status = 500;
+        err.extras = extras;
+        return err;
+      }
+    }
+  });
+
+  mock.module(distSessionStateWriteUrl, {
+    namedExports: {
+      extractRawEventFromBody() {
+        throw new Error("not used in this test");
+      },
+      async appendRuntimeEventMutation() {
+        throw new Error("not used in this test");
+      },
+      async startSessionMutation() {
+        throw new Error("not used in this test");
+      }
+    }
+  });
+
+  mock.module(distPlanSessionServiceUrl, {
+    namedExports: {
+      async planSessionService() {
+        throw new Error("not used in this test");
+      }
+    }
+  });
+
+  mock.module(distSessionEventsQueryUrl, {
+    namedExports: {
+      async listRuntimeEventsQuery() {
+        throw new Error("not used in this test");
+      }
+    }
+  });
+
+  mock.module(distSessionStateQueryUrl, {
+    namedExports: {
+      async getSessionStateQuery(sessionId) {
+        if (queryError) {
+          throw queryError;
+        }
+
+        return queryResult ?? {
+          session_id: sessionId,
+          status: "active",
+          trace: {
+            return_decision_required: false,
+            return_decision_options: []
+          }
+        };
+      }
+    }
+  });
+}
+
+test("getSessionState executed path: returns 200 with delegated JSON payload when query succeeds", async () => {
+  mock.reset();
+  installCommonMocks({
+    queryResult: {
+      session_id: "sess_123",
+      status: "active",
+      trace: {
+        return_decision_required: false,
+        return_decision_options: []
+      }
+    }
+  });
+
+  const { getSessionState } = await import(`${distHandlerUrl}?case=ok`);
+  const req = makeReq({
+    params: {
+      session_id: "sess_123"
+    }
+  });
+  const res = makeRes();
+
+  await getSessionState(req, res);
+
+  assert.equal(res.statusCode, 200);
+  assert.deepEqual(res.jsonBody, {
+    session_id: "sess_123",
+    status: "active",
+    trace: {
+      return_decision_required: false,
+      return_decision_options: []
+    }
+  });
+});
+
+test("getSessionState executed path: missing session_id throws 400 badRequest", async () => {
+  mock.reset();
+  installCommonMocks();
+
+  const { getSessionState } = await import(`${distHandlerUrl}?case=missing_session_id`);
+  const req = makeReq();
+  const res = makeRes();
+
+  await assert.rejects(
+    () => getSessionState(req, res),
+    (err) => err?.status === 400 && err?.message === "Missing session_id"
+  );
+});
+
+test("getSessionState executed path: delegated not-found error preserves explicit error contract", async () => {
+  mock.reset();
+  installCommonMocks({
+    queryError: Object.assign(new Error("Session not found"), {
+      status: 404,
+      extras: {
+        failure_token: "session_not_found"
+      }
+    })
+  });
+
+  const { getSessionState } = await import(`${distHandlerUrl}?case=not_found`);
+  const req = makeReq({
+    params: {
+      session_id: "sess_missing"
+    }
+  });
+  const res = makeRes();
+
+  await assert.rejects(
+    () => getSessionState(req, res),
+    (err) =>
+      err?.status === 404 &&
+      err?.message === "Session not found" &&
+      err?.extras?.failure_token === "session_not_found"
+  );
+});

--- a/test/ci_api_get_session_state_executed_handler_http_contract_wrapper.test.mjs
+++ b/test/ci_api_get_session_state_executed_handler_http_contract_wrapper.test.mjs
@@ -1,0 +1,29 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import path from "node:path";
+
+test("CI wrapper: getSessionState executed handler http contract test passes with experimental module mocks", () => {
+  const repo = process.cwd();
+  const target = path.join(repo, "test", "api_get_session_state_executed_handler_http_contract.test.mjs");
+
+  const out = spawnSync(
+    process.execPath,
+    [
+      "--experimental-test-module-mocks",
+      "--test",
+      target
+    ],
+    {
+      cwd: repo,
+      encoding: "utf8"
+    }
+  );
+
+  if (out.status !== 0) {
+    console.error(out.stdout);
+    console.error(out.stderr);
+  }
+
+  assert.equal(out.status, 0);
+});


### PR DESCRIPTION
## Summary
- add executed-path HTTP contract coverage for getSessionState using module-mocked query seams
- prove getSessionState returns the expected 200 payload, missing session_id failure, and delegated not-found mapping without drift
- wire the executed-handler wrapper into the dev session API cluster without disturbing existing coverage

## Testing
- node --experimental-test-module-mocks --test test/api_get_session_state_executed_handler_http_contract.test.mjs
- npm run test:one -- test/ci_api_get_session_state_executed_handler_http_contract_wrapper.test.mjs
- npm run test:one -- test/ci_dev_session_api_cluster_manifest_file.test.mjs
- npm run test:one -- test/ci_dev_session_api_manifest_file.test.mjs
- npm run test:one -- test/ci_dev_session_api_manifest.test.mjs
- npm run lint:fast