### PR TITLE
fix(helper): stabilize recursive post-merge run flattening

### DIFF
--- a/scripts/kolosseum_pr_helpers.ps1
+++ b/scripts/kolosseum_pr_helpers.ps1
@@ -25,6 +25,21 @@ function Format-KolosseumTextForConsole {
   return $clean
 }
 
+function Test-KolosseumRunRecord {
+  [CmdletBinding()]
+  param(
+    [AllowNull()]
+    [object]$Item
+  )
+
+  if ($null -eq $Item) {
+    return $false
+  }
+
+  $propertyNames = @($Item.PSObject.Properties.Name)
+  return (($propertyNames -contains "status") -and ($propertyNames -contains "workflowName"))
+}
+
 function Expand-KolosseumRunRecords {
   [CmdletBinding()]
   param(
@@ -32,33 +47,44 @@ function Expand-KolosseumRunRecords {
     [object[]]$Runs
   )
 
-  $expanded = New-Object System.Collections.Generic.List[object]
+  $expanded = [System.Collections.ArrayList]::new()
 
-  foreach ($item in $Runs) {
-    if ($null -eq $item) {
-      continue
+  function Add-KolosseumRunRecord {
+    param(
+      [AllowNull()]
+      [object]$Node,
+      [Parameter(Mandatory = $true)]
+      [System.Collections.ArrayList]$Sink
+    )
+
+    if ($null -eq $Node) {
+      return
     }
 
-    $propertyNames = @($item.PSObject.Properties.Name)
-
-    if ($propertyNames -contains "status" -and $propertyNames -contains "workflowName") {
-      $expanded.Add($item)
-      continue
+    if (Test-KolosseumRunRecord -Item $Node) {
+      [void]$Sink.Add($Node)
+      return
     }
 
-    if ($item -is [System.Collections.IEnumerable] -and $item -isnot [string]) {
-      foreach ($nested in $item) {
-        if ($null -ne $nested) {
-          $expanded.Add($nested)
-        }
+    if ($Node -is [string]) {
+      throw "Expand-KolosseumRunRecords: unsupported string run item shape."
+    }
+
+    if ($Node -is [System.Collections.IEnumerable]) {
+      foreach ($nested in $Node) {
+        Add-KolosseumRunRecord -Node $nested -Sink $Sink
       }
-      continue
+      return
     }
 
-    throw "Expand-KolosseumRunRecords: unsupported run item shape: $($item.GetType().FullName)"
+    throw "Expand-KolosseumRunRecords: unsupported run item shape: $($Node.GetType().FullName)"
   }
 
-  return @($expanded)
+  foreach ($item in $Runs) {
+    Add-KolosseumRunRecord -Node $item -Sink $expanded
+  }
+
+  return @($expanded.ToArray())
 }
 
 function Get-KolosseumDedupedCheckSummaryRows {
@@ -74,9 +100,9 @@ function Get-KolosseumDedupedCheckSummaryRows {
     $state = (Format-KolosseumTextForConsole $check.state).ToUpperInvariant()
 
     [pscustomobject]@{
-      workflow = $workflow
-      name = $name
-      state = $state
+      workflow   = $workflow
+      name       = $name
+      state      = $state
       dedupe_key = "{0}|{1}|{2}" -f $workflow, $name, $state
     }
   }
@@ -85,9 +111,9 @@ function Get-KolosseumDedupedCheckSummaryRows {
     $first = $group.Group | Select-Object -First 1
     [pscustomobject]@{
       workflow = $first.workflow
-      name = $first.name
-      state = $first.state
-      count = $group.Count
+      name     = $first.name
+      state    = $first.state
+      count    = $group.Count
     }
   }
 
@@ -118,12 +144,12 @@ function Get-KolosseumDedupedRecentRunRows {
     $created = Format-KolosseumTextForConsole $run.createdAt
 
     [pscustomobject]@{
-      status = $status
-      workflow = $workflow
-      branch = $branch
-      event = $event
-      title = $title
-      created = $created
+      status     = $status
+      workflow   = $workflow
+      branch     = $branch
+      event      = $event
+      title      = $title
+      created    = $created
       dedupe_key = "{0}|{1}|{2}|{3}|{4}|{5}" -f $status, $workflow, $branch, $event, $created, $title
     }
   }
@@ -131,13 +157,13 @@ function Get-KolosseumDedupedRecentRunRows {
   $deduped = foreach ($group in ($rows | Group-Object dedupe_key | Sort-Object Name)) {
     $first = $group.Group | Select-Object -First 1
     [pscustomobject]@{
-      status = $first.status
+      status   = $first.status
       workflow = $first.workflow
-      branch = $first.branch
-      event = $first.event
-      title = $first.title
-      created = $first.created
-      count = $group.Count
+      branch   = $first.branch
+      event    = $first.event
+      title    = $first.title
+      created  = $first.created
+      count    = $group.Count
     }
   }
 
@@ -279,9 +305,9 @@ function Wait-KolosseumMainPostMergeRuns {
       continue
     }
 
-    $flatMatchingRuns = Expand-KolosseumRunRecords -Runs @($matchingRuns)
+    $flatMatchingRuns = Expand-KolosseumRunRecords -Runs $matchingRuns
 
-    $dedupedRows = Get-KolosseumDedupedRecentRunRows -Runs @($flatMatchingRuns)
+    $dedupedRows = Get-KolosseumDedupedRecentRunRows -Runs $flatMatchingRuns
     Write-Host "Post-merge main runs:"
     foreach ($row in $dedupedRows) {
       $countSuffix = if ($row.count -gt 1) { " x$($row.count)" } else { "" }

--- a/test/kolosseum_pr_helpers_source_contract.test.mjs
+++ b/test/kolosseum_pr_helpers_source_contract.test.mjs
@@ -26,6 +26,7 @@ test("repo-tracked PR helper uses structured deterministic output helpers", () =
   const text = readHelper();
 
   assert.match(text, /function\s+Format-KolosseumTextForConsole\b/);
+  assert.match(text, /function\s+Test-KolosseumRunRecord\b/);
   assert.match(text, /function\s+Expand-KolosseumRunRecords\b/);
   assert.match(text, /function\s+Get-KolosseumDedupedCheckSummaryRows\b/);
   assert.match(text, /function\s+Get-KolosseumDedupedRecentRunRows\b/);
@@ -43,15 +44,17 @@ test("repo-tracked PR helper uses structured deterministic output helpers", () =
   assert.match(text, /0x00AA/);
 });
 
-test("repo-tracked PR helper expands nested run collections before dedupe and failure checks", () => {
+test("repo-tracked PR helper recursively flattens nested run collections with arraylist sink", () => {
   const text = readHelper();
 
+  assert.match(text, /function\s+Test-KolosseumRunRecord\b/);
   assert.match(text, /function\s+Expand-KolosseumRunRecords\b/);
-  assert.match(text, /\$propertyNames\s*=\s*@\(\$item\.PSObject\.Properties\.Name\)/);
-  assert.match(text, /\$propertyNames\s+-contains\s+"status"\s+-and\s+\$propertyNames\s+-contains\s+"workflowName"/);
-  assert.match(text, /\$item\s+-is\s+\[System\.Collections\.IEnumerable\]\s+-and\s+\$item\s+-isnot\s+\[string\]/);
-  assert.match(text, /Expand-KolosseumRunRecords -Runs \$Runs/);
-  assert.match(text, /Expand-KolosseumRunRecords -Runs @\(\$matchingRuns\)/);
+  assert.match(text, /\[System\.Collections\.ArrayList\]::new\(\)/);
+  assert.match(text, /function\s+Add-KolosseumRunRecord\b/);
+  assert.match(text, /if \(Test-KolosseumRunRecord -Item \$Node\)/);
+  assert.match(text, /\[void\]\$Sink\.Add\(\$Node\)/);
+  assert.match(text, /foreach \(\$nested in \$Node\)/);
+  assert.match(text, /return @\(\$expanded\.ToArray\(\)\)/);
 });
 
 test("repo-tracked PR helper dedupes identical workflow name state rows deterministically", () => {
@@ -67,6 +70,7 @@ test("repo-tracked PR helper dedupes identical recent run rows deterministically
   const text = readHelper();
 
   assert.match(text, /function\s+Get-KolosseumDedupedRecentRunRows\b/);
+  assert.match(text, /Expand-KolosseumRunRecords -Runs \$Runs/);
   assert.match(text, /dedupe_key\s*=\s*"\{0\}\|\{1\}\|\{2\}\|\{3\}\|\{4\}\|\{5\}"/);
   assert.match(text, /status\s*=\s*\$first\.status/);
   assert.match(text, /workflow\s*=\s*\$first\.workflow/);
@@ -84,6 +88,7 @@ test("repo-tracked PR helper waits for post-merge main push runs before final re
   assert.match(text, /git\s+rev-parse\s+HEAD/);
   assert.match(text, /gh\s+run\s+list\s+--branch\s+main\s+--event\s+push/);
   assert.match(text, /Where-Object\s+\{\s*\$_\.headSha\s+-eq\s+\$headSha\s*\}/);
+  assert.match(text, /Expand-KolosseumRunRecords -Runs \$matchingRuns/);
   assert.match(text, /\$failed\s*=\s*@\(\$flatMatchingRuns \| Where-Object/);
   assert.match(text, /Start-Sleep\s+-Seconds\s+\$PollSeconds/);
   assert.match(text, /Post-merge main runs complete for sha/);


### PR DESCRIPTION
## Summary
- replace fragile generic-list run flattening with recursive arraylist-based flattening
- distinguish real gh run records from nested collections before dedupe and failure checks
- keep deterministic check summaries, recent-run summaries, text cleanup, and post-merge main wait behaviour intact

## Testing
- npm run test:one -- test/kolosseum_pr_helpers_source_contract.test.mjs
- npm run verify
- npm run dev:status
- gh run list --limit 10