### PR TITLE
test(v0): prove rejected RETURN_SKIP replay preserves terminal-state shape and no-resurrection invariants under fresh uncached reload after merge-to-main parity

### DIFF
--- a/test/api.split_decision_idempotent_rejected.regression.test.mjs
+++ b/test/api.split_decision_idempotent_rejected.regression.test.mjs
@@ -1342,6 +1342,23 @@ test("API regression: rejected split-decision replay preserves normalized curren
   });
 });
 
+test("API regression: rejected RETURN_SKIP replay preserves terminal-state shape and no-resurrection invariants under fresh uncached reload after merge-to-main parity", async (t) => {
+  await withServer(t, async ({ baseUrl, root, sessionStateCache }) => {
+    await runResolvedReplayScenario({
+      baseUrl,
+      root,
+      sessionStateCache,
+      label: "skip terminal-state shape fresh uncached reload parity scenario",
+      decisionType: "RETURN_SKIP",
+      requireByteStableImmediateReplay: true,
+      requireByteStableAcrossRepeatedReloads: true,
+      requireAppendOnlyEventCardinalityAndOrderingAcrossRepeatedInterleavedReads: true,
+      requireNormalizedCurrentStepIdentityAndTraceContractAcrossRepeatedInterleavedReads: true,
+      requireTerminalStateShapeAndNoResurrectionAcrossRepeatedInterleavedReads: true
+    });
+  });
+});
+
 test("API regression: rejected split-decision replay preserves terminal-state shape and no-resurrection invariants across repeated interleaved reads", async (t) => {
   await withServer(t, async ({ baseUrl, root, sessionStateCache }) => {
     await runResolvedReplayScenario({


### PR DESCRIPTION
## Summary
- add a focused regression proof for rejected RETURN_SKIP replay after terminal state is reached
- prove terminal-state shape and no-resurrection invariants remain stable under a fresh uncached reload path after merge-to-main parity
- keep the broader combined terminal-state replay proof while adding a standalone RETURN_SKIP parity-focused regression

## Testing
- node --test test/api.split_decision_idempotent_rejected.regression.test.mjs
- npm run lint:fast
- npm run test:unit
- npm run build:fast
- gh run list --limit 10