### PR TITLE
fix(helper): restore post-merge run helper and extract required workflows

### DIFF
--- a/scripts/kolosseum_pr_helpers.ps1
+++ b/scripts/kolosseum_pr_helpers.ps1
@@ -266,6 +266,49 @@ function Sync-KolosseumMainAfterMerge {
   git reset --hard origin/main | Out-Host
 }
 
+function Get-KolosseumLatestMainPushRunsForSha {
+  [CmdletBinding()]
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$Sha,
+
+    [int]$Limit = 50
+  )
+
+  $runs = gh run list --branch main --event push --limit $Limit --json databaseId,headSha,workflowName,status,conclusion,event,displayTitle,createdAt,updatedAt | ConvertFrom-Json
+  if (-not $runs) {
+    return @()
+  }
+
+  $filtered = @(
+    $runs |
+      Where-Object { $_.headSha -eq $Sha -and $_.event -eq "push" } |
+      Sort-Object workflowName, @{ Expression = "databaseId"; Descending = $true }
+  )
+
+  if ($filtered.Count -eq 0) {
+    return @()
+  }
+
+  $latest = @(
+    $filtered |
+      Group-Object workflowName |
+      ForEach-Object { $_.Group | Select-Object -First 1 } |
+      Sort-Object workflowName
+  )
+
+  return $latest
+}
+
+$script:KolosseumRequiredPostMergeMainWorkflows = @(
+  "ci",
+  "engine-status",
+  "green",
+  "Protect main (auto-revert on CI failure)",
+  "runnable-v0",
+  "vertical-slice"
+)
+
 function Wait-KolosseumMainPostMergeRuns {
   [CmdletBinding(DefaultParameterSetName = "Minutes")]
   param(
@@ -288,14 +331,7 @@ function Wait-KolosseumMainPostMergeRuns {
     $effectiveTimeoutSeconds = $TimeoutMinutes * 60
   }
 
-  $requiredWorkflows = @(
-    "ci",
-    "engine-status",
-    "green",
-    "Protect main (auto-revert on CI failure)",
-    "runnable-v0",
-    "vertical-slice"
-  )
+  $requiredWorkflows = $script:KolosseumRequiredPostMergeMainWorkflows
 
   $deadline = (Get-Date).AddSeconds($effectiveTimeoutSeconds)
 


### PR DESCRIPTION
## Summary
- restore Get-KolosseumLatestMainPushRunsForSha as the helper used by Wait-KolosseumMainPostMergeRuns
- extract the required post-merge main workflow names into a single script-scope constant
- keep post-merge polling behaviour the same while reducing inline workflow-list drift

## Testing
- . .\scripts\kolosseum_pr_helpers.ps1
- Wait-KolosseumMainPostMergeRuns -Sha 053712ac4e999939cc9b311142b9b0fa8ea4b5a8.Trim() -PollSeconds 5 -TimeoutMinutes 15
- npm run dev:status