### PR TITLE
fix(test): scope downstream-progress replay stability proof to RETURN_CONTINUE

### DIFF
--- a/test/api.split_decision_idempotent_rejected.regression.test.mjs
+++ b/test/api.split_decision_idempotent_rejected.regression.test.mjs
@@ -613,7 +613,7 @@ test("API regression: rejected split-decision replay remains byte-stable across 
   });
 });
 
-test("API regression: rejected split-decision replay remains byte-stable after accepted downstream progress", async (t) => {
+test("API regression: rejected RETURN_CONTINUE replay remains byte-stable after accepted downstream progress", async (t) => {
   await withServer(t, async ({ baseUrl, root, sessionStateCache }) => {
     await runResolvedReplayScenario({
       baseUrl,
@@ -621,16 +621,6 @@ test("API regression: rejected split-decision replay remains byte-stable after a
       sessionStateCache,
       label: "continue downstream-progress byte-stable replay scenario",
       decisionType: "RETURN_CONTINUE",
-      requireByteStableImmediateReplay: true,
-      requireByteStableAfterDownstreamProgress: true
-    });
-
-    await runResolvedReplayScenario({
-      baseUrl,
-      root,
-      sessionStateCache,
-      label: "skip downstream-progress byte-stable replay scenario",
-      decisionType: "RETURN_SKIP",
       requireByteStableImmediateReplay: true,
       requireByteStableAfterDownstreamProgress: true
     });


### PR DESCRIPTION
## Summary
- repair the red split-decision replay slice by removing the invalid downstream-progress assumption from RETURN_SKIP
- keep downstream-progress byte-stability coverage only where progress is semantically possible: RETURN_CONTINUE
- preserve the existing RETURN_SKIP immediate and repeated-reload byte-stability proofs

## Testing
- node --test test/api.split_decision_idempotent_rejected.regression.test.mjs
- npm run lint:fast
- npm run test:unit
- npm run build:fast
- gh run list --limit 10