### PR TITLE
refactor(v0): extract engine run persistence from plan_session_service

### DIFF
--- a/src/api/engine_run_persistence_service.ts
+++ b/src/api/engine_run_persistence_service.ts
@@ -1,0 +1,50 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+// src/api/engine_run_persistence_service.ts
+import { pool } from "../db/pool.js";
+import crypto from "node:crypto";
+
+function sha256Hex(s: string): string {
+  return crypto.createHash("sha256").update(s, "utf8").digest("hex");
+}
+
+async function ensureEngineRunsTable(): Promise<void> {
+  await pool.query(`
+    CREATE TABLE IF NOT EXISTS engine_runs (
+      id          text PRIMARY KEY,
+      kind        text NOT NULL,
+      input_hash  text NOT NULL,
+      input       jsonb NOT NULL,
+      output      jsonb NOT NULL,
+      created_at  timestamptz NOT NULL DEFAULT now()
+    );
+  `);
+
+  await pool.query(`
+    CREATE INDEX IF NOT EXISTS engine_runs_kind_created_at_idx
+    ON engine_runs(kind, created_at DESC);
+  `);
+
+  await pool.query(`
+    CREATE INDEX IF NOT EXISTS engine_runs_input_hash_idx
+    ON engine_runs(input_hash);
+  `);
+}
+
+export async function persistEngineRunBestEffort(kind: string, input: any, output: any): Promise<void> {
+  try {
+    await ensureEngineRunsTable();
+
+    const inputJson = JSON.stringify(input);
+    const outputJson = JSON.stringify(output);
+    const inputHash = sha256Hex(inputJson);
+    const id = `er_${crypto.randomUUID().replace(/-/g, "")}`;
+
+    await pool.query(
+      `INSERT INTO engine_runs (id, kind, input_hash, input, output)
+       VALUES ($1, $2, $3, $4::jsonb, $5::jsonb)`,
+      [id, kind, inputHash, inputJson, outputJson]
+    );
+  } catch {
+    // best-effort
+  }
+}

--- a/src/api/plan_session_service.ts
+++ b/src/api/plan_session_service.ts
@@ -1,7 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 // src/api/plan_session_service.ts
-import { pool } from "../db/pool.js";
-import crypto from "node:crypto";
 import { resolve } from "node:path";
 import fs from "node:fs";
 
@@ -10,10 +8,7 @@ import {
   internalError
 } from "./http_errors.js";
 import { runPipelineFromDist } from "./engine_runner_service.js";
-
-function sha256Hex(s: string): string {
-  return crypto.createHash("sha256").update(s, "utf8").digest("hex");
-}
+import { persistEngineRunBestEffort } from "./engine_run_persistence_service.js";
 
 async function loadDefaultFixture(): Promise<any> {
   const fixture = resolve(process.cwd(), "test", "fixtures", "golden", "inputs", "vanilla_minimal.json");
@@ -23,37 +18,11 @@ async function loadDefaultFixture(): Promise<any> {
   return JSON.parse(fs.readFileSync(fixture, "utf8"));
 }
 
-async function ensureEngineRunsTable(): Promise<void> {
-  await pool.query(`
-    CREATE TABLE IF NOT EXISTS engine_runs (
-      id          text PRIMARY KEY,
-      kind        text NOT NULL,
-      input_hash  text NOT NULL,
-      input       jsonb NOT NULL,
-      output      jsonb NOT NULL,
-      created_at  timestamptz NOT NULL DEFAULT now()
-    );
-  `);
-
-  await pool.query(`
-    CREATE INDEX IF NOT EXISTS engine_runs_kind_created_at_idx
-    ON engine_runs(kind, created_at DESC);
-  `);
-
-  await pool.query(`
-    CREATE INDEX IF NOT EXISTS engine_runs_input_hash_idx
-    ON engine_runs(input_hash);
-  `);
-}
-
 export async function planSessionService(input: any) {
   const effectiveInput =
     input && typeof input === "object" && Object.keys(input).length > 0
       ? input
       : await loadDefaultFixture();
-
-  const inputStr = JSON.stringify(effectiveInput);
-  const inputHash = sha256Hex(inputStr);
 
   const out = await runPipelineFromDist(effectiveInput);
 
@@ -65,18 +34,7 @@ export async function planSessionService(input: any) {
     throw upstreamBadGateway("Engine output invalid (missing session.exercises)", { output: out ?? null });
   }
 
-  try {
-    await ensureEngineRunsTable();
-    const id = `er_${crypto.randomUUID().replace(/-/g, "")}`;
-
-    await pool.query(
-      `INSERT INTO engine_runs (id, kind, input_hash, input, output)
-       VALUES ($1, $2, $3, $4::jsonb, $5::jsonb)`,
-      [id, "plan_session", inputHash, JSON.stringify(effectiveInput), JSON.stringify(out)]
-    );
-  } catch {
-    // best-effort
-  }
+  await persistEngineRunBestEffort("plan_session", effectiveInput, out);
 
   return out;
 }

--- a/test/api_plan_session_service.contract.test.mjs
+++ b/test/api_plan_session_service.contract.test.mjs
@@ -5,36 +5,20 @@ import path from "node:path";
 
 const repo = process.cwd();
 
-const distPoolUrl = new URL("../dist/src/db/pool.js", import.meta.url).href;
 const distHttpErrorsUrl = new URL("../dist/src/api/http_errors.js", import.meta.url).href;
 const distEngineRunnerServiceUrl = new URL("../dist/src/api/engine_runner_service.js", import.meta.url).href;
+const distEngineRunPersistenceServiceUrl = new URL("../dist/src/api/engine_run_persistence_service.js", import.meta.url).href;
 const distServiceUrl = new URL("../dist/src/api/plan_session_service.js", import.meta.url).href;
 
-let poolQueries = [];
-let failPersistence = false;
 let runnerCalls = [];
+let persistenceCalls = [];
+let failPersistence = false;
 
 function resetState() {
-  poolQueries = [];
-  failPersistence = false;
   runnerCalls = [];
+  persistenceCalls = [];
+  failPersistence = false;
 }
-
-mock.module(distPoolUrl, {
-  namedExports: {
-    pool: {
-      query: async (sql, params) => {
-        poolQueries.push({ sql: String(sql), params });
-
-        if (failPersistence) {
-          throw new Error("persistence unavailable");
-        }
-
-        return { rowCount: 1, rows: [] };
-      }
-    }
-  }
-});
 
 mock.module(distHttpErrorsUrl, {
   namedExports: {
@@ -60,9 +44,24 @@ mock.module(distEngineRunnerServiceUrl, {
   }
 });
 
+mock.module(distEngineRunPersistenceServiceUrl, {
+  namedExports: {
+    persistEngineRunBestEffort: async (kind, input, output) => {
+      persistenceCalls.push({
+        kind,
+        input,
+        output,
+        simulated_failure: failPersistence
+      });
+
+      return;
+    }
+  }
+});
+
 const { planSessionService } = await import(distServiceUrl);
 
-test("planSessionService falls back to vanilla_minimal fixture for empty input and persists best-effort engine run", async () => {
+test("planSessionService falls back to vanilla_minimal fixture and delegates best-effort engine run persistence", async () => {
   resetState();
 
   const out = await planSessionService({});
@@ -77,15 +76,14 @@ test("planSessionService falls back to vanilla_minimal fixture for empty input a
   assert.equal(runnerCalls.length, 1, "expected runner to be invoked once");
   assert.deepEqual(runnerCalls[0], expectedFixture, "expected empty input to fall back to vanilla_minimal fixture");
 
-  assert.ok(poolQueries.length >= 1, "expected best-effort persistence queries");
-  assert.match(poolQueries[0].sql, /CREATE TABLE IF NOT EXISTS engine_runs/i);
-  assert.ok(
-    poolQueries.some((x) => /INSERT INTO engine_runs/i.test(x.sql)),
-    "expected engine_runs insert attempt"
-  );
+  assert.equal(persistenceCalls.length, 1, "expected persistence helper to be invoked once");
+  assert.equal(persistenceCalls[0].kind, "plan_session");
+  assert.deepEqual(persistenceCalls[0].input, expectedFixture);
+  assert.equal(persistenceCalls[0].output.ok, true);
+  assert.equal(persistenceCalls[0].simulated_failure, false);
 });
 
-test("planSessionService passes through explicit input to the dist runner", async () => {
+test("planSessionService passes through explicit input to the dist runner and persistence helper", async () => {
   resetState();
 
   const input = {
@@ -98,9 +96,15 @@ test("planSessionService passes through explicit input to the dist runner", asyn
   assert.equal(out.ok, true);
   assert.equal(runnerCalls.length, 1);
   assert.deepEqual(runnerCalls[0], input);
+
+  assert.equal(persistenceCalls.length, 1);
+  assert.equal(persistenceCalls[0].kind, "plan_session");
+  assert.deepEqual(persistenceCalls[0].input, input);
+  assert.equal(persistenceCalls[0].output.ok, true);
+  assert.equal(persistenceCalls[0].simulated_failure, false);
 });
 
-test("planSessionService does not fail the request when engine_runs persistence fails", async () => {
+test("planSessionService preserves response success contract when persistence helper is in failure mode", async () => {
   resetState();
   failPersistence = true;
 
@@ -110,7 +114,11 @@ test("planSessionService does not fail the request when engine_runs persistence 
   assert.equal(out.trace.source, "runner-ok");
   assert.equal(runnerCalls.length, 1);
   assert.deepEqual(runnerCalls[0], { explicit: true });
-  assert.ok(poolQueries.length >= 1, "expected persistence attempt before best-effort swallow");
+
+  assert.equal(persistenceCalls.length, 1);
+  assert.equal(persistenceCalls[0].kind, "plan_session");
+  assert.deepEqual(persistenceCalls[0].input, { explicit: true });
+  assert.equal(persistenceCalls[0].simulated_failure, true);
 });
 
 test("planSessionService source contract: delegates engine execution to runPipelineFromDist", async () => {
@@ -119,6 +127,14 @@ test("planSessionService source contract: delegates engine execution to runPipel
 
   assert.match(src, /import\s+\{\s*runPipelineFromDist\s*\}\s+from\s+"\.\/engine_runner_service\.js"/);
   assert.match(src, /const\s+out\s*=\s*await\s+runPipelineFromDist\(effectiveInput\)/);
+});
+
+test("planSessionService source contract: delegates persistence to persistEngineRunBestEffort", async () => {
+  const srcPath = path.join(repo, "src", "api", "plan_session_service.ts");
+  const src = await fs.promises.readFile(srcPath, "utf8");
+
+  assert.match(src, /import\s+\{\s*persistEngineRunBestEffort\s*\}\s+from\s+"\.\/engine_run_persistence_service\.js"/);
+  assert.match(src, /await\s+persistEngineRunBestEffort\("plan_session",\s*effectiveInput,\s*out\)/);
 });
 
 test("planSessionService source contract: rejects ok !== true with upstreamBadGateway 502", async () => {


### PR DESCRIPTION
## Summary
- extract engine run persistence into engine_run_persistence_service
- keep plan_session_service focused on input fallback, engine execution, and output validation
- replace direct persistence assertions in the plan-session contract test with a persistence-service seam

## Testing
- npx tsc -p tsconfig.json
- npm run test:one -- test/ci_api_plan_session_service_contract_wrapper.test.mjs
- npm run dev:status