### PR TITLE
fix(test): dedupe final compile-created operator-path regression proof

### DIFF
--- a/test/api.split_decision_idempotent_rejected.regression.test.mjs
+++ b/test/api.split_decision_idempotent_rejected.regression.test.mjs
@@ -1871,45 +1871,6 @@ test("API regression: compile-created session operator path preserves stable con
     });
   });
 });
-test("API regression: compile-created session operator path preserves stable contracts from creation through downstream progress to terminal state", async (t) => {
-  await withServer(t, async ({ baseUrl, root, sessionStateCache }) => {
-    await runResolvedReplayScenario({
-      baseUrl,
-      root,
-      sessionStateCache,
-      label: "compile-created session continue operator path stable contracts creation through downstream progress to terminal state scenario",
-      decisionType: "RETURN_CONTINUE",
-      requireByteStableImmediateReplay: true,
-      requireByteStableAcrossRepeatedReloads: true,
-      requireByteStableAfterDownstreamProgress: true,
-      acceptedDownstreamProgressMutationCount: 2,
-      requireByteStableAcrossAlternatingFreshProcessRestartsAfterDownstreamProgress: true,
-      requireAppendOnlyEventCardinalityAndOrderingAcrossAlternatingFreshProcessRestartsAfterDownstreamProgress: true,
-      requireByteStableStateAndEventsSnapshotsAcrossAlternatingFreshProcessRestartsAfterDownstreamProgress: true,
-      requireNormalizedCurrentStepIdentityAndTraceContractAcrossAlternatingFreshProcessRestartsAfterDownstreamProgress: true,
-      requireTerminalStateShapeAndNoResurrectionAcrossAlternatingFreshProcessRestartsAfterDownstreamProgress: true,
-      requireFullTerminalContractAcrossAlternatingFreshProcessRestartsAfterDownstreamProgress: true
-    });
-
-    await runResolvedReplayScenario({
-      baseUrl,
-      root,
-      sessionStateCache,
-      label: "compile-created session skip operator path stable contracts creation through downstream progress to terminal state scenario",
-      decisionType: "RETURN_SKIP",
-      requireByteStableImmediateReplay: true,
-      requireByteStableAcrossRepeatedReloads: true,
-      requireByteStableAfterDownstreamProgress: true,
-      acceptedDownstreamProgressMutationCount: 2,
-      requireByteStableAcrossAlternatingFreshProcessRestartsAfterDownstreamProgress: true,
-      requireAppendOnlyEventCardinalityAndOrderingAcrossAlternatingFreshProcessRestartsAfterDownstreamProgress: true,
-      requireByteStableStateAndEventsSnapshotsAcrossAlternatingFreshProcessRestartsAfterDownstreamProgress: true,
-      requireNormalizedCurrentStepIdentityAndTraceContractAcrossAlternatingFreshProcessRestartsAfterDownstreamProgress: true,
-      requireTerminalStateShapeAndNoResurrectionAcrossAlternatingFreshProcessRestartsAfterDownstreamProgress: true,
-      requireFullTerminalContractAcrossAlternatingFreshProcessRestartsAfterDownstreamProgress: true
-    });
-  });
-});
 test("API regression: compile-created session flow preserves full terminal contract across alternating fresh process restarts after multiple downstream progress mutations", async (t) => {
   await withServer(t, async ({ baseUrl, root, sessionStateCache }) => {
     await runResolvedReplayScenario({


### PR DESCRIPTION
## Summary
- remove any remaining duplicate copies of the compile-created operator-path regression test
- reduce the file to one canonical operator-path proof block
- restore single-execution coverage and eliminate remaining duplicate maintenance debt

## Testing
- node --test test/api.split_decision_idempotent_rejected.regression.test.mjs
- npm run lint:fast
- npm run test:unit
- npm run build:fast
- gh run list --limit 10