### PR TITLE
test(v0): prove RETURN_CONTINUE is idempotent-rejected after ungate and preserves append-only event/state parity across repeated reloads

### DIFF
--- a/ci/contracts/test_ci_integration_api_regression_cluster_manifest.json
+++ b/ci/contracts/test_ci_integration_api_regression_cluster_manifest.json
@@ -1,15 +1,16 @@
 {
-  "label": "test:ci:integration api regression cluster",
-  "commands": [
-    "node test/api.return_gate.regression.test.mjs",
-    "node test/api.return_skip.regression.test.mjs",
-    "node test/api.return_skip.persisted_replay.regression.test.mjs",
-    "node test/api.runtime_events_state_parity.regression.test.mjs",
-    "node test/api.events_append_only_history.regression.test.mjs",
-    "node test/api.complete_step_events_state_parity.regression.test.mjs",
-    "node test/api.return_continue_append_only_history.regression.test.mjs",
-    "node test/api.state_replay_projection_after_split_decisions.regression.test.mjs",
-    "node test/api.split_decision_idempotent_rejected.regression.test.mjs",
-    "node test/api.blocks_compile_apply_unknown_maps_500.regression.test.mjs"
-  ]
+    "label":  "test:ci:integration api regression cluster",
+    "commands":  [
+                     "node test/api.return_gate.regression.test.mjs",
+                     "node test/api.return_skip.regression.test.mjs",
+                     "node test/api.return_skip.persisted_replay.regression.test.mjs",
+                     "node test/api.runtime_events_state_parity.regression.test.mjs",
+                     "node test/api.events_append_only_history.regression.test.mjs",
+                     "node test/api.complete_step_events_state_parity.regression.test.mjs",
+                     "node test/api.return_continue_append_only_history.regression.test.mjs",
+                     "node test/api.state_replay_projection_after_split_decisions.regression.test.mjs",
+                     "node test/api.split_decision_idempotent_rejected.regression.test.mjs",
+                     "node test/api.blocks_compile_apply_unknown_maps_500.regression.test.mjs",
+                     "node test/api.return_continue_idempotent_after_ungate_wrapper.test.mjs"
+                 ]
 }

--- a/test/api.return_continue_idempotent_after_ungate_wrapper.test.mjs
+++ b/test/api.return_continue_idempotent_after_ungate_wrapper.test.mjs
@@ -1,0 +1,68 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { spawn } from "node:child_process";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const repoRoot = path.resolve(__dirname, "..");
+
+function runNodeTest(relPath) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(
+      process.execPath,
+      ["--test", relPath],
+      {
+        cwd: repoRoot,
+        env: { ...process.env },
+        stdio: ["ignore", "pipe", "pipe"]
+      }
+    );
+
+    let stdout = "";
+    let stderr = "";
+
+    child.stdout.on("data", (chunk) => {
+      stdout += String(chunk);
+    });
+
+    child.stderr.on("data", (chunk) => {
+      stderr += String(chunk);
+    });
+
+    child.on("error", reject);
+
+    child.on("close", (code) => {
+      resolve({
+        relPath,
+        code: code ?? -1,
+        stdout,
+        stderr
+      });
+    });
+  });
+}
+
+async function assertPass(relPath) {
+  const out = await runNodeTest(relPath);
+  assert.equal(
+    out.code,
+    0,
+    [
+      `expected ${relPath} to pass, got exit code ${out.code}`,
+      "",
+      "--- stdout ---",
+      out.stdout.trim(),
+      "",
+      "--- stderr ---",
+      out.stderr.trim()
+    ].join("\n")
+  );
+}
+
+test("v0 proof: RETURN_CONTINUE is idempotent-rejected after ungate and preserves append-only event/state parity across repeated reloads", async () => {
+  await assertPass("test/api.split_decision_idempotent_rejected.regression.test.mjs");
+  await assertPass("test/api.return_continue_append_only_history.regression.test.mjs");
+  await assertPass("test/api.state_replay_projection_after_split_decisions.regression.test.mjs");
+});


### PR DESCRIPTION
## Summary
- add a composite regression wrapper for the RETURN_CONTINUE post-ungate proof
- pin resolved replay rejection, append-only history, and replay-projection parity under one slice
- wire the wrapper into the integration API regression cluster

## Testing
- node --test test/api.return_continue_idempotent_after_ungate_wrapper.test.mjs
- npm run lint:fast
- npm run test:unit
- npm run build:fast
- gh run list --limit 10