### PR TITLE
fix(helper): remove empty-arraylist sink binding from post-merge run flattener

### DIFF
--- a/scripts/kolosseum_pr_helpers.ps1
+++ b/scripts/kolosseum_pr_helpers.ps1
@@ -52,9 +52,7 @@ function Expand-KolosseumRunRecords {
   function Add-KolosseumRunRecord {
     param(
       [AllowNull()]
-      [object]$Node,
-      [Parameter(Mandatory = $true)]
-      [System.Collections.ArrayList]$Sink
+      [object]$Node
     )
 
     if ($null -eq $Node) {
@@ -62,7 +60,7 @@ function Expand-KolosseumRunRecords {
     }
 
     if (Test-KolosseumRunRecord -Item $Node) {
-      [void]$Sink.Add($Node)
+      [void]$expanded.Add($Node)
       return
     }
 
@@ -72,7 +70,7 @@ function Expand-KolosseumRunRecords {
 
     if ($Node -is [System.Collections.IEnumerable]) {
       foreach ($nested in $Node) {
-        Add-KolosseumRunRecord -Node $nested -Sink $Sink
+        Add-KolosseumRunRecord -Node $nested
       }
       return
     }
@@ -81,7 +79,7 @@ function Expand-KolosseumRunRecords {
   }
 
   foreach ($item in $Runs) {
-    Add-KolosseumRunRecord -Node $item -Sink $expanded
+    Add-KolosseumRunRecord -Node $item
   }
 
   return @($expanded.ToArray())

--- a/test/kolosseum_pr_helpers_source_contract.test.mjs
+++ b/test/kolosseum_pr_helpers_source_contract.test.mjs
@@ -52,8 +52,11 @@ test("repo-tracked PR helper recursively flattens nested run collections with ar
   assert.match(text, /\[System\.Collections\.ArrayList\]::new\(\)/);
   assert.match(text, /function\s+Add-KolosseumRunRecord\b/);
   assert.match(text, /if \(Test-KolosseumRunRecord -Item \$Node\)/);
-  assert.match(text, /\[void\]\$Sink\.Add\(\$Node\)/);
+  assert.match(text, /\[void\]\$expanded\.Add\(\$Node\)/);
   assert.match(text, /foreach \(\$nested in \$Node\)/);
+  assert.match(text, /Add-KolosseumRunRecord -Node \$nested/);
+  assert.doesNotMatch(text, /-Sink \$expanded/);
+  assert.doesNotMatch(text, /\[System\.Collections\.ArrayList\]\$Sink/);
   assert.match(text, /return @\(\$expanded\.ToArray\(\)\)/);
 });
 


### PR DESCRIPTION
## Summary
- remove the nested -Sink arraylist parameter that PowerShell rejects when the collection is empty
- keep recursive run-record flattening but close over the arraylist sink instead of passing it through parameter binding
- extend the source-contract test to forbid the old empty-collection sink pattern

## Testing
- npm run test:one -- test/kolosseum_pr_helpers_source_contract.test.mjs
- npm run verify
- npm run dev:status
- gh run list --limit 10