### PR TITLE
test(v0): prove plan-session orchestration order and failure boundaries

### DIFF
--- a/test/api_plan_session_service.contract.test.mjs
+++ b/test/api_plan_session_service.contract.test.mjs
@@ -16,6 +16,21 @@ let persistenceCalls = [];
 let normalizationCalls = [];
 let normalizedInputValue = null;
 let validationCalls = [];
+let callLog = [];
+let normalizationError = null;
+let validationError = null;
+let validationShouldEnforceContract = false;
+let runnerReturnValue = null;
+
+function makeRunnerSuccessOutput() {
+  return {
+    ok: true,
+    session: {
+      exercises: [{ exercise_id: "ex1", source: "program" }]
+    },
+    trace: { source: "runner-ok" }
+  };
+}
 
 function resetState() {
   runnerCalls = [];
@@ -23,19 +38,26 @@ function resetState() {
   normalizationCalls = [];
   normalizedInputValue = null;
   validationCalls = [];
+  callLog = [];
+  normalizationError = null;
+  validationError = null;
+  validationShouldEnforceContract = false;
+  runnerReturnValue = makeRunnerSuccessOutput();
+}
+
+function isInvalidPlanSessionOutput(out) {
+  return !out || out.ok !== true ||
+    !out.session ||
+    !Array.isArray(out.session.exercises) ||
+    out.session.exercises.length < 1;
 }
 
 mock.module(distEngineRunnerServiceUrl, {
   namedExports: {
     runPipelineFromDist: async (input) => {
+      callLog.push("run");
       runnerCalls.push(input);
-      return {
-        ok: true,
-        session: {
-          exercises: [{ exercise_id: "ex1", source: "program" }]
-        },
-        trace: { source: "runner-ok" }
-      };
+      return runnerReturnValue;
     }
   }
 });
@@ -43,6 +65,7 @@ mock.module(distEngineRunnerServiceUrl, {
 mock.module(distEngineRunPersistenceServiceUrl, {
   namedExports: {
     persistEngineRunBestEffort: async (kind, input, output) => {
+      callLog.push("persist");
       persistenceCalls.push({ kind, input, output });
     }
   }
@@ -51,7 +74,11 @@ mock.module(distEngineRunPersistenceServiceUrl, {
 mock.module(distRequestNormalizationServiceUrl, {
   namedExports: {
     normalizePlanSessionRequest: async (input) => {
+      callLog.push("normalize");
       normalizationCalls.push(input);
+      if (normalizationError) {
+        throw normalizationError;
+      }
       return normalizedInputValue;
     }
   }
@@ -60,7 +87,16 @@ mock.module(distRequestNormalizationServiceUrl, {
 mock.module(distOutputValidationServiceUrl, {
   namedExports: {
     validatePlanSessionOutput: (out) => {
+      callLog.push("validate");
       validationCalls.push(out);
+
+      if (validationError) {
+        throw validationError;
+      }
+
+      if (validationShouldEnforceContract && isInvalidPlanSessionOutput(out)) {
+        throw new Error("validation rejected invalid output");
+      }
     }
   }
 });
@@ -93,6 +129,8 @@ test("planSessionService delegates request normalization, output validation, and
   assert.equal(persistenceCalls[0].kind, "plan_session");
   assert.deepEqual(persistenceCalls[0].input, normalizedInputValue);
   assert.equal(persistenceCalls[0].output.ok, true);
+
+  assert.deepEqual(callLog, ["normalize", "run", "validate", "persist"]);
 });
 
 test("planSessionService passes explicit input to request normalization helper", async () => {
@@ -121,6 +159,91 @@ test("planSessionService passes explicit input to request normalization helper",
   assert.equal(persistenceCalls[0].kind, "plan_session");
   assert.deepEqual(persistenceCalls[0].input, input);
   assert.equal(persistenceCalls[0].output.ok, true);
+
+  assert.deepEqual(callLog, ["normalize", "run", "validate", "persist"]);
+});
+
+test("planSessionService preserves orchestration order and returns the validated engine payload without drift", async () => {
+  resetState();
+
+  normalizedInputValue = {
+    user: { activity: "powerlifting" },
+    constraints: { available_equipment: ["barbell", "bench"] }
+  };
+  runnerReturnValue = {
+    ok: true,
+    session: {
+      exercises: [
+        { exercise_id: "squat", source: "program" },
+        { exercise_id: "bench_press", source: "program" }
+      ]
+    },
+    trace: { source: "runner-custom" }
+  };
+
+  const out = await planSessionService({ request: "raw" });
+
+  assert.deepEqual(callLog, ["normalize", "run", "validate", "persist"]);
+  assert.deepEqual(validationCalls[0], runnerReturnValue);
+  assert.deepEqual(persistenceCalls[0].output, runnerReturnValue);
+  assert.deepEqual(out, runnerReturnValue);
+});
+
+test("planSessionService failure boundary: normalization failure blocks runner, validation, and persistence", async () => {
+  resetState();
+
+  normalizationError = Object.assign(new Error("normalization failed"), { status: 500 });
+
+  await assert.rejects(
+    () => planSessionService({ broken: true }),
+    /normalization failed/
+  );
+
+  assert.deepEqual(callLog, ["normalize"]);
+  assert.equal(runnerCalls.length, 0);
+  assert.equal(validationCalls.length, 0);
+  assert.equal(persistenceCalls.length, 0);
+});
+
+test("planSessionService failure boundary: invalid runner output fails at validation and blocks persistence", async () => {
+  resetState();
+
+  normalizedInputValue = { user: { activity: "general_strength" } };
+  runnerReturnValue = {
+    ok: false,
+    session: {
+      exercises: []
+    },
+    trace: { source: "runner-invalid" }
+  };
+  validationShouldEnforceContract = true;
+
+  await assert.rejects(
+    () => planSessionService({ invalid_case: true }),
+    /validation rejected invalid output/
+  );
+
+  assert.deepEqual(callLog, ["normalize", "run", "validate"]);
+  assert.equal(runnerCalls.length, 1);
+  assert.equal(validationCalls.length, 1);
+  assert.equal(persistenceCalls.length, 0);
+});
+
+test("planSessionService failure boundary: explicit validation failure blocks persistence after runner", async () => {
+  resetState();
+
+  normalizedInputValue = { user: { activity: "general_strength" } };
+  validationError = Object.assign(new Error("validation exploded"), { status: 502 });
+
+  await assert.rejects(
+    () => planSessionService({ explicit_validation_failure: true }),
+    /validation exploded/
+  );
+
+  assert.deepEqual(callLog, ["normalize", "run", "validate"]);
+  assert.equal(runnerCalls.length, 1);
+  assert.equal(validationCalls.length, 1);
+  assert.equal(persistenceCalls.length, 0);
 });
 
 test("planSessionService source contract: delegates request normalization to normalizePlanSessionRequest", async () => {


### PR DESCRIPTION
## Summary
- prove plan-session orchestration order across request normalization, engine execution, output validation, and persistence
- prove failure boundaries so normalization or validation failures block downstream work
- prove the service returns the validated engine payload without drift

## Testing
- npx tsc -p tsconfig.json
- npm run test:one -- test/ci_api_plan_session_service_contract_wrapper.test.mjs
- npm run dev:status