### PR TITLE
test(v0): prove plan-session never mutates normalized input before runner or persistence

### DIFF
--- a/test/api_plan_session_service.contract.test.mjs
+++ b/test/api_plan_session_service.contract.test.mjs
@@ -26,6 +26,7 @@ let runnerError = null;
 let persistenceShouldRequireValidatedOutput = false;
 let validatedOutputRefs = new Set();
 let validationSnapshots = new Map();
+let normalizedInputSnapshots = new Map();
 
 function makeRunnerSuccessOutput() {
   return {
@@ -53,6 +54,7 @@ function resetState() {
   persistenceShouldRequireValidatedOutput = false;
   validatedOutputRefs = new Set();
   validationSnapshots = new Map();
+  normalizedInputSnapshots = new Map();
 }
 
 function isInvalidPlanSessionOutput(out) {
@@ -314,6 +316,56 @@ test("planSessionService invokes persistence exactly once for validated success 
   assert.equal(persistenceCalls[0].input, normalizedInputValue, "persistence should receive the normalized input exactly once");
   assert.equal(persistenceCalls[0].output, runnerReturnValue, "persistence should receive the validated output exactly once");
   assert.equal(out, runnerReturnValue, "success path should still return the validated runner object");
+});
+
+test("planSessionService never mutates normalized input before runner or persistence", async () => {
+  resetState();
+
+  normalizedInputValue = {
+    user: {
+      activity: "general_strength",
+      profile: {
+        training_age: "intermediate"
+      }
+    },
+    constraints: {
+      available_equipment: ["barbell", "bench", "dumbbell"],
+      session_minutes: 45
+    },
+    context: {
+      block_id: "block-normalized-input-stable"
+    }
+  };
+  normalizedInputSnapshots.set(
+    normalizedInputValue,
+    JSON.parse(JSON.stringify(normalizedInputValue))
+  );
+
+  runnerReturnValue = {
+    ok: true,
+    session: {
+      exercises: [
+        { exercise_id: "deadlift", source: "program" },
+        { exercise_id: "bench_press", source: "program" }
+      ]
+    },
+    trace: {
+      source: "runner-normalized-input-stable"
+    }
+  };
+
+  const out = await planSessionService({ normalized_input_identity_case: true });
+
+  assert.deepEqual(callLog, ["normalize", "run", "validate", "persist"]);
+  assert.equal(runnerCalls.length, 1, "runner should be invoked exactly once");
+  assert.equal(persistenceCalls.length, 1, "persistence should be invoked exactly once");
+  assert.equal(runnerCalls[0], normalizedInputValue, "runner should receive the exact normalized input object identity");
+  assert.equal(persistenceCalls[0].input, normalizedInputValue, "persistence should receive the exact normalized input object identity");
+
+  const normalizedSnapshot = normalizedInputSnapshots.get(normalizedInputValue);
+  assert.ok(normalizedSnapshot, "expected snapshot for normalized input");
+  assert.deepEqual(normalizedInputValue, normalizedSnapshot, "normalized input must remain unmutated after runner and persistence");
+  assert.equal(out, runnerReturnValue, "service should still return the validated runner object");
 });
 
 test("planSessionService never persists on any non-success response shape rejected by validation", async () => {


### PR DESCRIPTION
## Summary
- prove plan-session preserves normalized input identity through runner and persistence
- prove no downstream mutation is applied to normalized input on validated success paths
- tighten the input-side orchestration contract at the plan-session service seam

## Testing
- npx tsc -p tsconfig.json
- npm run test:one -- test/ci_api_plan_session_service_contract_wrapper.test.mjs
- npm run dev:status