### PR TITLE
fix(helper): add required post-merge workflow accessor

### DIFF
--- a/scripts/kolosseum_pr_helpers.ps1
+++ b/scripts/kolosseum_pr_helpers.ps1
@@ -308,6 +308,12 @@ $script:KolosseumRequiredPostMergeMainWorkflows = @(
   "runnable-v0",
   "vertical-slice"
 )
+function Get-KolosseumRequiredPostMergeMainWorkflows {
+  [CmdletBinding()]
+  param()
+
+  return @($script:KolosseumRequiredPostMergeMainWorkflows)
+}
 
 function Wait-KolosseumMainPostMergeRuns {
   [CmdletBinding(DefaultParameterSetName = "Minutes")]
@@ -331,7 +337,7 @@ function Wait-KolosseumMainPostMergeRuns {
     $effectiveTimeoutSeconds = $TimeoutMinutes * 60
   }
 
-  $requiredWorkflows = $script:KolosseumRequiredPostMergeMainWorkflows
+  $requiredWorkflows = @(Get-KolosseumRequiredPostMergeMainWorkflows)
 
   $deadline = (Get-Date).AddSeconds($effectiveTimeoutSeconds)
 


### PR DESCRIPTION
## Summary
- add Get-KolosseumRequiredPostMergeMainWorkflows as the single accessor for required post-merge main workflow names
- stop reading the script-scope constant directly inside Wait-KolosseumMainPostMergeRuns
- preserve current post-merge polling behaviour while reducing direct script-variable coupling

## Testing
- . .\scripts\kolosseum_pr_helpers.ps1
- Get-KolosseumRequiredPostMergeMainWorkflows
- Wait-KolosseumMainPostMergeRuns -Sha 5aaf07df920c286b67bf98b27be9a9bfbd642579.Trim() -PollSeconds 5 -TimeoutMinutes 15
- npm run dev:status