### PR TITLE
test(v0): prove RETURN_CONTINUE replay rejection leaves /events and /state byte-stable across immediate re-post

### DIFF
--- a/test/api.split_decision_idempotent_rejected.regression.test.mjs
+++ b/test/api.split_decision_idempotent_rejected.regression.test.mjs
@@ -205,7 +205,14 @@ async function getEvents(baseUrl, sessionId, label) {
   return events;
 }
 
-async function runResolvedReplayScenario({ baseUrl, root, sessionStateCache, label, decisionType }) {
+async function runResolvedReplayScenario({
+  baseUrl,
+  root,
+  sessionStateCache,
+  label,
+  decisionType,
+  requireByteStableImmediateReplay = false
+}) {
   const sessionId = await createSession(baseUrl, root);
 
   const initialState = await getState(baseUrl, sessionId, `${label} initial`);
@@ -284,6 +291,9 @@ async function runResolvedReplayScenario({ baseUrl, root, sessionStateCache, lab
     `${label}: expected no return options after first ${decisionType}. trace=${JSON.stringify(acceptedState.json.trace)}`
   );
 
+  const acceptedEventsText = acceptedEvents.text;
+  const acceptedStateText = acceptedState.text;
+
   const replay = await httpJson(
     "POST",
     `${baseUrl}/sessions/${sessionId}/events`,
@@ -314,6 +324,19 @@ async function runResolvedReplayScenario({ baseUrl, root, sessionStateCache, lab
 
   const afterReplayEvents = await getEvents(baseUrl, sessionId, `${label} after replay events`);
   const afterReplayState = await getState(baseUrl, sessionId, `${label} after replay state`);
+
+  if (requireByteStableImmediateReplay) {
+    assert.equal(
+      afterReplayEvents.text,
+      acceptedEventsText,
+      `${label}: /events raw payload changed after rejected replay.\nbefore=${acceptedEventsText}\nafter=${afterReplayEvents.text}`
+    );
+    assert.equal(
+      afterReplayState.text,
+      acceptedStateText,
+      `${label}: /state raw payload changed after rejected replay.\nbefore=${acceptedStateText}\nafter=${afterReplayState.text}`
+    );
+  }
 
   assert.deepEqual(
     afterReplayEvents.json,
@@ -427,5 +450,101 @@ test("API regression: split decision commands are idempotent-rejected after gate
     sessionStateCache,
     label: "skip scenario",
     decisionType: "RETURN_SKIP"
+  });
+});
+
+test("API regression: RETURN_CONTINUE replay rejection leaves /events and /state byte-stable across immediate re-post", async (t) => {
+  const root = repoRoot();
+
+  const databaseUrl =
+    process.env.DATABASE_URL ??
+    "postgres://postgres:postgres@127.0.0.1:5432/kolosseum_test";
+
+  const buildEnv = {
+    ...process.env,
+    DATABASE_URL: databaseUrl,
+    PORT: "0"
+  };
+  delete buildEnv.SMOKE_NO_DB;
+
+  const previousDatabaseUrl = process.env.DATABASE_URL;
+  const previousSmokeNoDb = process.env.SMOKE_NO_DB;
+
+  process.env.DATABASE_URL = databaseUrl;
+  delete process.env.SMOKE_NO_DB;
+
+  t.after(() => {
+    if (typeof previousDatabaseUrl === "undefined") {
+      delete process.env.DATABASE_URL;
+    } else {
+      process.env.DATABASE_URL = previousDatabaseUrl;
+    }
+
+    if (typeof previousSmokeNoDb === "undefined") {
+      delete process.env.SMOKE_NO_DB;
+    } else {
+      process.env.SMOKE_NO_DB = previousSmokeNoDb;
+    }
+  });
+
+  const serverModulePath = await ensureBuiltDist(root, buildEnv);
+
+  {
+    const schemaScript = path.join(root, "scripts", "apply-schema.mjs");
+    const schema = spawnNode([schemaScript], { cwd: root, env: buildEnv });
+    const code = await new Promise((resolve) => schema.child.on("close", resolve));
+    if (code !== 0) {
+      throw new Error(
+        `apply-schema failed (code=${code}).\nstdout:\n${schema.stdout}\nstderr:\n${schema.stderr}`
+      );
+    }
+  }
+
+  const port = await getFreePort();
+  process.env.PORT = String(port);
+
+  const serverModuleUrl = pathToFileURL(serverModulePath).href + `?t=${Date.now()}`;
+  const cacheModuleUrl =
+    pathToFileURL(path.join(root, "dist", "src", "api", "session_state_cache.js")).href +
+    `?t=${Date.now()}`;
+
+  const [{ app }, { sessionStateCache }] = await Promise.all([
+    import(serverModuleUrl),
+    import(cacheModuleUrl)
+  ]);
+
+  assert.ok(app && typeof app.listen === "function", "expected dist server app.listen()");
+  assert.ok(
+    sessionStateCache && typeof sessionStateCache.clear === "function",
+    "expected dist sessionStateCache.clear()"
+  );
+
+  const baseUrl = `http://127.0.0.1:${port}`;
+
+  const srv = await new Promise((resolve, reject) => {
+    const instance = app.listen(port, "127.0.0.1", () => resolve(instance));
+    instance.on("error", reject);
+  });
+
+  t.after(async () => {
+    await new Promise((resolve) => {
+      try {
+        srv.close(() => resolve());
+      } catch {
+        resolve();
+      }
+    });
+    await delay(50);
+  });
+
+  await waitForHealth(baseUrl);
+
+  await runResolvedReplayScenario({
+    baseUrl,
+    root,
+    sessionStateCache,
+    label: "continue byte-stable immediate replay scenario",
+    decisionType: "RETURN_CONTINUE",
+    requireByteStableImmediateReplay: true
   });
 });


### PR DESCRIPTION
## Summary
- tighten the resolved RETURN_CONTINUE replay proof to assert raw /events and /state payload stability
- keep the existing semantic replay-rejection coverage for both RETURN_CONTINUE and RETURN_SKIP
- add a dedicated immediate re-post byte-stability regression for RETURN_CONTINUE

## Testing
- node --test test/api.split_decision_idempotent_rejected.regression.test.mjs
- npm run lint:fast
- npm run test:unit
- npm run build:fast
- gh run list --limit 10