### PR TITLE
test(v0): prove compile-created session flow preserves normalized current-step identity and trace contract across alternating /state -> /events -> /state read cycles after downstream progress

### DIFF
--- a/test/api.split_decision_idempotent_rejected.regression.test.mjs
+++ b/test/api.split_decision_idempotent_rejected.regression.test.mjs
@@ -1792,6 +1792,33 @@ test("API regression: compile-created session flow preserves byte-stable /state 
     });
   });
 });
+test("API regression: compile-created session flow preserves normalized current-step identity and trace contract across alternating /state -> /events -> /state read cycles after downstream progress", async (t) => {
+  await withServer(t, async ({ baseUrl, root, sessionStateCache }) => {
+    await runResolvedReplayScenario({
+      baseUrl,
+      root,
+      sessionStateCache,
+      label: "compile-created session continue normalized current-step identity trace alternating state events state cycles after downstream progress scenario",
+      decisionType: "RETURN_CONTINUE",
+      requireByteStableImmediateReplay: true,
+      requireByteStableAcrossRepeatedReloads: true,
+      requireByteStableAfterDownstreamProgress: true,
+      requireNormalizedCurrentStepIdentityAndTraceContractAcrossAlternatingStateEventsStateReadCyclesAfterDownstreamProgress: true
+    });
+
+    await runResolvedReplayScenario({
+      baseUrl,
+      root,
+      sessionStateCache,
+      label: "compile-created session skip normalized current-step identity trace alternating state events state cycles after downstream progress scenario",
+      decisionType: "RETURN_SKIP",
+      requireByteStableImmediateReplay: true,
+      requireByteStableAcrossRepeatedReloads: true,
+      requireByteStableAfterDownstreamProgress: true,
+      requireNormalizedCurrentStepIdentityAndTraceContractAcrossAlternatingStateEventsStateReadCyclesAfterDownstreamProgress: true
+    });
+  });
+});
 test("API regression: compile-created session flow preserves deterministic terminal parity across alternating fresh process restarts after downstream progress", async (t) => {
   await withServer(t, async ({ baseUrl, root, sessionStateCache }) => {
     await runResolvedReplayScenario({


### PR DESCRIPTION
## Summary
- add a focused regression proof that compile-created sessions preserve normalized current-step identity and trace contract across alternating /state -> /events -> /state read cycles after accepted downstream progress
- prove both RETURN_CONTINUE and RETURN_SKIP flows remain stable on the live operator path without current-step identity drift, trace drift, or response-contract drift under repeated interleaved reads
- close the adjacent same-process identity/trace seam next to the mixed-endpoint snapshot, event-log, and full-terminal-contract coverage already merged

## Testing
- node --test test/api.split_decision_idempotent_rejected.regression.test.mjs
- npm run lint:fast
- npm run test:unit
- npm run build:fast
- gh run list --limit 10