### PR TITLE
test(v0): prove compile-created session flow preserves full terminal contract across alternating /state -> /events -> /state read cycles after downstream progress

### DIFF
--- a/test/api.split_decision_idempotent_rejected.regression.test.mjs
+++ b/test/api.split_decision_idempotent_rejected.regression.test.mjs
@@ -1711,6 +1711,33 @@ test("API regression: compile-created session flow preserves full terminal contr
     });
   });
 });
+test("API regression: compile-created session flow preserves full terminal contract across alternating /state -> /events -> /state read cycles after downstream progress", async (t) => {
+  await withServer(t, async ({ baseUrl, root, sessionStateCache }) => {
+    await runResolvedReplayScenario({
+      baseUrl,
+      root,
+      sessionStateCache,
+      label: "compile-created session continue full terminal contract alternating state events state cycles after downstream progress scenario",
+      decisionType: "RETURN_CONTINUE",
+      requireByteStableImmediateReplay: true,
+      requireByteStableAcrossRepeatedReloads: true,
+      requireByteStableAfterDownstreamProgress: true,
+      requireFullTerminalContractAcrossAlternatingStateEventsStateReadCyclesAfterDownstreamProgress: true
+    });
+
+    await runResolvedReplayScenario({
+      baseUrl,
+      root,
+      sessionStateCache,
+      label: "compile-created session skip full terminal contract alternating state events state cycles after downstream progress scenario",
+      decisionType: "RETURN_SKIP",
+      requireByteStableImmediateReplay: true,
+      requireByteStableAcrossRepeatedReloads: true,
+      requireByteStableAfterDownstreamProgress: true,
+      requireFullTerminalContractAcrossAlternatingStateEventsStateReadCyclesAfterDownstreamProgress: true
+    });
+  });
+});
 test("API regression: compile-created session flow preserves deterministic terminal parity across alternating fresh process restarts after downstream progress", async (t) => {
   await withServer(t, async ({ baseUrl, root, sessionStateCache }) => {
     await runResolvedReplayScenario({


### PR DESCRIPTION
## Summary
- add a focused regression proof that compile-created sessions preserve the full terminal contract across alternating /state -> /events -> /state read cycles after accepted downstream progress
- prove both RETURN_CONTINUE and RETURN_SKIP flows remain stable on the live operator path without terminal drift, resurrection, snapshot drift, identity drift, ordering drift, or contract-shape drift under repeated interleaved reads
- close the adjacent same-process mixed-endpoint seam after the fresh-restart full-terminal-contract coverage already merged

## Testing
- node --test test/api.split_decision_idempotent_rejected.regression.test.mjs
- npm run lint:fast
- npm run test:unit
- npm run build:fast
- gh run list --limit 10