### PR TITLE
fix(helper): flatten post-merge run rows before failure checks

### DIFF
--- a/scripts/kolosseum_pr_helpers.ps1
+++ b/scripts/kolosseum_pr_helpers.ps1
@@ -9,17 +9,11 @@ function Format-KolosseumTextForConsole {
     return ""
   }
 
-  $raw = if ($Text -is [string]) {
-    $Text
-  } elseif ($Text -is [System.Collections.IEnumerable] -and -not ($Text -is [string])) {
-    (($Text | ForEach-Object {
-      if ($null -eq $_) { "" } else { [string]$_ }
-    }) -join " ")
-  } else {
-    [string]$Text
+  if ($Text -isnot [string] -and $Text -is [System.Collections.IEnumerable]) {
+    throw "Format-KolosseumTextForConsole expects a scalar value, not a collection."
   }
 
-  $clean = $raw
+  $clean = [string]$Text
   $clean = $clean -replace "`r?`n", " "
   $clean = $clean -replace "\s+", " "
   $clean = $clean.Trim()
@@ -29,6 +23,42 @@ function Format-KolosseumTextForConsole {
   $clean = $clean -replace [regex]::Escape([string][char]0x00C3 + [string][char]0x201D + [string][char]0x00C3 + [string][char]0x2021 + [string][char]0x00C2 + [string][char]0x00AA), "..."
 
   return $clean
+}
+
+function Expand-KolosseumRunRecords {
+  [CmdletBinding()]
+  param(
+    [Parameter(Mandatory = $true)]
+    [object[]]$Runs
+  )
+
+  $expanded = New-Object System.Collections.Generic.List[object]
+
+  foreach ($item in $Runs) {
+    if ($null -eq $item) {
+      continue
+    }
+
+    $propertyNames = @($item.PSObject.Properties.Name)
+
+    if ($propertyNames -contains "status" -and $propertyNames -contains "workflowName") {
+      $expanded.Add($item)
+      continue
+    }
+
+    if ($item -is [System.Collections.IEnumerable] -and $item -isnot [string]) {
+      foreach ($nested in $item) {
+        if ($null -ne $nested) {
+          $expanded.Add($nested)
+        }
+      }
+      continue
+    }
+
+    throw "Expand-KolosseumRunRecords: unsupported run item shape: $($item.GetType().FullName)"
+  }
+
+  return @($expanded)
 }
 
 function Get-KolosseumDedupedCheckSummaryRows {
@@ -71,9 +101,11 @@ function Get-KolosseumDedupedRecentRunRows {
     [object[]]$Runs
   )
 
-  $rows = foreach ($run in $Runs) {
+  $flatRuns = Expand-KolosseumRunRecords -Runs $Runs
+
+  $rows = foreach ($run in $flatRuns) {
     $status = if ($run.status -eq "completed") {
-      if ([string]::IsNullOrWhiteSpace($run.conclusion)) { "completed" } else { $run.conclusion }
+      if ([string]::IsNullOrWhiteSpace([string]$run.conclusion)) { "completed" } else { $run.conclusion }
     } else {
       $run.status
     }
@@ -233,7 +265,7 @@ function Wait-KolosseumMainPostMergeRuns {
       throw "Wait-KolosseumMainPostMergeRuns: timed out waiting for post-merge main runs for sha $headSha"
     }
 
-    $runsJson = gh run list --branch main --event push --json databaseId,status,conclusion,workflowName,headSha,createdAt,displayTitle --limit 20 2>$null
+    $runsJson = gh run list --branch main --event push --json databaseId,status,conclusion,workflowName,headSha,headBranch,event,createdAt,displayTitle --limit 20 2>$null
     if (-not $runsJson) {
       Start-Sleep -Seconds $PollSeconds
       continue
@@ -247,14 +279,16 @@ function Wait-KolosseumMainPostMergeRuns {
       continue
     }
 
-    $dedupedRows = Get-KolosseumDedupedRecentRunRows -Runs @($matchingRuns)
+    $flatMatchingRuns = Expand-KolosseumRunRecords -Runs @($matchingRuns)
+
+    $dedupedRows = Get-KolosseumDedupedRecentRunRows -Runs @($flatMatchingRuns)
     Write-Host "Post-merge main runs:"
     foreach ($row in $dedupedRows) {
       $countSuffix = if ($row.count -gt 1) { " x$($row.count)" } else { "" }
       Write-Host ("- [{0}] {1} | {2} | {3} | {4} | {5}{6}" -f $row.status, $row.workflow, $row.branch, $row.event, $row.created, $row.title, $countSuffix)
     }
 
-    $failed = @($matchingRuns | Where-Object {
+    $failed = @($flatMatchingRuns | Where-Object {
       $_.status -eq "completed" -and $_.conclusion -and $_.conclusion -ne "success"
     })
     if ($failed.Count -gt 0) {
@@ -262,11 +296,11 @@ function Wait-KolosseumMainPostMergeRuns {
       throw "Wait-KolosseumMainPostMergeRuns: post-merge main run failure detected for sha $headSha in workflow(s): $failedNames"
     }
 
-    $allCompleted = @($matchingRuns | Where-Object {
+    $allCompleted = @($flatMatchingRuns | Where-Object {
       $_.status -eq "completed" -and $terminalConclusions -contains $_.conclusion
     })
 
-    if ($allCompleted.Count -eq $matchingRuns.Count) {
+    if ($allCompleted.Count -eq $flatMatchingRuns.Count) {
       Write-Host "Post-merge main runs complete for sha $headSha"
       return
     }

--- a/test/kolosseum_pr_helpers_source_contract.test.mjs
+++ b/test/kolosseum_pr_helpers_source_contract.test.mjs
@@ -26,6 +26,7 @@ test("repo-tracked PR helper uses structured deterministic output helpers", () =
   const text = readHelper();
 
   assert.match(text, /function\s+Format-KolosseumTextForConsole\b/);
+  assert.match(text, /function\s+Expand-KolosseumRunRecords\b/);
   assert.match(text, /function\s+Get-KolosseumDedupedCheckSummaryRows\b/);
   assert.match(text, /function\s+Get-KolosseumDedupedRecentRunRows\b/);
   assert.match(text, /function\s+Wait-KolosseumMainPostMergeRuns\b/);
@@ -33,14 +34,24 @@ test("repo-tracked PR helper uses structured deterministic output helpers", () =
   assert.match(text, /function\s+Show-KolosseumRecentRuns\b/);
   assert.match(text, /gh\s+pr\s+checks\s+\$PrNumber\s+--json\s+name,state,workflow,bucket,link/);
   assert.match(text, /gh\s+run\s+list\s+--limit\s+\$Limit\s+--json\s+status,conclusion,workflowName,headBranch,event,displayTitle,createdAt/);
-  assert.match(text, /gh\s+run\s+list\s+--branch\s+main\s+--event\s+push\s+--json\s+databaseId,status,conclusion,workflowName,headSha,createdAt,displayTitle\s+--limit\s+20/);
+  assert.match(text, /gh\s+run\s+list\s+--branch\s+main\s+--event\s+push\s+--json\s+databaseId,status,conclusion,workflowName,headSha,headBranch,event,createdAt,displayTitle\s+--limit\s+20/);
   assert.match(text, /\[object\]\$Text/);
-  assert.match(text, /\$Text\s+-is\s+\[System\.Collections\.IEnumerable\]\s+-and\s+-not\s+\(\$Text\s+-is\s+\[string\]\)/);
-  assert.match(text, /\[string\]\$_/);
+  assert.match(text, /Format-KolosseumTextForConsole expects a scalar value, not a collection/);
   assert.match(text, /0x2026/);
   assert.match(text, /0x00D4/);
   assert.match(text, /0x00C7/);
   assert.match(text, /0x00AA/);
+});
+
+test("repo-tracked PR helper expands nested run collections before dedupe and failure checks", () => {
+  const text = readHelper();
+
+  assert.match(text, /function\s+Expand-KolosseumRunRecords\b/);
+  assert.match(text, /\$propertyNames\s*=\s*@\(\$item\.PSObject\.Properties\.Name\)/);
+  assert.match(text, /\$propertyNames\s+-contains\s+"status"\s+-and\s+\$propertyNames\s+-contains\s+"workflowName"/);
+  assert.match(text, /\$item\s+-is\s+\[System\.Collections\.IEnumerable\]\s+-and\s+\$item\s+-isnot\s+\[string\]/);
+  assert.match(text, /Expand-KolosseumRunRecords -Runs \$Runs/);
+  assert.match(text, /Expand-KolosseumRunRecords -Runs @\(\$matchingRuns\)/);
 });
 
 test("repo-tracked PR helper dedupes identical workflow name state rows deterministically", () => {
@@ -73,6 +84,7 @@ test("repo-tracked PR helper waits for post-merge main push runs before final re
   assert.match(text, /git\s+rev-parse\s+HEAD/);
   assert.match(text, /gh\s+run\s+list\s+--branch\s+main\s+--event\s+push/);
   assert.match(text, /Where-Object\s+\{\s*\$_\.headSha\s+-eq\s+\$headSha\s*\}/);
+  assert.match(text, /\$failed\s*=\s*@\(\$flatMatchingRuns \| Where-Object/);
   assert.match(text, /Start-Sleep\s+-Seconds\s+\$PollSeconds/);
   assert.match(text, /Post-merge main runs complete for sha/);
 });


### PR DESCRIPTION
## Summary
- flatten post-merge main run records before dedupe and failure detection
- stop collection-shaped gh json payloads from collapsing into one synthetic recent-run row
- keep deterministic check summaries, recent-run summaries, text cleanup, and post-merge main wait behaviour intact

## Testing
- npm run test:one -- test/kolosseum_pr_helpers_source_contract.test.mjs
- npm run verify
- npm run dev:status
- gh run list --limit 10