### PR TITLE
fix(helper): capture post-merge main sha before waiting for main runs

### DIFF
--- a/scripts/kolosseum_pr_helpers.ps1
+++ b/scripts/kolosseum_pr_helpers.ps1
@@ -362,7 +362,15 @@ function Merge-KolosseumPr {
   gh pr merge $PrNumber --squash --delete-branch --admin | Out-Host
 
   Sync-KolosseumMainAfterMerge
-  Wait-KolosseumMainPostMergeRuns -TimeoutMinutes 15 -PollSeconds 10
+
+  $postMergeSha = (git rev-parse HEAD).Trim()
+  if ([string]::IsNullOrWhiteSpace($postMergeSha)) {
+    throw "Merge-KolosseumPr: failed to resolve post-merge local main HEAD sha."
+  }
+
+  Write-Host ("Resolved post-merge main sha: {0}" -f $postMergeSha)
+
+  Wait-KolosseumMainPostMergeRuns -Sha $postMergeSha -TimeoutMinutes 15 -PollSeconds 10
   Show-KolosseumRecentRuns -Limit 10
 }
 


### PR DESCRIPTION
## Summary
- capture the updated local main HEAD sha after merge completes
- pass the resolved sha explicitly into Wait-KolosseumMainPostMergeRuns
- remove the empty-sha prompt/failure at the end of an otherwise successful merge flow

## Testing
- . .\scripts\kolosseum_pr_helpers.ps1
- npm run dev:status
- npm run lint:fast
- npm run test:unit
- npm run build:fast
- npm run e2e:golden