### PR TITLE
test(v0): prove compile-created session flow preserves no-resurrection and terminal-shape invariants across alternating fresh process restarts after downstream progress

### DIFF
--- a/test/api.split_decision_idempotent_rejected.regression.test.mjs
+++ b/test/api.split_decision_idempotent_rejected.regression.test.mjs
@@ -1653,6 +1653,35 @@ test("API regression: compile-created session flow preserves byte-stable /state 
     });
   });
 });
+test("API regression: compile-created session flow preserves no-resurrection and terminal-shape invariants across alternating fresh process restarts after downstream progress", async (t) => {
+  await withServer(t, async ({ baseUrl, root, sessionStateCache }) => {
+    await runResolvedReplayScenario({
+      baseUrl,
+      root,
+      sessionStateCache,
+      label: "compile-created session continue no-resurrection terminal-shape alternating fresh restarts after downstream progress scenario",
+      decisionType: "RETURN_CONTINUE",
+      requireByteStableImmediateReplay: true,
+      requireByteStableAcrossRepeatedReloads: true,
+      requireByteStableAfterDownstreamProgress: true,
+      requireByteStableAcrossAlternatingFreshProcessRestartsAfterDownstreamProgress: true,
+      requireTerminalStateShapeAndNoResurrectionAcrossAlternatingFreshProcessRestartsAfterDownstreamProgress: true
+    });
+
+    await runResolvedReplayScenario({
+      baseUrl,
+      root,
+      sessionStateCache,
+      label: "compile-created session skip no-resurrection terminal-shape alternating fresh restarts after downstream progress scenario",
+      decisionType: "RETURN_SKIP",
+      requireByteStableImmediateReplay: true,
+      requireByteStableAcrossRepeatedReloads: true,
+      requireByteStableAfterDownstreamProgress: true,
+      requireByteStableAcrossAlternatingFreshProcessRestartsAfterDownstreamProgress: true,
+      requireTerminalStateShapeAndNoResurrectionAcrossAlternatingFreshProcessRestartsAfterDownstreamProgress: true
+    });
+  });
+});
 test("API regression: compile-created session flow preserves deterministic terminal parity across alternating fresh process restarts after downstream progress", async (t) => {
   await withServer(t, async ({ baseUrl, root, sessionStateCache }) => {
     await runResolvedReplayScenario({


### PR DESCRIPTION
## Summary
- add a focused regression proof that compile-created sessions preserve no-resurrection and terminal-shape invariants across alternating fresh process restarts after accepted downstream progress
- prove both RETURN_CONTINUE and RETURN_SKIP flows remain restart-stable on the real operator path without terminal-shape drift or any resurrection of already-terminalized work
- extend compile-created session replay hardening from byte-stability, event-log integrity, and identity/trace coverage into explicit terminal no-resurrection guarantees after downstream progress

## Testing
- node --test test/api.split_decision_idempotent_rejected.regression.test.mjs
- npm run lint:fast
- npm run test:unit
- npm run build:fast
- gh run list --limit 10