### PR TITLE
revert: remove false multi-downstream-progress parity claim from compile-created session regression

### DIFF
--- a/test/api.split_decision_idempotent_rejected.regression.test.mjs
+++ b/test/api.split_decision_idempotent_rejected.regression.test.mjs
@@ -1819,7 +1819,7 @@ test("API regression: compile-created session flow preserves normalized current-
     });
   });
 });
-
+test("API regression: compile-created session flow preserves deterministic terminal parity across alternating fresh process restarts after downstream progress", async (t) => {
   await withServer(t, async ({ baseUrl, root, sessionStateCache }) => {
     await runResolvedReplayScenario({
       baseUrl,


### PR DESCRIPTION
## Summary
- revert the bad #220 change that did not add a real multi-downstream-progress proof
- restore the prior compile-created regression surface after the attempted helperless test insertion went wrong
- return main to the last semantically valid state before adding real multi-progress helper support

## Testing
- node --test test/api.split_decision_idempotent_rejected.regression.test.mjs
- npm run lint:fast
- npm run test:unit
- npm run build:fast
- gh run list --limit 10