### PR TITLE
fix(helper): suppress raw post-merge run object dump

### DIFF
--- a/scripts/kolosseum_pr_helpers.ps1
+++ b/scripts/kolosseum_pr_helpers.ps1
@@ -498,7 +498,7 @@ function Wait-KolosseumMainPostMergeRuns {
 
     if ($missing.Count -eq 0 -and $inProgress.Count -eq 0) {
       Write-Host ("Wait-KolosseumMainPostMergeRuns: all required post-merge main push workflows succeeded for sha {0}" -f $Sha)
-      return $latest
+      return
     }
 
     if ((Get-Date) -ge $deadline) {


### PR DESCRIPTION
## Summary
- suppress the raw post-merge run object dump from Wait-KolosseumMainPostMergeRuns
- keep concise workflow polling output and final success summary
- reduce helper noise without changing merge, sha-resolution, or workflow-selection logic

## Testing
- . .\scripts\kolosseum_pr_helpers.ps1
- Wait-KolosseumMainPostMergeRuns -Sha 14940d43235b9bad9036abd2fe51be554499a047.Trim() -PollSeconds 5 -TimeoutMinutes 15
- npm run dev:status