### PR TITLE
test(v0): prove compile-created session flow preserves normalized current-step identity and trace contract across alternating fresh process restarts after downstream progress

### DIFF
--- a/test/api.split_decision_idempotent_rejected.regression.test.mjs
+++ b/test/api.split_decision_idempotent_rejected.regression.test.mjs
@@ -1566,6 +1566,35 @@ test("API regression: compile-created session flow preserves terminal no-resurre
     });
   });
 });
+test("API regression: compile-created session flow preserves normalized current-step identity and trace contract across alternating fresh process restarts after downstream progress", async (t) => {
+  await withServer(t, async ({ baseUrl, root, sessionStateCache }) => {
+    await runResolvedReplayScenario({
+      baseUrl,
+      root,
+      sessionStateCache,
+      label: "compile-created session continue current-step identity and trace contract alternating fresh restarts after downstream progress scenario",
+      decisionType: "RETURN_CONTINUE",
+      requireByteStableImmediateReplay: true,
+      requireByteStableAcrossRepeatedReloads: true,
+      requireByteStableAfterDownstreamProgress: true,
+      requireByteStableAcrossAlternatingFreshProcessRestartsAfterDownstreamProgress: true,
+      requireNormalizedCurrentStepIdentityAndTraceContractAcrossAlternatingFreshProcessRestartsAfterDownstreamProgress: true
+    });
+
+    await runResolvedReplayScenario({
+      baseUrl,
+      root,
+      sessionStateCache,
+      label: "compile-created session skip current-step identity and trace contract alternating fresh restarts after downstream progress scenario",
+      decisionType: "RETURN_SKIP",
+      requireByteStableImmediateReplay: true,
+      requireByteStableAcrossRepeatedReloads: true,
+      requireByteStableAfterDownstreamProgress: true,
+      requireByteStableAcrossAlternatingFreshProcessRestartsAfterDownstreamProgress: true,
+      requireNormalizedCurrentStepIdentityAndTraceContractAcrossAlternatingFreshProcessRestartsAfterDownstreamProgress: true
+    });
+  });
+});
 test("API regression: compile-created session flow preserves deterministic terminal parity across alternating fresh process restarts after downstream progress", async (t) => {
   await withServer(t, async ({ baseUrl, root, sessionStateCache }) => {
     await runResolvedReplayScenario({


### PR DESCRIPTION
## Summary
- add a focused regression proof that compile-created sessions preserve normalized current-step identity and runtime trace contract across alternating fresh process restarts after accepted downstream progress
- prove both RETURN_CONTINUE and RETURN_SKIP flows remain restart-stable after downstream operator progress, without current-step drift or trace-shape drift
- extend compile-created session replay hardening from terminal/no-resurrection coverage into fresh-restart identity and runtime trace parity on the real operator path

## Testing
- node --test test/api.split_decision_idempotent_rejected.regression.test.mjs
- npm run lint:fast
- npm run test:unit
- npm run build:fast
- gh run list --limit 10