### PR TITLE
revert: remove bad current-step identity replay proof from main

### DIFF
--- a/test/api.split_decision_idempotent_rejected.regression.test.mjs
+++ b/test/api.split_decision_idempotent_rejected.regression.test.mjs
@@ -319,68 +319,6 @@ function assertAppendOnlyEventCardinalityAndOrderingStable(
   );
 }
 
-function snapshotCurrentStepIdentity(statePayload) {
-  const currentStep = statePayload?.json?.current_step;
-  const trace = statePayload?.json?.trace;
-
-  assert.ok(currentStep && typeof currentStep === "object", "snapshotCurrentStepIdentity expected current_step object");
-  assert.ok(trace && typeof trace === "object", "snapshotCurrentStepIdentity expected trace object");
-
-  return {
-    current_step_type: currentStep?.type ?? null,
-    current_step_exercise_id: currentStep?.exercise?.exercise_id ?? null,
-    current_step_block_id: currentStep?.block_id ?? null,
-    trace_return_decision_required: trace?.return_decision_required ?? null,
-    trace_return_decision_options: Array.isArray(trace?.return_decision_options)
-      ? [...trace.return_decision_options]
-      : [],
-    trace_split_session_active: trace?.split_session_active ?? null
-  };
-}
-
-function assertCurrentStepIdentityAndTraceStable(
-  statePayload,
-  acceptedState,
-  acceptedIdentity,
-  label
-) {
-  const actualIdentity = snapshotCurrentStepIdentity(statePayload);
-
-  assert.deepEqual(
-    actualIdentity,
-    acceptedIdentity,
-    `${label}: current-step identity or trace contract changed.\nbefore=${JSON.stringify(acceptedIdentity)}\nafter=${JSON.stringify(actualIdentity)}`
-  );
-
-  assert.equal(
-    statePayload?.json?.current_step?.type ?? null,
-    acceptedState?.json?.current_step?.type ?? null,
-    `${label}: current_step.type drifted`
-  );
-
-  assert.equal(
-    statePayload?.json?.current_step?.exercise?.exercise_id ?? null,
-    acceptedState?.json?.current_step?.exercise?.exercise_id ?? null,
-    `${label}: current_step.exercise.exercise_id drifted`
-  );
-
-  assert.equal(
-    statePayload?.json?.trace?.return_decision_required ?? null,
-    acceptedState?.json?.trace?.return_decision_required ?? null,
-    `${label}: trace.return_decision_required drifted`
-  );
-
-  assert.deepEqual(
-    Array.isArray(statePayload?.json?.trace?.return_decision_options)
-      ? statePayload.json.trace.return_decision_options
-      : [],
-    Array.isArray(acceptedState?.json?.trace?.return_decision_options)
-      ? acceptedState.json.trace.return_decision_options
-      : [],
-    `${label}: trace.return_decision_options drifted`
-  );
-}
-
 async function runResolvedReplayScenario({
   baseUrl,
   root,
@@ -392,8 +330,7 @@ async function runResolvedReplayScenario({
   requireByteStableAfterDownstreamProgress = false,
   requireByteStableAcrossMixedReadPaths = false,
   requireByteStableAcrossAlternatingReadCyclesAfterMultipleRejectedReposts = false,
-  requireAppendOnlyEventCardinalityAndOrderingAcrossRepeatedInterleavedReads = false,
-  requireCurrentStepIdentityAndTraceContractAcrossRepeatedInterleavedReads = false
+  requireAppendOnlyEventCardinalityAndOrderingAcrossRepeatedInterleavedReads = false
 }) {
   const sessionId = await createSession(baseUrl, root);
 
@@ -541,7 +478,6 @@ async function runResolvedReplayScenario({
   const acceptedEventsText = acceptedEvents.text;
   const acceptedStateText = acceptedState.text;
   const acceptedEventOrdering = snapshotEventOrdering(acceptedEvents);
-  const acceptedCurrentStepIdentity = snapshotCurrentStepIdentity(acceptedState);
 
   const replay = await httpJson(
     "POST",
@@ -680,56 +616,6 @@ async function runResolvedReplayScenario({
     }
   }
 
-  if (requireCurrentStepIdentityAndTraceContractAcrossRepeatedInterleavedReads) {
-    for (let i = 2; i <= 4; i += 1) {
-      const replayAgain = await httpJson(
-        "POST",
-        `${baseUrl}/sessions/${sessionId}/events`,
-        { event: { type: decisionType } }
-      );
-      assertRejectedResolvedReplay(replayAgain, { label, decisionType, ordinal: i });
-    }
-
-    for (let cycle = 1; cycle <= 3; cycle += 1) {
-      sessionStateCache.clear();
-
-      const interleavedStateA = await getState(
-        baseUrl,
-        sessionId,
-        `${label} current-step cycle ${cycle} state A`
-      );
-      const interleavedEvents = await getEvents(
-        baseUrl,
-        sessionId,
-        `${label} current-step cycle ${cycle} events`
-      );
-      const interleavedStateB = await getState(
-        baseUrl,
-        sessionId,
-        `${label} current-step cycle ${cycle} state B`
-      );
-
-      assertCurrentStepIdentityAndTraceStable(
-        interleavedStateA,
-        acceptedState,
-        acceptedCurrentStepIdentity,
-        `${label}: current-step cycle ${cycle} first /state`
-      );
-      assertAppendOnlyEventCardinalityAndOrderingStable(
-        interleavedEvents,
-        acceptedEvents,
-        acceptedEventOrdering,
-        `${label}: current-step cycle ${cycle} /events`
-      );
-      assertCurrentStepIdentityAndTraceStable(
-        interleavedStateB,
-        acceptedState,
-        acceptedCurrentStepIdentity,
-        `${label}: current-step cycle ${cycle} second /state`
-      );
-    }
-  }
-
   sessionStateCache.clear();
 
   const afterReplayEvents = await getEvents(baseUrl, sessionId, `${label} after replay events`);
@@ -770,15 +656,6 @@ async function runResolvedReplayScenario({
     );
   }
 
-  if (requireCurrentStepIdentityAndTraceContractAcrossRepeatedInterleavedReads) {
-    assertCurrentStepIdentityAndTraceStable(
-      afterReplayState,
-      acceptedState,
-      acceptedCurrentStepIdentity,
-      `${label}: final /state after repeated interleaved reads`
-    );
-  }
-
   if (requireByteStableAcrossRepeatedReloads) {
     sessionStateCache.clear();
 
@@ -812,15 +689,6 @@ async function runResolvedReplayScenario({
         acceptedEvents,
         acceptedEventOrdering,
         `${label}: second reload /events after repeated interleaved reads`
-      );
-    }
-
-    if (requireCurrentStepIdentityAndTraceContractAcrossRepeatedInterleavedReads) {
-      assertCurrentStepIdentityAndTraceStable(
-        secondReloadState,
-        acceptedState,
-        acceptedCurrentStepIdentity,
-        `${label}: second reload /state after repeated interleaved reads`
       );
     }
   }
@@ -1069,34 +937,6 @@ test("API regression: rejected split-decision replay preserves append-only event
       requireByteStableImmediateReplay: true,
       requireByteStableAcrossRepeatedReloads: true,
       requireAppendOnlyEventCardinalityAndOrderingAcrossRepeatedInterleavedReads: true
-    });
-  });
-});
-
-test("API regression: rejected split-decision replay preserves current-step identity and trace contract across repeated interleaved reads", async (t) => {
-  await withServer(t, async ({ baseUrl, root, sessionStateCache }) => {
-    await runResolvedReplayScenario({
-      baseUrl,
-      root,
-      sessionStateCache,
-      label: "continue current-step identity and trace contract scenario",
-      decisionType: "RETURN_CONTINUE",
-      requireByteStableImmediateReplay: true,
-      requireByteStableAcrossRepeatedReloads: true,
-      requireAppendOnlyEventCardinalityAndOrderingAcrossRepeatedInterleavedReads: true,
-      requireCurrentStepIdentityAndTraceContractAcrossRepeatedInterleavedReads: true
-    });
-
-    await runResolvedReplayScenario({
-      baseUrl,
-      root,
-      sessionStateCache,
-      label: "skip current-step identity and trace contract scenario",
-      decisionType: "RETURN_SKIP",
-      requireByteStableImmediateReplay: true,
-      requireByteStableAcrossRepeatedReloads: true,
-      requireAppendOnlyEventCardinalityAndOrderingAcrossRepeatedInterleavedReads: true,
-      requireCurrentStepIdentityAndTraceContractAcrossRepeatedInterleavedReads: true
     });
   });
 });


### PR DESCRIPTION
## Summary
- revert PR #199 because the new current-step identity replay proof made an invalid assumption that current_step must always exist
- restore main to the last known-good split-decision replay regression coverage
- unblock green/integration and return trunk to a validated state before re-cutting the proof with a nullable current-step identity model

## Testing
- node --test test/api.split_decision_idempotent_rejected.regression.test.mjs
- npm run lint:fast
- npm run test:unit
- npm run build:fast
- gh run list --limit 10