### PR TITLE
fix(helper): sanitize displayTitle for console output

### DIFF
--- a/scripts/kolosseum_pr_helpers.ps1
+++ b/scripts/kolosseum_pr_helpers.ps1
@@ -460,7 +460,8 @@ function Wait-KolosseumMainPostMergeRuns {
             "failure"
           }
 
-        Write-Host ("- [{0}] {1} | main | push | {2} | {3}" -f $state, $run.workflowName, $run.createdAt, $run.displayTitle)
+        $displayTitle = Format-KolosseumTextForConsole $run.displayTitle
+        Write-Host ("- [{0}] {1} | main | push | {2} | {3}" -f $state, $run.workflowName, $run.createdAt, $displayTitle)
       }
     }
 


### PR DESCRIPTION
## Summary
- sanitize displayTitle only at console render time inside Wait-KolosseumMainPostMergeRuns
- keep merge flow and run-selection logic unchanged
- remove mojibake from helper console output without mutating underlying run data

## Testing
- . .\scripts\kolosseum_pr_helpers.ps1
- Wait-KolosseumMainPostMergeRuns -Sha 2d250dff7300cc916944391efe89ddd928da2252.Trim() -PollSeconds 5 -TimeoutMinutes 15
- npm run dev:status
- npm run lint:fast