### PR TITLE
test(v0): prove compile-created session flow preserves append-only event cardinality and ordering across alternating /state -> /events -> /state read cycles after downstream progress

### DIFF
--- a/test/api.split_decision_idempotent_rejected.regression.test.mjs
+++ b/test/api.split_decision_idempotent_rejected.regression.test.mjs
@@ -1738,6 +1738,33 @@ test("API regression: compile-created session flow preserves full terminal contr
     });
   });
 });
+test("API regression: compile-created session flow preserves append-only event cardinality and ordering across alternating /state -> /events -> /state read cycles after downstream progress", async (t) => {
+  await withServer(t, async ({ baseUrl, root, sessionStateCache }) => {
+    await runResolvedReplayScenario({
+      baseUrl,
+      root,
+      sessionStateCache,
+      label: "compile-created session continue append-only event ordering alternating state events state cycles after downstream progress scenario",
+      decisionType: "RETURN_CONTINUE",
+      requireByteStableImmediateReplay: true,
+      requireByteStableAcrossRepeatedReloads: true,
+      requireByteStableAfterDownstreamProgress: true,
+      requireAppendOnlyEventCardinalityAndOrderingAcrossAlternatingStateEventsStateReadCyclesAfterDownstreamProgress: true
+    });
+
+    await runResolvedReplayScenario({
+      baseUrl,
+      root,
+      sessionStateCache,
+      label: "compile-created session skip append-only event ordering alternating state events state cycles after downstream progress scenario",
+      decisionType: "RETURN_SKIP",
+      requireByteStableImmediateReplay: true,
+      requireByteStableAcrossRepeatedReloads: true,
+      requireByteStableAfterDownstreamProgress: true,
+      requireAppendOnlyEventCardinalityAndOrderingAcrossAlternatingStateEventsStateReadCyclesAfterDownstreamProgress: true
+    });
+  });
+});
 test("API regression: compile-created session flow preserves deterministic terminal parity across alternating fresh process restarts after downstream progress", async (t) => {
   await withServer(t, async ({ baseUrl, root, sessionStateCache }) => {
     await runResolvedReplayScenario({


### PR DESCRIPTION
## Summary
- add a focused regression proof that compile-created sessions preserve append-only event cardinality and ordering across alternating /state -> /events -> /state read cycles after accepted downstream progress
- prove both RETURN_CONTINUE and RETURN_SKIP flows remain stable on the live operator path without event-count drift, dropped events, duplicate events, or ordering drift under repeated interleaved reads
- close the adjacent same-process event-log integrity seam next to the mixed-endpoint full-terminal-contract coverage already merged

## Testing
- node --test test/api.split_decision_idempotent_rejected.regression.test.mjs
- npm run lint:fast
- npm run test:unit
- npm run build:fast
- gh run list --limit 10