### PR TITLE
fix(helper): make PR helper parser-safe with ascii-only mojibake cleanup

### DIFF
--- a/scripts/kolosseum_pr_helpers.ps1
+++ b/scripts/kolosseum_pr_helpers.ps1
@@ -13,8 +13,11 @@ function Format-KolosseumTextForConsole {
   $clean = $clean -replace "`r?`n", " "
   $clean = $clean -replace "\s+", " "
   $clean = $clean.Trim()
+
   $clean = $clean.Replace([string][char]0x2026, "...")
-  $clean = $clean.Replace("ÔÇª", "...")
+  $clean = $clean -replace [regex]::Escape([string][char]0x00D4 + [string][char]0x00C7 + [string][char]0x00AA), "..."
+  $clean = $clean -replace [regex]::Escape([string][char]0x00C3 + [string][char]0x201D + [string][char]0x00C3 + [string][char]0x2021 + [string][char]0x00C2 + [string][char]0x00AA), "..."
+
   return $clean
 }
 
@@ -42,6 +45,7 @@ function Show-KolosseumCheckSummary {
     $workflow = Format-KolosseumTextForConsole $check.workflow
     $name = Format-KolosseumTextForConsole $check.name
     $state = Format-KolosseumTextForConsole $check.state
+
     if ([string]::IsNullOrWhiteSpace($workflow)) {
       Write-Host ("- [{0}] {1}" -f $state, $name)
     } else {

--- a/test/kolosseum_pr_helpers_source_contract.test.mjs
+++ b/test/kolosseum_pr_helpers_source_contract.test.mjs
@@ -30,8 +30,10 @@ test("repo-tracked PR helper uses structured deterministic output helpers", () =
   assert.match(text, /function\s+Show-KolosseumRecentRuns\b/);
   assert.match(text, /gh\s+pr\s+checks\s+\$PrNumber\s+--json\s+name,state,workflow,bucket,link/);
   assert.match(text, /gh\s+run\s+list\s+--limit\s+\$Limit\s+--json\s+status,conclusion,workflowName,headBranch,event,displayTitle,createdAt/);
-  assert.match(text, /Replace\("ÔÇª", "\.\.\."\)/);
-  assert.match(text, /Replace\(\[string\]\[char\]0x2026, "\.\.\."\)/);
+  assert.match(text, /0x2026/);
+  assert.match(text, /0x00D4/);
+  assert.match(text, /0x00C7/);
+  assert.match(text, /0x00AA/);
 });
 
 test("repo-tracked PR helper realigns main only after successful merge call site", () => {


### PR DESCRIPTION
## Summary
- remove parser-hostile mojibake string literals from the PowerShell helper
- keep deterministic helper summaries while making sanitization ascii-safe
- prove the helper source still preserves merge ordering and post-merge sync behaviour

## Testing
- npm run test:one -- test/kolosseum_pr_helpers_source_contract.test.mjs
- npm run verify
- npm run dev:status
- gh run list --limit 10