### PR TITLE
fix(helper): wait for post-merge main runs before returning

### DIFF
--- a/scripts/kolosseum_pr_helpers.ps1
+++ b/scripts/kolosseum_pr_helpers.ps1
@@ -200,6 +200,71 @@ function Sync-KolosseumMainAfterMerge {
   git reset --hard origin/main | Out-Host
 }
 
+function Wait-KolosseumMainPostMergeRuns {
+  [CmdletBinding()]
+  param(
+    [int]$TimeoutMinutes = 15,
+    [int]$PollSeconds = 10
+  )
+
+  Set-Location C:\Users\rober\kolosseum
+  $ErrorActionPreference = "Stop"
+
+  $headSha = (git rev-parse HEAD).Trim()
+  if (-not $headSha) {
+    throw "Wait-KolosseumMainPostMergeRuns: could not resolve HEAD sha"
+  }
+
+  $deadline = (Get-Date).AddMinutes($TimeoutMinutes)
+  $terminalConclusions = @("success", "failure", "cancelled", "skipped", "neutral", "timed_out", "action_required", "startup_failure", "stale")
+
+  while ($true) {
+    if ((Get-Date) -gt $deadline) {
+      throw "Wait-KolosseumMainPostMergeRuns: timed out waiting for post-merge main runs for sha $headSha"
+    }
+
+    $runsJson = gh run list --branch main --event push --json databaseId,status,conclusion,workflowName,headSha,createdAt,displayTitle --limit 20 2>$null
+    if (-not $runsJson) {
+      Start-Sleep -Seconds $PollSeconds
+      continue
+    }
+
+    $runs = @($runsJson | ConvertFrom-Json)
+    $matchingRuns = @($runs | Where-Object { $_.headSha -eq $headSha })
+
+    if ($matchingRuns.Count -eq 0) {
+      Start-Sleep -Seconds $PollSeconds
+      continue
+    }
+
+    $dedupedRows = Get-KolosseumDedupedRecentRunRows -Runs $matchingRuns
+    Write-Host "Post-merge main runs:"
+    foreach ($row in $dedupedRows) {
+      $countSuffix = if ($row.count -gt 1) { " x$($row.count)" } else { "" }
+      Write-Host ("- [{0}] {1} | {2} | {3} | {4} | {5}{6}" -f $row.status, $row.workflow, $row.branch, $row.event, $row.created, $row.title, $countSuffix)
+    }
+
+    $failed = @($matchingRuns | Where-Object {
+      $_.status -eq "completed" -and $_.conclusion -and $_.conclusion -ne "success"
+    })
+    if ($failed.Count -gt 0) {
+      $failedNames = ($failed | ForEach-Object { Format-KolosseumTextForConsole $_.workflowName } | Sort-Object -Unique) -join ", "
+      throw "Wait-KolosseumMainPostMergeRuns: post-merge main run failure detected for sha $headSha in workflow(s): $failedNames"
+    }
+
+    $allCompleted = @($matchingRuns | Where-Object {
+      $_.status -eq "completed" -and $terminalConclusions -contains $_.conclusion
+    })
+
+    if ($allCompleted.Count -eq $matchingRuns.Count) {
+      Write-Host "Post-merge main runs complete for sha $headSha"
+      return
+    }
+
+    Start-Sleep -Seconds $PollSeconds
+  }
+}
+
 function Merge-KolosseumPr {
   [CmdletBinding()]
   param(
@@ -229,5 +294,6 @@ function Merge-KolosseumPr {
   gh pr merge $PrNumber --squash --delete-branch --admin | Out-Host
 
   Sync-KolosseumMainAfterMerge
+  Wait-KolosseumMainPostMergeRuns -TimeoutMinutes 15 -PollSeconds 10
   Show-KolosseumRecentRuns -Limit 10
 }

--- a/test/kolosseum_pr_helpers_source_contract.test.mjs
+++ b/test/kolosseum_pr_helpers_source_contract.test.mjs
@@ -28,10 +28,12 @@ test("repo-tracked PR helper uses structured deterministic output helpers", () =
   assert.match(text, /function\s+Format-KolosseumTextForConsole\b/);
   assert.match(text, /function\s+Get-KolosseumDedupedCheckSummaryRows\b/);
   assert.match(text, /function\s+Get-KolosseumDedupedRecentRunRows\b/);
+  assert.match(text, /function\s+Wait-KolosseumMainPostMergeRuns\b/);
   assert.match(text, /function\s+Show-KolosseumCheckSummary\b/);
   assert.match(text, /function\s+Show-KolosseumRecentRuns\b/);
   assert.match(text, /gh\s+pr\s+checks\s+\$PrNumber\s+--json\s+name,state,workflow,bucket,link/);
   assert.match(text, /gh\s+run\s+list\s+--limit\s+\$Limit\s+--json\s+status,conclusion,workflowName,headBranch,event,displayTitle,createdAt/);
+  assert.match(text, /gh\s+run\s+list\s+--branch\s+main\s+--event\s+push\s+--json\s+databaseId,status,conclusion,workflowName,headSha,createdAt,displayTitle\s+--limit\s+20/);
   assert.match(text, /0x2026/);
   assert.match(text, /0x00D4/);
   assert.match(text, /0x00C7/);
@@ -59,10 +61,20 @@ test("repo-tracked PR helper dedupes identical recent run rows deterministically
   assert.match(text, /title\s*=\s*\$first\.title/);
   assert.match(text, /created\s*=\s*\$first\.created/);
   assert.match(text, /count\s*=\s*\$group\.Count/);
-  assert.match(text, /Write-Host\s+\("- \[\{0\}\] \{1\} \| \{2\} \| \{3\} \| \{4\} \| \{5\}\{6\}"/);
 });
 
-test("repo-tracked PR helper realigns main only after successful merge call site", () => {
+test("repo-tracked PR helper waits for post-merge main push runs before final recent-runs summary", () => {
+  const text = readHelper();
+
+  assert.match(text, /function\s+Wait-KolosseumMainPostMergeRuns\b/);
+  assert.match(text, /git\s+rev-parse\s+HEAD/);
+  assert.match(text, /gh\s+run\s+list\s+--branch\s+main\s+--event\s+push/);
+  assert.match(text, /Where-Object\s+\{\s*\$_\.headSha\s+-eq\s+\$headSha\s*\}/);
+  assert.match(text, /Start-Sleep\s+-Seconds\s+\$PollSeconds/);
+  assert.match(text, /Post-merge main runs complete for sha/);
+});
+
+test("repo-tracked PR helper realigns main and waits only after successful merge call site", () => {
   const text = readHelper();
 
   assert.match(text, /function\s+Merge-KolosseumPr\b/);
@@ -70,17 +82,21 @@ test("repo-tracked PR helper realigns main only after successful merge call site
   assert.match(text, /Show-KolosseumCheckSummary\s+-PrNumber\s+\$PrNumber/);
   assert.match(text, /gh\s+pr\s+merge\s+\$PrNumber\s+--squash\s+--delete-branch\s+--admin/);
   assert.match(text, /Sync-KolosseumMainAfterMerge/);
+  assert.match(text, /Wait-KolosseumMainPostMergeRuns\s+-TimeoutMinutes\s+15\s+-PollSeconds\s+10/);
   assert.match(text, /Show-KolosseumRecentRuns\s+-Limit\s+10/);
 
   const mergeFnStart = text.search(/function\s+Merge-KolosseumPr\b/);
   const mergeCallIndex = text.indexOf("gh pr merge $PrNumber --squash --delete-branch --admin", mergeFnStart);
   const syncCallIndex = text.indexOf("Sync-KolosseumMainAfterMerge", mergeCallIndex);
-  const runsCallIndex = text.indexOf("Show-KolosseumRecentRuns -Limit 10", syncCallIndex);
+  const waitCallIndex = text.indexOf("Wait-KolosseumMainPostMergeRuns -TimeoutMinutes 15 -PollSeconds 10", syncCallIndex);
+  const runsCallIndex = text.indexOf("Show-KolosseumRecentRuns -Limit 10", waitCallIndex);
 
   assert.notEqual(mergeFnStart, -1, "missing Merge-KolosseumPr function");
   assert.notEqual(mergeCallIndex, -1, "missing merge call");
   assert.notEqual(syncCallIndex, -1, "missing sync call after merge");
-  assert.notEqual(runsCallIndex, -1, "missing recent runs summary after sync");
+  assert.notEqual(waitCallIndex, -1, "missing post-merge wait call after sync");
+  assert.notEqual(runsCallIndex, -1, "missing recent runs summary after post-merge wait");
   assert.ok(syncCallIndex > mergeCallIndex, "main realignment must happen after successful gh pr merge");
-  assert.ok(runsCallIndex > syncCallIndex, "recent runs summary must happen after main realignment");
+  assert.ok(waitCallIndex > syncCallIndex, "post-merge main run wait must happen after main realignment");
+  assert.ok(runsCallIndex > waitCallIndex, "recent runs summary must happen after post-merge main run wait");
 });


### PR DESCRIPTION
## Summary
- wait for fresh post-merge main push runs before the helper returns
- keep deterministic deduped check summaries and recent-run summaries
- preserve parser-safe text cleanup and post-merge main realignment behaviour

## Testing
- npm run test:one -- test/kolosseum_pr_helpers_source_contract.test.mjs
- npm run verify
- npm run dev:status
- gh run list --limit 10