### PR TITLE
fix(helper): collapse duplicate recent run rows deterministically

### DIFF
--- a/scripts/kolosseum_pr_helpers.ps1
+++ b/scripts/kolosseum_pr_helpers.ps1
@@ -54,6 +54,54 @@ function Get-KolosseumDedupedCheckSummaryRows {
   return $deduped
 }
 
+function Get-KolosseumDedupedRecentRunRows {
+  [CmdletBinding()]
+  param(
+    [Parameter(Mandatory = $true)]
+    [object[]]$Runs
+  )
+
+  $rows = foreach ($run in $Runs) {
+    $status = if ($run.status -eq "completed") {
+      if ([string]::IsNullOrWhiteSpace($run.conclusion)) { "completed" } else { $run.conclusion }
+    } else {
+      $run.status
+    }
+
+    $status = Format-KolosseumTextForConsole $status
+    $workflow = Format-KolosseumTextForConsole $run.workflowName
+    $branch = Format-KolosseumTextForConsole $run.headBranch
+    $event = Format-KolosseumTextForConsole $run.event
+    $title = Format-KolosseumTextForConsole $run.displayTitle
+    $created = Format-KolosseumTextForConsole $run.createdAt
+
+    [pscustomobject]@{
+      status = $status
+      workflow = $workflow
+      branch = $branch
+      event = $event
+      title = $title
+      created = $created
+      dedupe_key = "{0}|{1}|{2}|{3}|{4}|{5}" -f $status, $workflow, $branch, $event, $created, $title
+    }
+  }
+
+  $deduped = foreach ($group in ($rows | Group-Object dedupe_key | Sort-Object Name)) {
+    $first = $group.Group | Select-Object -First 1
+    [pscustomobject]@{
+      status = $first.status
+      workflow = $first.workflow
+      branch = $first.branch
+      event = $first.event
+      title = $first.title
+      created = $first.created
+      count = $group.Count
+    }
+  }
+
+  return $deduped
+}
+
 function Show-KolosseumCheckSummary {
   [CmdletBinding()]
   param(
@@ -105,21 +153,12 @@ function Show-KolosseumRecentRuns {
     return
   }
 
+  $recentRows = Get-KolosseumDedupedRecentRunRows -Runs @($runs)
+
   Write-Host "Recent runs:"
-  foreach ($run in $runs) {
-    $status = if ($run.status -eq "completed") {
-      if ([string]::IsNullOrWhiteSpace($run.conclusion)) { "completed" } else { $run.conclusion }
-    } else {
-      $run.status
-    }
-
-    $workflow = Format-KolosseumTextForConsole $run.workflowName
-    $branch = Format-KolosseumTextForConsole $run.headBranch
-    $event = Format-KolosseumTextForConsole $run.event
-    $title = Format-KolosseumTextForConsole $run.displayTitle
-    $created = Format-KolosseumTextForConsole $run.createdAt
-
-    Write-Host ("- [{0}] {1} | {2} | {3} | {4} | {5}" -f $status, $workflow, $branch, $event, $created, $title)
+  foreach ($row in $recentRows) {
+    $countSuffix = if ($row.count -gt 1) { " x$($row.count)" } else { "" }
+    Write-Host ("- [{0}] {1} | {2} | {3} | {4} | {5}{6}" -f $row.status, $row.workflow, $row.branch, $row.event, $row.created, $row.title, $countSuffix)
   }
 }
 

--- a/test/kolosseum_pr_helpers_source_contract.test.mjs
+++ b/test/kolosseum_pr_helpers_source_contract.test.mjs
@@ -27,13 +27,11 @@ test("repo-tracked PR helper uses structured deterministic output helpers", () =
 
   assert.match(text, /function\s+Format-KolosseumTextForConsole\b/);
   assert.match(text, /function\s+Get-KolosseumDedupedCheckSummaryRows\b/);
+  assert.match(text, /function\s+Get-KolosseumDedupedRecentRunRows\b/);
   assert.match(text, /function\s+Show-KolosseumCheckSummary\b/);
   assert.match(text, /function\s+Show-KolosseumRecentRuns\b/);
   assert.match(text, /gh\s+pr\s+checks\s+\$PrNumber\s+--json\s+name,state,workflow,bucket,link/);
   assert.match(text, /gh\s+run\s+list\s+--limit\s+\$Limit\s+--json\s+status,conclusion,workflowName,headBranch,event,displayTitle,createdAt/);
-  assert.match(text, /Group-Object\s+dedupe_key/);
-  assert.match(text, /Sort-Object\s+Name/);
-  assert.match(text, /x\$\(\$row\.count\)/);
   assert.match(text, /0x2026/);
   assert.match(text, /0x00D4/);
   assert.match(text, /0x00C7/);
@@ -43,12 +41,25 @@ test("repo-tracked PR helper uses structured deterministic output helpers", () =
 test("repo-tracked PR helper dedupes identical workflow name state rows deterministically", () => {
   const text = readHelper();
 
+  assert.match(text, /Group-Object\s+dedupe_key/);
+  assert.match(text, /Sort-Object\s+Name/);
   assert.match(text, /dedupe_key\s*=\s*"\{0\}\|\{1\}\|\{2\}"/);
-  assert.match(text, /workflow\s*=\s*\$first\.workflow/);
-  assert.match(text, /name\s*=\s*\$first\.name/);
-  assert.match(text, /state\s*=\s*\$first\.state/);
-  assert.match(text, /count\s*=\s*\$group\.Count/);
   assert.match(text, /if\s*\(\$row\.count\s+-gt\s+1\)\s*\{\s*" x\$\(\$row\.count\)"\s*\}/);
+});
+
+test("repo-tracked PR helper dedupes identical recent run rows deterministically", () => {
+  const text = readHelper();
+
+  assert.match(text, /function\s+Get-KolosseumDedupedRecentRunRows\b/);
+  assert.match(text, /dedupe_key\s*=\s*"\{0\}\|\{1\}\|\{2\}\|\{3\}\|\{4\}\|\{5\}"/);
+  assert.match(text, /status\s*=\s*\$first\.status/);
+  assert.match(text, /workflow\s*=\s*\$first\.workflow/);
+  assert.match(text, /branch\s*=\s*\$first\.branch/);
+  assert.match(text, /event\s*=\s*\$first\.event/);
+  assert.match(text, /title\s*=\s*\$first\.title/);
+  assert.match(text, /created\s*=\s*\$first\.created/);
+  assert.match(text, /count\s*=\s*\$group\.Count/);
+  assert.match(text, /Write-Host\s+\("- \[\{0\}\] \{1\} \| \{2\} \| \{3\} \| \{4\} \| \{5\}\{6\}"/);
 });
 
 test("repo-tracked PR helper realigns main only after successful merge call site", () => {


### PR DESCRIPTION
## Summary
- collapse duplicate recent run rows in the PR helper output
- preserve deterministic ordering while surfacing duplicate counts only when needed
- keep parser-safe text cleanup, deduped check summaries, and post-merge main realignment behaviour intact

## Testing
- npm run test:one -- test/kolosseum_pr_helpers_source_contract.test.mjs
- npm run verify
- npm run dev:status
- gh run list --limit 10