### PR TITLE
fix(helper): collapse duplicate check summary rows deterministically

### DIFF
--- a/scripts/kolosseum_pr_helpers.ps1
+++ b/scripts/kolosseum_pr_helpers.ps1
@@ -21,6 +21,39 @@ function Format-KolosseumTextForConsole {
   return $clean
 }
 
+function Get-KolosseumDedupedCheckSummaryRows {
+  [CmdletBinding()]
+  param(
+    [Parameter(Mandatory = $true)]
+    [object[]]$Checks
+  )
+
+  $rows = foreach ($check in $Checks) {
+    $workflow = Format-KolosseumTextForConsole $check.workflow
+    $name = Format-KolosseumTextForConsole $check.name
+    $state = (Format-KolosseumTextForConsole $check.state).ToUpperInvariant()
+
+    [pscustomobject]@{
+      workflow = $workflow
+      name = $name
+      state = $state
+      dedupe_key = "{0}|{1}|{2}" -f $workflow, $name, $state
+    }
+  }
+
+  $deduped = foreach ($group in ($rows | Group-Object dedupe_key | Sort-Object Name)) {
+    $first = $group.Group | Select-Object -First 1
+    [pscustomobject]@{
+      workflow = $first.workflow
+      name = $first.name
+      state = $first.state
+      count = $group.Count
+    }
+  }
+
+  return $deduped
+}
+
 function Show-KolosseumCheckSummary {
   [CmdletBinding()]
   param(
@@ -40,16 +73,16 @@ function Show-KolosseumCheckSummary {
     return
   }
 
-  Write-Host "Checks summary:"
-  foreach ($check in ($checks | Sort-Object workflow, name)) {
-    $workflow = Format-KolosseumTextForConsole $check.workflow
-    $name = Format-KolosseumTextForConsole $check.name
-    $state = Format-KolosseumTextForConsole $check.state
+  $summaryRows = Get-KolosseumDedupedCheckSummaryRows -Checks @($checks)
 
-    if ([string]::IsNullOrWhiteSpace($workflow)) {
-      Write-Host ("- [{0}] {1}" -f $state, $name)
+  Write-Host "Checks summary:"
+  foreach ($row in $summaryRows) {
+    $countSuffix = if ($row.count -gt 1) { " x$($row.count)" } else { "" }
+
+    if ([string]::IsNullOrWhiteSpace($row.workflow)) {
+      Write-Host ("- [{0}] {1}{2}" -f $row.state, $row.name, $countSuffix)
     } else {
-      Write-Host ("- [{0}] {1} / {2}" -f $state, $workflow, $name)
+      Write-Host ("- [{0}] {1} / {2}{3}" -f $row.state, $row.workflow, $row.name, $countSuffix)
     }
   }
 }

--- a/test/kolosseum_pr_helpers_source_contract.test.mjs
+++ b/test/kolosseum_pr_helpers_source_contract.test.mjs
@@ -26,14 +26,29 @@ test("repo-tracked PR helper uses structured deterministic output helpers", () =
   const text = readHelper();
 
   assert.match(text, /function\s+Format-KolosseumTextForConsole\b/);
+  assert.match(text, /function\s+Get-KolosseumDedupedCheckSummaryRows\b/);
   assert.match(text, /function\s+Show-KolosseumCheckSummary\b/);
   assert.match(text, /function\s+Show-KolosseumRecentRuns\b/);
   assert.match(text, /gh\s+pr\s+checks\s+\$PrNumber\s+--json\s+name,state,workflow,bucket,link/);
   assert.match(text, /gh\s+run\s+list\s+--limit\s+\$Limit\s+--json\s+status,conclusion,workflowName,headBranch,event,displayTitle,createdAt/);
+  assert.match(text, /Group-Object\s+dedupe_key/);
+  assert.match(text, /Sort-Object\s+Name/);
+  assert.match(text, /x\$\(\$row\.count\)/);
   assert.match(text, /0x2026/);
   assert.match(text, /0x00D4/);
   assert.match(text, /0x00C7/);
   assert.match(text, /0x00AA/);
+});
+
+test("repo-tracked PR helper dedupes identical workflow name state rows deterministically", () => {
+  const text = readHelper();
+
+  assert.match(text, /dedupe_key\s*=\s*"\{0\}\|\{1\}\|\{2\}"/);
+  assert.match(text, /workflow\s*=\s*\$first\.workflow/);
+  assert.match(text, /name\s*=\s*\$first\.name/);
+  assert.match(text, /state\s*=\s*\$first\.state/);
+  assert.match(text, /count\s*=\s*\$group\.Count/);
+  assert.match(text, /if\s*\(\$row\.count\s+-gt\s+1\)\s*\{\s*" x\$\(\$row\.count\)"\s*\}/);
 });
 
 test("repo-tracked PR helper realigns main only after successful merge call site", () => {


### PR DESCRIPTION
## Summary
- collapse duplicate workflow/name/state rows in the PR helper check summary
- preserve deterministic ordering while surfacing duplicate counts only when needed
- keep parser-safe mojibake cleanup and post-merge main realignment behaviour intact

## Testing
- npm run test:one -- test/kolosseum_pr_helpers_source_contract.test.mjs
- npm run verify
- npm run dev:status
- gh run list --limit 10