### PR TITLE
fix(helper): make PR helper output deterministic and encoding-clean

### DIFF
--- a/scripts/kolosseum_pr_helpers.ps1
+++ b/scripts/kolosseum_pr_helpers.ps1
@@ -1,3 +1,91 @@
+function Format-KolosseumTextForConsole {
+  [CmdletBinding()]
+  param(
+    [AllowNull()]
+    [string]$Text
+  )
+
+  if ($null -eq $Text) {
+    return ""
+  }
+
+  $clean = $Text
+  $clean = $clean -replace "`r?`n", " "
+  $clean = $clean -replace "\s+", " "
+  $clean = $clean.Trim()
+  $clean = $clean.Replace([string][char]0x2026, "...")
+  $clean = $clean.Replace("ÔÇª", "...")
+  return $clean
+}
+
+function Show-KolosseumCheckSummary {
+  [CmdletBinding()]
+  param(
+    [Parameter(Mandatory = $true)]
+    [int]$PrNumber
+  )
+
+  $checksJson = gh pr checks $PrNumber --json name,state,workflow,bucket,link 2>$null
+  if (-not $checksJson) {
+    Write-Host "Checks: no structured results returned for PR #$PrNumber"
+    return
+  }
+
+  $checks = $checksJson | ConvertFrom-Json
+  if (-not $checks) {
+    Write-Host "Checks: no checks found for PR #$PrNumber"
+    return
+  }
+
+  Write-Host "Checks summary:"
+  foreach ($check in ($checks | Sort-Object workflow, name)) {
+    $workflow = Format-KolosseumTextForConsole $check.workflow
+    $name = Format-KolosseumTextForConsole $check.name
+    $state = Format-KolosseumTextForConsole $check.state
+    if ([string]::IsNullOrWhiteSpace($workflow)) {
+      Write-Host ("- [{0}] {1}" -f $state, $name)
+    } else {
+      Write-Host ("- [{0}] {1} / {2}" -f $state, $workflow, $name)
+    }
+  }
+}
+
+function Show-KolosseumRecentRuns {
+  [CmdletBinding()]
+  param(
+    [int]$Limit = 10
+  )
+
+  $runsJson = gh run list --limit $Limit --json status,conclusion,workflowName,headBranch,event,displayTitle,createdAt 2>$null
+  if (-not $runsJson) {
+    Write-Host "Recent runs: no structured results returned"
+    return
+  }
+
+  $runs = $runsJson | ConvertFrom-Json
+  if (-not $runs) {
+    Write-Host "Recent runs: none"
+    return
+  }
+
+  Write-Host "Recent runs:"
+  foreach ($run in $runs) {
+    $status = if ($run.status -eq "completed") {
+      if ([string]::IsNullOrWhiteSpace($run.conclusion)) { "completed" } else { $run.conclusion }
+    } else {
+      $run.status
+    }
+
+    $workflow = Format-KolosseumTextForConsole $run.workflowName
+    $branch = Format-KolosseumTextForConsole $run.headBranch
+    $event = Format-KolosseumTextForConsole $run.event
+    $title = Format-KolosseumTextForConsole $run.displayTitle
+    $created = Format-KolosseumTextForConsole $run.createdAt
+
+    Write-Host ("- [{0}] {1} | {2} | {3} | {4} | {5}" -f $status, $workflow, $branch, $event, $created, $title)
+  }
+}
+
 function Sync-KolosseumMainAfterMerge {
   [CmdletBinding()]
   param()
@@ -47,17 +135,23 @@ function Merge-KolosseumPr {
   $ErrorActionPreference = "Stop"
 
   $prInfo = gh pr view $PrNumber --json mergeable,mergeStateStatus,reviewDecision,isDraft,title,url | ConvertFrom-Json
+  $prTitle = Format-KolosseumTextForConsole $prInfo.title
 
   if ($prInfo.isDraft) {
-    throw "PR #$PrNumber is draft: $($prInfo.title)"
+    throw "PR #$PrNumber is draft: $prTitle"
   }
 
   if ($prInfo.mergeable -ne "MERGEABLE") {
     throw "PR #$PrNumber is not mergeable.`nmergeable=$($prInfo.mergeable)`nmergeStateStatus=$($prInfo.mergeStateStatus)`nreviewDecision=$($prInfo.reviewDecision)`nurl=$($prInfo.url)"
   }
 
-  gh pr checks $PrNumber --watch | Out-Host
+  Write-Host ("Watching checks for PR #{0}: {1}" -f $PrNumber, $prTitle)
+  gh pr checks $PrNumber --watch | Out-Null
+  Show-KolosseumCheckSummary -PrNumber $PrNumber
+
+  Write-Host ("Merging PR #{0}: {1}" -f $PrNumber, $prTitle)
   gh pr merge $PrNumber --squash --delete-branch --admin | Out-Host
+
   Sync-KolosseumMainAfterMerge
-  gh run list --limit 10 | Out-Host
+  Show-KolosseumRecentRuns -Limit 10
 }

--- a/test/kolosseum_pr_helpers_source_contract.test.mjs
+++ b/test/kolosseum_pr_helpers_source_contract.test.mjs
@@ -22,19 +22,37 @@ test("repo-tracked PR helper defines deterministic post-merge main sync", () => 
   assert.match(text, /git\s+reset\s+--hard\s+origin\/main/);
 });
 
-test("repo-tracked PR helper only realigns main after successful gh pr merge", () => {
+test("repo-tracked PR helper uses structured deterministic output helpers", () => {
+  const text = readHelper();
+
+  assert.match(text, /function\s+Format-KolosseumTextForConsole\b/);
+  assert.match(text, /function\s+Show-KolosseumCheckSummary\b/);
+  assert.match(text, /function\s+Show-KolosseumRecentRuns\b/);
+  assert.match(text, /gh\s+pr\s+checks\s+\$PrNumber\s+--json\s+name,state,workflow,bucket,link/);
+  assert.match(text, /gh\s+run\s+list\s+--limit\s+\$Limit\s+--json\s+status,conclusion,workflowName,headBranch,event,displayTitle,createdAt/);
+  assert.match(text, /Replace\("ÔÇª", "\.\.\."\)/);
+  assert.match(text, /Replace\(\[string\]\[char\]0x2026, "\.\.\."\)/);
+});
+
+test("repo-tracked PR helper realigns main only after successful merge call site", () => {
   const text = readHelper();
 
   assert.match(text, /function\s+Merge-KolosseumPr\b/);
-  assert.match(text, /gh\s+pr\s+checks\s+\$PrNumber\s+--watch/);
+  assert.match(text, /gh\s+pr\s+checks\s+\$PrNumber\s+--watch\s+\|\s+Out-Null/);
+  assert.match(text, /Show-KolosseumCheckSummary\s+-PrNumber\s+\$PrNumber/);
   assert.match(text, /gh\s+pr\s+merge\s+\$PrNumber\s+--squash\s+--delete-branch\s+--admin/);
   assert.match(text, /Sync-KolosseumMainAfterMerge/);
-  assert.match(text, /gh\s+run\s+list\s+--limit\s+10/);
+  assert.match(text, /Show-KolosseumRecentRuns\s+-Limit\s+10/);
 
-  const mergeIndex = text.search(/gh\s+pr\s+merge\s+\$PrNumber\s+--squash\s+--delete-branch\s+--admin/);
-  const syncIndex = text.search(/Sync-KolosseumMainAfterMerge/);
+  const mergeFnStart = text.search(/function\s+Merge-KolosseumPr\b/);
+  const mergeCallIndex = text.indexOf("gh pr merge $PrNumber --squash --delete-branch --admin", mergeFnStart);
+  const syncCallIndex = text.indexOf("Sync-KolosseumMainAfterMerge", mergeCallIndex);
+  const runsCallIndex = text.indexOf("Show-KolosseumRecentRuns -Limit 10", syncCallIndex);
 
-  assert.notEqual(mergeIndex, -1, "missing merge call");
-  assert.notEqual(syncIndex, -1, "missing post-merge sync call");
-  assert.ok(syncIndex > mergeIndex, "main realignment must happen after successful gh pr merge");
+  assert.notEqual(mergeFnStart, -1, "missing Merge-KolosseumPr function");
+  assert.notEqual(mergeCallIndex, -1, "missing merge call");
+  assert.notEqual(syncCallIndex, -1, "missing sync call after merge");
+  assert.notEqual(runsCallIndex, -1, "missing recent runs summary after sync");
+  assert.ok(syncCallIndex > mergeCallIndex, "main realignment must happen after successful gh pr merge");
+  assert.ok(runsCallIndex > syncCallIndex, "recent runs summary must happen after main realignment");
 });


### PR DESCRIPTION
## Summary
- replace raw helper console dumps with structured deterministic summaries
- sanitize helper output to avoid mojibake and noisy duplicate check rows
- keep merge and post-merge main realignment behaviour unchanged

## Testing
- npm run test:one -- test/kolosseum_pr_helpers_source_contract.test.mjs
- npm run verify
- npm run dev:status
- gh run list --limit 10