### PR TITLE
test(v0): prove COMPLETE_STEP is rejected during RETURN_DECISION and accepted after RETURN_CONTINUE

### DIFF
--- a/test/vertical_slice.api_http_complete_step.e2e.test.mjs
+++ b/test/vertical_slice.api_http_complete_step.e2e.test.mjs
@@ -49,7 +49,6 @@ async function reserveEphemeralPort() {
     const server = net.createServer();
 
     server.unref();
-
     server.on("error", reject);
 
     server.listen(0, "127.0.0.1", () => {
@@ -72,11 +71,6 @@ async function reserveEphemeralPort() {
 }
 
 async function runNpm(scriptOrArgs, opts = {}) {
-  // Contract:
-  // - runNpm("db:schema")  => npm run db:schema
-  // - runNpm(["run","db:schema"]) => npm run db:schema
-  // Windows: wrap via cmd.exe to avoid npm(.cmd) spawn quirks.
-
   const env = { ...process.env, ...(opts.env || {}) };
 
   const tokens = Array.isArray(scriptOrArgs)
@@ -108,13 +102,34 @@ async function runNpm(scriptOrArgs, opts = {}) {
 }
 
 function loadPhase1FixtureOrThrow() {
-  // Canonical minimal Phase-1 contract fixture.
   const fixturePath = path.resolve(process.cwd(), "test", "fixtures", "golden", "inputs", "vanilla_minimal.json");
   if (!fs.existsSync(fixturePath)) throw new Error(`Missing fixture: ${fixturePath}`);
   return JSON.parse(fs.readFileSync(fixturePath, "utf8"));
 }
 
-test("Vertical slice (HTTP): COMPLETE_STEP expands to COMPLETE_EXERCISE + state exposes current_step", async (t) => {
+async function fetchState(baseUrl, sessionId) {
+  const res = await fetch(`${baseUrl}/sessions/${encodeURIComponent(sessionId)}/state`);
+  const body = await readJsonOnce(res);
+  assert.equal(res.status, 200, body.text);
+  assert.ok(body.json && typeof body.json === "object", "expected state object");
+  assert.ok("current_step" in body.json, "expected current_step field (top-level)");
+  assert.ok(body.json.trace && typeof body.json.trace === "object", "expected trace object");
+  assert.ok("return_decision_required" in body.json.trace, "expected trace.return_decision_required");
+  assert.equal(typeof body.json.trace.return_decision_required, "boolean", "expected trace.return_decision_required boolean");
+  return body.json;
+}
+
+async function postEvent(baseUrl, sessionId, event) {
+  const res = await fetch(`${baseUrl}/sessions/${encodeURIComponent(sessionId)}/events`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ event }),
+  });
+  const body = await readJsonOnce(res);
+  return { res, body };
+}
+
+test("Vertical slice (HTTP): COMPLETE_STEP is rejected during RETURN_DECISION and accepted immediately after RETURN_CONTINUE", async (t) => {
   const enabled = process.env.KOLOSSEUM_HTTP_E2E_COMPLETE_STEP === "1";
 
   if (!process.env.DATABASE_URL) {
@@ -133,7 +148,6 @@ test("Vertical slice (HTTP): COMPLETE_STEP expands to COMPLETE_EXERCISE + state 
 
   const port = await reserveEphemeralPort();
   const baseUrl = `http://127.0.0.1:${port}`;
-
   const { child, getLogs } = spawnServer(port);
 
   t.after(async () => {
@@ -146,7 +160,6 @@ test("Vertical slice (HTTP): COMPLETE_STEP expands to COMPLETE_EXERCISE + state 
   try {
     await waitForHealth(baseUrl);
 
-    // Tier-0 probe
     {
       const r = await fetch(`${baseUrl}/health`);
       const body = await readJsonOnce(r);
@@ -155,12 +168,10 @@ test("Vertical slice (HTTP): COMPLETE_STEP expands to COMPLETE_EXERCISE + state 
       assert.ok(typeof body.json?.version === "string" && body.json.version.length > 0);
     }
 
-    // Gate is opt-in.
     if (!enabled) return;
 
     const phase1_input = loadPhase1FixtureOrThrow();
 
-    // 1) Compile + create session
     const compile = await fetch(`${baseUrl}/blocks/compile?create_session=true`, {
       method: "POST",
       headers: { "content-type": "application/json" },
@@ -169,11 +180,9 @@ test("Vertical slice (HTTP): COMPLETE_STEP expands to COMPLETE_EXERCISE + state 
     const compileBody = await readJsonOnce(compile);
     assert.ok(compile.status === 200 || compile.status === 201, compileBody.text);
 
-    const compiled = compileBody.json;
-    assert.ok(typeof compiled?.session_id === "string" && compiled.session_id.length > 0, "expected session_id");
-    const sessionId = compiled.session_id;
+    const sessionId = compileBody.json?.session_id;
+    assert.ok(typeof sessionId === "string" && sessionId.length > 0, "expected session_id");
 
-    // 2) Start session (idempotent)
     const start = await fetch(`${baseUrl}/sessions/${encodeURIComponent(sessionId)}/start`, {
       method: "POST",
       headers: { "content-type": "application/json" },
@@ -182,58 +191,45 @@ test("Vertical slice (HTTP): COMPLETE_STEP expands to COMPLETE_EXERCISE + state 
     const startBody = await readJsonOnce(start);
     assert.equal(start.status, 200, startBody.text);
 
-    // 3) State must expose current_step at top-level (contract), plus trace.return_decision_required
-    const st1r = await fetch(`${baseUrl}/sessions/${encodeURIComponent(sessionId)}/state`);
-    const st1Body = await readJsonOnce(st1r);
-    assert.equal(st1r.status, 200, st1Body.text);
+    const st1 = await fetchState(baseUrl, sessionId);
 
-    const st1 = st1Body.json;
-    assert.ok(st1 && typeof st1 === "object", "expected state object");
-    assert.ok(st1.trace && typeof st1.trace === "object", "expected trace object");
-    assert.ok("return_decision_required" in st1.trace, "expected trace.return_decision_required");
-    assert.equal(typeof st1.trace.return_decision_required, "boolean", "expected trace.return_decision_required boolean");
-
-    assert.ok("current_step" in st1, "expected current_step field (top-level)");
     const beforeCompleted = Array.isArray(st1.completed_exercises) ? st1.completed_exercises.length : 0;
 
-    // If return gate is active, COMPLETE_STEP must be rejected (engine guard).
     if (st1.trace.return_decision_required === true) {
       assert.equal(st1.current_step?.type, "RETURN_DECISION");
       assert.ok(Array.isArray(st1.current_step?.options), "expected current_step.options");
 
-      const evBlocked = await fetch(`${baseUrl}/sessions/${encodeURIComponent(sessionId)}/events`, {
-        method: "POST",
-        headers: { "content-type": "application/json" },
-        body: JSON.stringify({ event: { type: "COMPLETE_STEP" } }),
-      });
-      const blockedBody = await readJsonOnce(evBlocked);
-      assert.equal(evBlocked.status, 400, blockedBody.text);
-      assert.match(blockedBody.text, /phase6_runtime_await_return_decision/, "expected failure token in body");
+      const blocked = await postEvent(baseUrl, sessionId, { type: "COMPLETE_STEP" });
+      assert.equal(blocked.res.status, 400, blocked.body.text);
+      assert.match(blocked.body.text, /phase6_runtime_await_return_decision/, "expected failure token in body");
+
+      const continueEvent = await postEvent(baseUrl, sessionId, { type: "RETURN_CONTINUE" });
+      assert.equal(continueEvent.res.status, 201, continueEvent.body.text);
+
+      const st2 = await fetchState(baseUrl, sessionId);
+      assert.equal(st2.trace.return_decision_required, false, "RETURN_CONTINUE should immediately ungate the state");
+      assert.equal(st2.current_step?.type, "EXERCISE", "expected EXERCISE step immediately after RETURN_CONTINUE");
+      assert.ok(st2.current_step?.exercise?.exercise_id, "expected exercise after RETURN_CONTINUE");
+
+      const accepted = await postEvent(baseUrl, sessionId, { type: "COMPLETE_STEP" });
+      assert.equal(accepted.res.status, 201, accepted.body.text);
+
+      const st3 = await fetchState(baseUrl, sessionId);
+      const afterCompleted = Array.isArray(st3.completed_exercises) ? st3.completed_exercises.length : 0;
+      assert.ok(
+        afterCompleted === beforeCompleted + 1,
+        `expected completed_exercises +1 after RETURN_CONTINUE then COMPLETE_STEP (before=${beforeCompleted}, after=${afterCompleted})`
+      );
       return;
     }
 
-    // Otherwise we must be on an EXERCISE step and COMPLETE_STEP should advance completion.
     assert.equal(st1.current_step?.type, "EXERCISE");
     assert.ok(st1.current_step?.exercise?.exercise_id, "expected current_step.exercise.exercise_id");
 
-    // 4) COMPLETE_STEP (server expands to COMPLETE_EXERCISE)
-    const ev = await fetch(`${baseUrl}/sessions/${encodeURIComponent(sessionId)}/events`, {
-      method: "POST",
-      headers: { "content-type": "application/json" },
-      body: JSON.stringify({ event: { type: "COMPLETE_STEP" } }),
-    });
-    const evBody = await readJsonOnce(ev);
-    assert.equal(ev.status, 201, evBody.text);
+    const accepted = await postEvent(baseUrl, sessionId, { type: "COMPLETE_STEP" });
+    assert.equal(accepted.res.status, 201, accepted.body.text);
 
-    // 5) State must show completed count increased deterministically (+1)
-    const st2r = await fetch(`${baseUrl}/sessions/${encodeURIComponent(sessionId)}/state`);
-    const st2Body = await readJsonOnce(st2r);
-    assert.equal(st2r.status, 200, st2Body.text);
-
-    const st2 = st2Body.json;
-    assert.ok(st2 && typeof st2 === "object", "expected state object");
-    assert.ok("current_step" in st2, "expected current_step field (top-level)");
-
+    const st2 = await fetchState(baseUrl, sessionId);
     const afterCompleted = Array.isArray(st2.completed_exercises) ? st2.completed_exercises.length : 0;
     assert.ok(
       afterCompleted === beforeCompleted + 1,


### PR DESCRIPTION
## Summary
- prove COMPLETE_STEP is rejected while the return decision gate is active
- prove RETURN_CONTINUE immediately ungates the session and allows COMPLETE_STEP
- keep the existing HTTP vertical-slice contract focused on engine-facing runtime behavior

## Testing
- npx tsc -p tsconfig.json
- npm run test:one -- test/vertical_slice.api_http_complete_step.e2e.test.mjs
- npm run dev:status