### PR TITLE
fix(helper): restore TimeoutMinutes compatibility for post-merge wait

### DIFF
--- a/scripts/kolosseum_pr_helpers.ps1
+++ b/scripts/kolosseum_pr_helpers.ps1
@@ -402,7 +402,7 @@ function Get-KolosseumLatestMainPushRunsForSha {
 }
 
 function Wait-KolosseumMainPostMergeRuns {
-  [CmdletBinding()]
+  [CmdletBinding(DefaultParameterSetName = "Minutes")]
   param(
     [Parameter(Mandatory = $true, Position = 0)]
     [Alias("HeadSha", "CommitSha", "MergeSha")]
@@ -410,8 +410,18 @@ function Wait-KolosseumMainPostMergeRuns {
 
     [int]$PollSeconds = 10,
 
-    [int]$TimeoutSeconds = 900
+    [Parameter(ParameterSetName = "Minutes")]
+    [int]$TimeoutMinutes = 15,
+
+    [Parameter(ParameterSetName = "Seconds")]
+    [int]$TimeoutSeconds
   )
+
+  if ($PSCmdlet.ParameterSetName -eq "Seconds") {
+    $effectiveTimeoutSeconds = $TimeoutSeconds
+  } else {
+    $effectiveTimeoutSeconds = $TimeoutMinutes * 60
+  }
 
   $requiredWorkflows = @(
     "ci",
@@ -422,7 +432,7 @@ function Wait-KolosseumMainPostMergeRuns {
     "vertical-slice"
   )
 
-  $deadline = (Get-Date).AddSeconds($TimeoutSeconds)
+  $deadline = (Get-Date).AddSeconds($effectiveTimeoutSeconds)
 
   while ($true) {
     $latest = @(Get-KolosseumLatestMainPushRunsForSha -Sha $Sha)
@@ -483,7 +493,7 @@ function Wait-KolosseumMainPostMergeRuns {
     }
 
     if ((Get-Date) -ge $deadline) {
-      throw ("Wait-KolosseumMainPostMergeRuns: timeout waiting for post-merge main push workflows for sha {0}. Missing: {1}. In-progress: {2}" -f $Sha, (($missing -join ", "), ($inProgress -join ", ")))
+      throw ("Wait-KolosseumMainPostMergeRuns: timeout waiting for post-merge main push workflows for sha {0}. Missing: {1}. In-progress: {2}" -f $Sha, ($missing -join ", "), ($inProgress -join ", "))
     }
 
     Start-Sleep -Seconds $PollSeconds


### PR DESCRIPTION
## Summary
- restore TimeoutMinutes compatibility for Wait-KolosseumMainPostMergeRuns
- support both TimeoutMinutes and TimeoutSeconds parameter sets
- keep post-merge wait behaviour deterministic while preserving existing caller compatibility

## Testing
- . .\scripts\kolosseum_pr_helpers.ps1
- Wait-KolosseumMainPostMergeRuns -Sha 8590918695741fa7491c9f7fedbbd748682ff06a -PollSeconds 2 -TimeoutSeconds 30
- Wait-KolosseumMainPostMergeRuns -Sha 8590918695741fa7491c9f7fedbbd748682ff06a -PollSeconds 2 -TimeoutMinutes 1
- npm run dev:status
- npm run lint:fast
- npm run test:unit
- npm run build:fast
- npm run e2e:golden