### PR TITLE
fix(helper): harden post-merge run text normalization

### DIFF
--- a/scripts/kolosseum_pr_helpers.ps1
+++ b/scripts/kolosseum_pr_helpers.ps1
@@ -2,14 +2,24 @@ function Format-KolosseumTextForConsole {
   [CmdletBinding()]
   param(
     [AllowNull()]
-    [string]$Text
+    [object]$Text
   )
 
   if ($null -eq $Text) {
     return ""
   }
 
-  $clean = $Text
+  $raw = if ($Text -is [string]) {
+    $Text
+  } elseif ($Text -is [System.Collections.IEnumerable] -and -not ($Text -is [string])) {
+    (($Text | ForEach-Object {
+      if ($null -eq $_) { "" } else { [string]$_ }
+    }) -join " ")
+  } else {
+    [string]$Text
+  }
+
+  $clean = $raw
   $clean = $clean -replace "`r?`n", " "
   $clean = $clean -replace "\s+", " "
   $clean = $clean.Trim()
@@ -237,7 +247,7 @@ function Wait-KolosseumMainPostMergeRuns {
       continue
     }
 
-    $dedupedRows = Get-KolosseumDedupedRecentRunRows -Runs $matchingRuns
+    $dedupedRows = Get-KolosseumDedupedRecentRunRows -Runs @($matchingRuns)
     Write-Host "Post-merge main runs:"
     foreach ($row in $dedupedRows) {
       $countSuffix = if ($row.count -gt 1) { " x$($row.count)" } else { "" }

--- a/test/kolosseum_pr_helpers_source_contract.test.mjs
+++ b/test/kolosseum_pr_helpers_source_contract.test.mjs
@@ -34,6 +34,9 @@ test("repo-tracked PR helper uses structured deterministic output helpers", () =
   assert.match(text, /gh\s+pr\s+checks\s+\$PrNumber\s+--json\s+name,state,workflow,bucket,link/);
   assert.match(text, /gh\s+run\s+list\s+--limit\s+\$Limit\s+--json\s+status,conclusion,workflowName,headBranch,event,displayTitle,createdAt/);
   assert.match(text, /gh\s+run\s+list\s+--branch\s+main\s+--event\s+push\s+--json\s+databaseId,status,conclusion,workflowName,headSha,createdAt,displayTitle\s+--limit\s+20/);
+  assert.match(text, /\[object\]\$Text/);
+  assert.match(text, /\$Text\s+-is\s+\[System\.Collections\.IEnumerable\]\s+-and\s+-not\s+\(\$Text\s+-is\s+\[string\]\)/);
+  assert.match(text, /\[string\]\$_/);
   assert.match(text, /0x2026/);
   assert.match(text, /0x00D4/);
   assert.match(text, /0x00C7/);


### PR DESCRIPTION
## Summary
- harden helper text normalization so post-merge run polling tolerates non-string gh json fields
- preserve deterministic deduped check summaries, recent-run summaries, and post-merge wait behaviour
- keep parser-safe mojibake cleanup and post-merge main realignment intact

## Testing
- npm run test:one -- test/kolosseum_pr_helpers_source_contract.test.mjs
- npm run verify
- npm run dev:status
- gh run list --limit 10