### PR TITLE
test(v0): prove compile-created session flow preserves terminal no-resurrection invariants across alternating /state -> /events -> /state cycles after downstream progress

### DIFF
--- a/test/api.split_decision_idempotent_rejected.regression.test.mjs
+++ b/test/api.split_decision_idempotent_rejected.regression.test.mjs
@@ -1533,6 +1533,39 @@ test("API regression: compile-created session flow preserves deterministic appen
     });
   });
 });
+test("API regression: compile-created session flow preserves terminal no-resurrection invariants across alternating /state -> /events -> /state cycles after downstream progress", async (t) => {
+  await withServer(t, async ({ baseUrl, root, sessionStateCache }) => {
+    await runResolvedReplayScenario({
+      baseUrl,
+      root,
+      sessionStateCache,
+      label: "compile-created session continue terminal no-resurrection alternating read cycles after downstream progress scenario",
+      decisionType: "RETURN_CONTINUE",
+      requireByteStableImmediateReplay: true,
+      requireByteStableAcrossRepeatedReloads: true,
+      requireByteStableAfterDownstreamProgress: true,
+      requireByteStableAcrossAlternatingReadCyclesAfterMultipleRejectedReposts: true,
+      requireAppendOnlyEventCardinalityAndOrderingAcrossRepeatedInterleavedReads: true,
+      requireNormalizedCurrentStepIdentityAndTraceContractAcrossRepeatedInterleavedReads: true,
+      requireTerminalStateShapeAndNoResurrectionAcrossRepeatedInterleavedReads: true
+    });
+
+    await runResolvedReplayScenario({
+      baseUrl,
+      root,
+      sessionStateCache,
+      label: "compile-created session skip terminal no-resurrection alternating read cycles after downstream progress scenario",
+      decisionType: "RETURN_SKIP",
+      requireByteStableImmediateReplay: true,
+      requireByteStableAcrossRepeatedReloads: true,
+      requireByteStableAfterDownstreamProgress: true,
+      requireByteStableAcrossAlternatingReadCyclesAfterMultipleRejectedReposts: true,
+      requireAppendOnlyEventCardinalityAndOrderingAcrossRepeatedInterleavedReads: true,
+      requireNormalizedCurrentStepIdentityAndTraceContractAcrossRepeatedInterleavedReads: true,
+      requireTerminalStateShapeAndNoResurrectionAcrossRepeatedInterleavedReads: true
+    });
+  });
+});
 test("API regression: compile-created session flow preserves deterministic terminal parity across alternating fresh process restarts after downstream progress", async (t) => {
   await withServer(t, async ({ baseUrl, root, sessionStateCache }) => {
     await runResolvedReplayScenario({


### PR DESCRIPTION
## Summary
- add a focused regression proof that compile-created sessions preserve terminal no-resurrection invariants across alternating /state -> /events -> /state cycles after accepted downstream progress
- prove both RETURN_CONTINUE and RETURN_SKIP flows remain terminal-shape-safe, append-only, and byte-stable under repeated alternating read cycles after the operator path has already advanced downstream
- extend compile-created session coverage by combining downstream-progress replay hardening with alternating interleaved read-cycle terminal safety on the real operator path

## Testing
- node --test test/api.split_decision_idempotent_rejected.regression.test.mjs
- npm run lint:fast
- npm run test:unit
- npm run build:fast
- gh run list --limit 10