### PR TITLE
test(v0): prove compile-created session flow preserves byte-stable /state and /events snapshots across alternating /state -> /events -> /state read cycles after downstream progress

### DIFF
--- a/test/api.split_decision_idempotent_rejected.regression.test.mjs
+++ b/test/api.split_decision_idempotent_rejected.regression.test.mjs
@@ -1765,6 +1765,33 @@ test("API regression: compile-created session flow preserves append-only event c
     });
   });
 });
+test("API regression: compile-created session flow preserves byte-stable /state and /events snapshots across alternating /state -> /events -> /state read cycles after downstream progress", async (t) => {
+  await withServer(t, async ({ baseUrl, root, sessionStateCache }) => {
+    await runResolvedReplayScenario({
+      baseUrl,
+      root,
+      sessionStateCache,
+      label: "compile-created session continue byte-stable state and events alternating state events state cycles after downstream progress scenario",
+      decisionType: "RETURN_CONTINUE",
+      requireByteStableImmediateReplay: true,
+      requireByteStableAcrossRepeatedReloads: true,
+      requireByteStableAfterDownstreamProgress: true,
+      requireByteStableStateAndEventsSnapshotsAcrossAlternatingStateEventsStateReadCyclesAfterDownstreamProgress: true
+    });
+
+    await runResolvedReplayScenario({
+      baseUrl,
+      root,
+      sessionStateCache,
+      label: "compile-created session skip byte-stable state and events alternating state events state cycles after downstream progress scenario",
+      decisionType: "RETURN_SKIP",
+      requireByteStableImmediateReplay: true,
+      requireByteStableAcrossRepeatedReloads: true,
+      requireByteStableAfterDownstreamProgress: true,
+      requireByteStableStateAndEventsSnapshotsAcrossAlternatingStateEventsStateReadCyclesAfterDownstreamProgress: true
+    });
+  });
+});
 test("API regression: compile-created session flow preserves deterministic terminal parity across alternating fresh process restarts after downstream progress", async (t) => {
   await withServer(t, async ({ baseUrl, root, sessionStateCache }) => {
     await runResolvedReplayScenario({


### PR DESCRIPTION
## Summary
- add a focused regression proof that compile-created sessions preserve byte-stable /state and /events snapshots across alternating /state -> /events -> /state read cycles after accepted downstream progress
- prove both RETURN_CONTINUE and RETURN_SKIP flows remain stable on the live operator path without response-byte drift, state-snapshot drift, or events-snapshot drift under repeated interleaved reads
- close the adjacent same-process wire-level snapshot seam next to the mixed-endpoint event-log and full-terminal-contract coverage already merged

## Testing
- node --test test/api.split_decision_idempotent_rejected.regression.test.mjs
- npm run lint:fast
- npm run test:unit
- npm run build:fast
- gh run list --limit 10