### PR TITLE
test(v0): prove compile-created session flow preserves deterministic terminal contract across full operator path

### DIFF
--- a/test/api.split_decision_idempotent_rejected.regression.test.mjs
+++ b/test/api.split_decision_idempotent_rejected.regression.test.mjs
@@ -1502,6 +1502,37 @@ test("API regression: rejected resolved split-decision replays preserve terminal
     });
   });
 });
+test("API regression: compile-created session flow preserves deterministic terminal contract across full operator path", async (t) => {
+  await withServer(t, async ({ baseUrl, root, sessionStateCache }) => {
+    await runResolvedReplayScenario({
+      baseUrl,
+      root,
+      sessionStateCache,
+      label: "compile-created session continue deterministic terminal contract full operator path scenario",
+      decisionType: "RETURN_CONTINUE",
+      requireByteStableImmediateReplay: true,
+      requireByteStableAcrossRepeatedReloads: true,
+      requireAppendOnlyEventCardinalityAndOrderingAcrossRepeatedInterleavedReads: true,
+      requireNormalizedCurrentStepIdentityAndTraceContractAcrossRepeatedInterleavedReads: true,
+      requireTerminalStateShapeAndNoResurrectionAcrossRepeatedInterleavedReads: true,
+      requireTerminalParityAcrossAlternatingFreshProcessRestarts: true
+    });
+
+    await runResolvedReplayScenario({
+      baseUrl,
+      root,
+      sessionStateCache,
+      label: "compile-created session skip deterministic terminal contract full operator path scenario",
+      decisionType: "RETURN_SKIP",
+      requireByteStableImmediateReplay: true,
+      requireByteStableAcrossRepeatedReloads: true,
+      requireAppendOnlyEventCardinalityAndOrderingAcrossRepeatedInterleavedReads: true,
+      requireNormalizedCurrentStepIdentityAndTraceContractAcrossRepeatedInterleavedReads: true,
+      requireTerminalStateShapeAndNoResurrectionAcrossRepeatedInterleavedReads: true,
+      requireTerminalParityAcrossAlternatingFreshProcessRestarts: true
+    });
+  });
+});
 test("API regression: rejected split-decision replay preserves terminal-state shape and no-resurrection invariants across repeated interleaved reads", async (t) => {
   await withServer(t, async ({ baseUrl, root, sessionStateCache }) => {
     await runResolvedReplayScenario({


### PR DESCRIPTION
## Summary
- add a focused regression proof that compile-created sessions preserve a deterministic terminal contract across the full operator path
- prove both RETURN_CONTINUE and RETURN_SKIP flows remain byte-stable, append-only, and terminal-shape-safe from compile-created session through terminal replay reads
- reuse the fresh-process terminal parity coverage so this slice locks the compile -> create_session -> operator path end to end

## Testing
- node --test test/api.split_decision_idempotent_rejected.regression.test.mjs
- npm run lint:fast
- npm run test:unit
- npm run build:fast
- gh run list --limit 10