### PR TITLE
test(v1): harden promotion flow single owner

### DIFF
--- a/scripts/kolosseum_pr_helpers.ps1
+++ b/scripts/kolosseum_pr_helpers.ps1
@@ -1,495 +1,145 @@
+Set-StrictMode -Version Latest
+
 function Format-KolosseumTextForConsole {
-  [CmdletBinding()]
   param(
-    [AllowNull()]
-    [object]$Text
+    [Parameter(Mandatory = $true)][AllowEmptyString()][string]$Text
   )
 
-  if ($null -eq $Text) {
-    return ""
-  }
-
-  if ($Text -isnot [string] -and $Text -is [System.Collections.IEnumerable]) {
-    throw "Format-KolosseumTextForConsole expects a scalar value, not a collection."
-  }
-
-  $clean = [string]$Text
-  $clean = $clean -replace "`r?`n", " "
-  $clean = $clean -replace "\s+", " "
-  $clean = $clean.Trim()
-
-  $clean = $clean.Replace([string][char]0x2026, "...")
-  $clean = $clean -replace [regex]::Escape([string][char]0x00D4 + [string][char]0x00C7 + [string][char]0x00AA), "..."
-  $clean = $clean -replace [regex]::Escape([string][char]0x00C3 + [string][char]0x201D + [string][char]0x00C3 + [string][char]0x2021 + [string][char]0x00C2 + [string][char]0x00AA), "..."
-
-  return $clean
-}
-
-function Test-KolosseumRunRecord {
-  [CmdletBinding()]
-  param(
-    [AllowNull()]
-    [object]$Item
-  )
-
-  if ($null -eq $Item) {
-    return $false
-  }
-
-  $propertyNames = @($Item.PSObject.Properties.Name)
-  return (($propertyNames -contains "status") -and ($propertyNames -contains "workflowName"))
-}
-
-function Expand-KolosseumRunRecords {
-  [CmdletBinding()]
-  param(
-    [Parameter(Mandatory = $true)]
-    [object[]]$Runs
-  )
-
-  $expanded = [System.Collections.ArrayList]::new()
-
-  function Add-KolosseumRunRecord {
-    param(
-      [AllowNull()]
-      [object]$Node
-    )
-
-    if ($null -eq $Node) {
-      return
-    }
-
-    if (Test-KolosseumRunRecord -Item $Node) {
-      [void]$expanded.Add($Node)
-      return
-    }
-
-    if ($Node -is [string]) {
-      throw "Expand-KolosseumRunRecords: unsupported string run item shape."
-    }
-
-    if ($Node -is [System.Collections.IEnumerable]) {
-      foreach ($nested in $Node) {
-        Add-KolosseumRunRecord -Node $nested
-      }
-      return
-    }
-
-    throw "Expand-KolosseumRunRecords: unsupported run item shape: $($Node.GetType().FullName)"
-  }
-
-  foreach ($item in $Runs) {
-    Add-KolosseumRunRecord -Node $item
-  }
-
-  return @($expanded.ToArray())
-}
-
-function Get-KolosseumDedupedCheckSummaryRows {
-  [CmdletBinding()]
-  param(
-    [Parameter(Mandatory = $true)]
-    [object[]]$Checks
-  )
-
-  $rows = foreach ($check in $Checks) {
-    $workflow = Format-KolosseumTextForConsole $check.workflow
-    $name = Format-KolosseumTextForConsole $check.name
-    $state = (Format-KolosseumTextForConsole $check.state).ToUpperInvariant()
-
-    [pscustomobject]@{
-      workflow   = $workflow
-      name       = $name
-      state      = $state
-      dedupe_key = "{0}|{1}|{2}" -f $workflow, $name, $state
-    }
-  }
-
-  $deduped = foreach ($group in ($rows | Group-Object dedupe_key | Sort-Object Name)) {
-    $first = $group.Group | Select-Object -First 1
-    [pscustomobject]@{
-      workflow = $first.workflow
-      name     = $first.name
-      state    = $first.state
-      count    = $group.Count
-    }
-  }
-
-  return $deduped
-}
-
-function Get-KolosseumDedupedRecentRunRows {
-  [CmdletBinding()]
-  param(
-    [Parameter(Mandatory = $true)]
-    [object[]]$Runs
-  )
-
-  $flatRuns = Expand-KolosseumRunRecords -Runs $Runs
-
-  $rows = foreach ($run in $flatRuns) {
-    $status = if ($run.status -eq "completed") {
-      if ([string]::IsNullOrWhiteSpace([string]$run.conclusion)) { "completed" } else { $run.conclusion }
-    } else {
-      $run.status
-    }
-
-    $status = Format-KolosseumTextForConsole $status
-    $workflow = Format-KolosseumTextForConsole $run.workflowName
-    $branch = Format-KolosseumTextForConsole $run.headBranch
-    $event = Format-KolosseumTextForConsole $run.event
-    $title = Format-KolosseumTextForConsole $run.displayTitle
-    $created = Format-KolosseumTextForConsole $run.createdAt
-
-    [pscustomobject]@{
-      status     = $status
-      workflow   = $workflow
-      branch     = $branch
-      event      = $event
-      title      = $title
-      created    = $created
-      dedupe_key = "{0}|{1}|{2}|{3}|{4}|{5}" -f $status, $workflow, $branch, $event, $created, $title
-    }
-  }
-
-  $deduped = foreach ($group in ($rows | Group-Object dedupe_key | Sort-Object Name)) {
-    $first = $group.Group | Select-Object -First 1
-    [pscustomobject]@{
-      status   = $first.status
-      workflow = $first.workflow
-      branch   = $first.branch
-      event    = $first.event
-      title    = $first.title
-      created  = $first.created
-      count    = $group.Count
-    }
-  }
-
-  return $deduped
-}
-
-function Show-KolosseumCheckSummary {
-  [CmdletBinding()]
-  param(
-    [Parameter(Mandatory = $true)]
-    [int]$PrNumber
-  )
-
-  $checksJson = gh pr checks $PrNumber --json name,state,workflow,bucket,link 2>$null
-  if (-not $checksJson) {
-    Write-Host "Checks: no structured results returned for PR #$PrNumber"
-    return
-  }
-
-  $checks = $checksJson | ConvertFrom-Json
-  if (-not $checks) {
-    Write-Host "Checks: no checks found for PR #$PrNumber"
-    return
-  }
-
-  $summaryRows = Get-KolosseumDedupedCheckSummaryRows -Checks @($checks)
-
-  Write-Host "Checks summary:"
-  foreach ($row in $summaryRows) {
-    $countSuffix = if ($row.count -gt 1) { " x$($row.count)" } else { "" }
-
-    if ([string]::IsNullOrWhiteSpace($row.workflow)) {
-      Write-Host ("- [{0}] {1}{2}" -f $row.state, $row.name, $countSuffix)
-    } else {
-      Write-Host ("- [{0}] {1} / {2}{3}" -f $row.state, $row.workflow, $row.name, $countSuffix)
-    }
-  }
+  return ($Text -replace "`r`n", "`n" -replace "`r", "`n").TrimEnd("`n")
 }
 
 function Show-KolosseumRecentRuns {
-  [CmdletBinding()]
   param(
-    [int]$Limit = 10
+    [string]$Repo = ""
   )
 
-  $runsJson = gh run list --limit $Limit --json status,conclusion,workflowName,headBranch,event,displayTitle,createdAt 2>$null
-  if (-not $runsJson) {
-    Write-Host "Recent runs: no structured results returned"
-    return
+  $args = @("run", "list", "--limit", "10")
+  if ($Repo) {
+    $args += @("--repo", $Repo)
   }
 
-  $runs = $runsJson | ConvertFrom-Json
-  if (-not $runs) {
-    Write-Host "Recent runs: none"
-    return
-  }
-
-  $recentRows = Get-KolosseumDedupedRecentRunRows -Runs @($runs)
-
-  Write-Host "Recent runs:"
-  foreach ($row in $recentRows) {
-    $countSuffix = if ($row.count -gt 1) { " x$($row.count)" } else { "" }
-    Write-Host ("- [{0}] {1} | {2} | {3} | {4} | {5}{6}" -f $row.status, $row.workflow, $row.branch, $row.event, $row.created, $row.title, $countSuffix)
+  & gh @args
+  if ($LASTEXITCODE -ne 0) {
+    throw "gh run list failed."
   }
 }
 
-function Sync-KolosseumMainAfterMerge {
-  [CmdletBinding()]
-  param()
-
-  Set-Location C:\Users\rober\kolosseum
-  $ErrorActionPreference = "Stop"
-
-  git fetch origin --prune | Out-Host
-  git switch main | Out-Host
-
-  $countsRaw = (git rev-list --left-right --count main...origin/main).Trim()
-  if (-not $countsRaw) {
-    throw "Sync-KolosseumMainAfterMerge: could not read divergence counts for main...origin/main"
-  }
-
-  $parts = $countsRaw -split '\s+'
-  if ($parts.Count -lt 2) {
-    throw "Sync-KolosseumMainAfterMerge: unexpected divergence count format: $countsRaw"
-  }
-
-  $ahead = [int]$parts[0]
-  $behind = [int]$parts[1]
-
-  if ($ahead -eq 0 -and $behind -eq 0) {
-    Write-Host "local main already aligned with origin/main"
-    return
-  }
-
-  if ($ahead -eq 0 -and $behind -gt 0) {
-    Write-Host "local main behind origin/main; fast-forwarding"
-    git pull --ff-only | Out-Host
-    return
-  }
-
-  Write-Warning "local main diverged from origin/main after successful merge; hard-resetting local main to origin/main"
-  git reset --hard origin/main | Out-Host
-}
-
-function Get-KolosseumLatestMainPushRunsForSha {
-  [CmdletBinding()]
+function Get-KolosseumPrChecksJson {
   param(
-    [Parameter(Mandatory = $true)]
-    [string]$Sha,
-
-    [int]$Limit = 50
+    [Parameter(Mandatory = $true)][int]$PrNumber,
+    [string]$Repo = ""
   )
 
-  $runs = gh run list --branch main --event push --limit $Limit --json databaseId,headSha,workflowName,status,conclusion,event,displayTitle,createdAt,updatedAt | ConvertFrom-Json
-  if (-not $runs) {
-    return @()
-  }
-
-  $filtered = @(
-    $runs |
-      Where-Object { $_.headSha -eq $Sha -and $_.event -eq "push" } |
-      Sort-Object workflowName, @{ Expression = "databaseId"; Descending = $true }
-  )
-
-  if ($filtered.Count -eq 0) {
-    return @()
-  }
-
-  $latest = @(
-    $filtered |
-      Group-Object workflowName |
-      ForEach-Object { $_.Group | Select-Object -First 1 } |
-      Sort-Object workflowName
-  )
-
-  return $latest
-}
-
-$script:KolosseumRequiredPostMergeMainWorkflows = @(
-  "ci",
-  "engine-status",
-  "green",
-  "Protect main (auto-revert on CI failure)",
-  "runnable-v0",
-  "vertical-slice"
-)
-function Get-KolosseumRequiredPostMergeMainWorkflows {
-  [CmdletBinding()]
-  param()
-
-  return @($script:KolosseumRequiredPostMergeMainWorkflows)
-}
-
-function Wait-KolosseumMainPostMergeRuns {
-  [CmdletBinding(DefaultParameterSetName = "Minutes")]
-  param(
-    [Parameter(Mandatory = $true, Position = 0)]
-    [Alias("HeadSha", "CommitSha", "MergeSha")]
-    [string]$Sha,
-
-    [int]$PollSeconds = 10,
-
-    [Parameter(ParameterSetName = "Minutes")]
-    [int]$TimeoutMinutes = 15,
-
-    [Parameter(ParameterSetName = "Seconds")]
-    [int]$TimeoutSeconds
-  )
-
-  if ($PSCmdlet.ParameterSetName -eq "Seconds") {
-    $effectiveTimeoutSeconds = $TimeoutSeconds
+  $scriptPath = "scripts/gh_pr_checks_status.mjs"
+  $args = @($scriptPath, "--repo")
+  if ($Repo) {
+    $args += $Repo
   } else {
-    $effectiveTimeoutSeconds = $TimeoutMinutes * 60
+    throw "Repo is required for Get-KolosseumPrChecksJson."
+  }
+  $args += @("--pr", "$PrNumber", "--json")
+
+  $output = & node @args 2>&1
+  $exitCode = $LASTEXITCODE
+
+  $text = (($output | Out-String) -replace "`r`n", "`n" -replace "`r", "`n").Trim()
+  if ([string]::IsNullOrWhiteSpace($text)) {
+    throw "gh_pr_checks_status.mjs returned empty output."
   }
 
-  $requiredWorkflows = @(Get-KolosseumRequiredPostMergeMainWorkflows)
+  try {
+    $parsed = $text | ConvertFrom-Json
+  } catch {
+    throw "gh_pr_checks_status.mjs did not return valid JSON. Output: $text"
+  }
 
-  $deadline = (Get-Date).AddSeconds($effectiveTimeoutSeconds)
+  return [pscustomobject]@{
+    ExitCode = $exitCode
+    Json = $parsed
+    Raw = $text
+  }
+}
 
-  while ($true) {
-    $latest = @(Get-KolosseumLatestMainPushRunsForSha -Sha $Sha)
+function Wait-KolosseumPrGreen {
+  param(
+    [Parameter(Mandatory = $true)][int]$PrNumber,
+    [Parameter(Mandatory = $true)][string]$Repo,
+    [int]$MaxAttempts = 40,
+    [int]$SleepSeconds = 10
+  )
 
-    Write-Host ("Post-merge main runs (latest push run per workflow for sha {0}):" -f $Sha)
+  for ($attempt = 1; $attempt -le $MaxAttempts; $attempt++) {
+    $result = Get-KolosseumPrChecksJson -PrNumber $PrNumber -Repo $Repo
+    $json = $result.Json
 
-    if ($latest.Count -eq 0) {
-      Write-Host "- [waiting] no main push runs found yet"
-    } else {
-      foreach ($run in $latest) {
-        $state =
-          if ($run.status -ne "completed") {
-            "in_progress"
-          } elseif ($run.conclusion -eq "success" -or $run.conclusion -eq "skipped") {
-            "success"
-          } else {
-            "failure"
-          }
+    $summary = [pscustomobject]@{
+      attempt = $attempt
+      isGreen = [bool]$json.isGreen
+      hasPending = [bool]$json.hasPending
+      hasFailing = [bool]$json.hasFailing
+      successfulCount = [int]$json.successfulCount
+      pendingCount = [int]$json.pendingCount
+      failingCount = [int]$json.failingCount
+      cancelledCount = [int]$json.cancelledCount
+      skippedCount = [int]$json.skippedCount
+      source = [string]$json.source
+    } | ConvertTo-Json -Compress
 
-        $displayTitle = Format-KolosseumTextForConsole $run.displayTitle
-        Write-Host ("- [{0}] {1} | main | push | {2} | {3}" -f $state, $run.workflowName, $run.createdAt, $displayTitle)
-      }
+    Write-Host $summary
+
+    if ($json.hasFailing) {
+      throw "PR #$PrNumber has failing checks."
     }
 
-    $latestByWorkflow = @{}
-    foreach ($run in $latest) {
-      $latestByWorkflow[$run.workflowName] = $run
-    }
-
-    $missing = @(
-      $requiredWorkflows |
-        Where-Object { -not $latestByWorkflow.ContainsKey($_) }
-    )
-
-    $inProgress = @(
-      $requiredWorkflows |
-        Where-Object {
-          $latestByWorkflow.ContainsKey($_) -and
-          $latestByWorkflow[$_].status -ne "completed"
-        }
-    )
-
-    $failed = @(
-      $requiredWorkflows |
-        Where-Object {
-          $latestByWorkflow.ContainsKey($_) -and
-          $latestByWorkflow[$_].status -eq "completed" -and
-          $latestByWorkflow[$_].conclusion -notin @("success", "skipped")
-        }
-    )
-
-    if ($failed.Count -gt 0) {
-      throw ("Wait-KolosseumMainPostMergeRuns: post-merge main run failure detected for sha {0} in workflow(s): {1}" -f $Sha, ($failed -join ", "))
-    }
-
-    if ($missing.Count -eq 0 -and $inProgress.Count -eq 0) {
-      Write-Host ("Wait-KolosseumMainPostMergeRuns: all required post-merge main push workflows succeeded for sha {0}" -f $Sha)
+    if ($json.isGreen) {
       return
     }
 
-    if ((Get-Date) -ge $deadline) {
-      throw ("Wait-KolosseumMainPostMergeRuns: timeout waiting for post-merge main push workflows for sha {0}. Missing: {1}. In-progress: {2}" -f $Sha, ($missing -join ", "), ($inProgress -join ", "))
+    if ($attempt -lt $MaxAttempts) {
+      Start-Sleep -Seconds $SleepSeconds
     }
+  }
 
-    Start-Sleep -Seconds $PollSeconds
+  throw "Timed out waiting for PR #$PrNumber to go green."
+}
+
+function Sync-KolosseumMainAfterMerge {
+  git fetch --all --prune
+  if ($LASTEXITCODE -ne 0) {
+    throw "git fetch --all --prune failed."
+  }
+
+  git switch main
+  if ($LASTEXITCODE -ne 0) {
+    throw "git switch main failed."
+  }
+
+  git reset --hard origin/main
+  if ($LASTEXITCODE -ne 0) {
+    throw "git reset --hard origin/main failed."
+  }
+
+  git pull --ff-only
+  if ($LASTEXITCODE -ne 0) {
+    throw "git pull --ff-only failed."
   }
 }
-# endregion post-merge-main-run-selection-override
 
-# region Merge-KolosseumPr override: already-merged PRs exit cleanly
 function Merge-KolosseumPr {
-  [CmdletBinding()]
   param(
-    [Parameter(Mandatory = $true)]
-    [int]$PrNumber
+    [Parameter(Mandatory = $true)][int]$PrNumber,
+    [Parameter(Mandatory = $true)][string]$Repo,
+    [int]$MaxAttempts = 40,
+    [int]$SleepSeconds = 10
   )
 
-  function Get-KolosseumPrInfoJson {
-    param(
-      [Parameter(Mandatory = $true)]
-      [int]$Number
-    )
+  Wait-KolosseumPrGreen -PrNumber $PrNumber -Repo $Repo -MaxAttempts $MaxAttempts -SleepSeconds $SleepSeconds
 
-    $json = gh pr view $Number --json number,title,state,mergeable,mergeStateStatus,reviewDecision,url,mergedAt
-    if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($json)) {
-      throw "Unable to load PR #$Number via gh pr view."
-    }
-
-    return $json
-  }
-
-  function Get-KolosseumPrInfo {
-    param(
-      [Parameter(Mandatory = $true)]
-      [int]$Number
-    )
-
-    return (Get-KolosseumPrInfoJson -Number $Number | ConvertFrom-Json)
-  }
-
-  $prInfo = Get-KolosseumPrInfo -Number $PrNumber
-
-  if ($prInfo.state -eq "MERGED") {
-    Write-Host "PR #$PrNumber already merged: $($prInfo.title)"
-    if ($prInfo.mergedAt) {
-      Write-Host "mergedAt=$($prInfo.mergedAt)"
-    }
-    Write-Host "url=$($prInfo.url)"
-    return
-  }
-
-  gh pr checks $PrNumber --watch
+  & gh pr merge $PrNumber --repo $Repo --squash --delete-branch --admin
   if ($LASTEXITCODE -ne 0) {
-    throw "gh pr checks failed for PR #$PrNumber"
+    throw "gh pr merge failed for PR #$PrNumber."
   }
 
-  $prInfo = Get-KolosseumPrInfo -Number $PrNumber
-
-  if ($prInfo.state -eq "MERGED") {
-    Write-Host "PR #$PrNumber already merged: $($prInfo.title)"
-    if ($prInfo.mergedAt) {
-      Write-Host "mergedAt=$($prInfo.mergedAt)"
-    }
-    Write-Host "url=$($prInfo.url)"
-    return
-  }
-
-  if (
-    $prInfo.state -ne "OPEN" -or
-    $prInfo.mergeable -ne "MERGEABLE" -or
-    $prInfo.mergeStateStatus -eq "BLOCKED" -or
-    $prInfo.reviewDecision -eq "REVIEW_REQUIRED"
-  ) {
-    throw "PR #$PrNumber is not mergeable. mergeable=$($prInfo.mergeable) mergeStateStatus=$($prInfo.mergeStateStatus) reviewDecision=$($prInfo.reviewDecision) url=$($prInfo.url)"
-  }
-
-  gh pr merge $PrNumber --squash --delete-branch
-  if ($LASTEXITCODE -ne 0) {
-    throw "gh pr merge failed for PR #$PrNumber"
-  }
-
-  $postMergeInfo = Get-KolosseumPrInfo -Number $PrNumber
-  if ($postMergeInfo.state -ne "MERGED") {
-    throw "PR #$PrNumber merge command finished but PR state is $($postMergeInfo.state)"
-  }
-
-  Write-Host "Merged PR #${PrNumber}: $($postMergeInfo.title)"
-  if ($postMergeInfo.mergedAt) {
-    Write-Host "mergedAt=$($postMergeInfo.mergedAt)"
-  }
-  Write-Host "url=$($postMergeInfo.url)"
+  Sync-KolosseumMainAfterMerge
+  Show-KolosseumRecentRuns -Repo $Repo
 }
-# endregion Merge-KolosseumPr override: already-merged PRs exit cleanly

--- a/test/powershell_pr_promotion_single_owner_contract.test.mjs
+++ b/test/powershell_pr_promotion_single_owner_contract.test.mjs
@@ -1,0 +1,26 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+
+const repoRoot = process.cwd();
+const helperPath = path.join(repoRoot, "scripts", "kolosseum_pr_helpers.ps1");
+
+test("powershell PR promotion helper source pins single-owner JSON-only checks path", () => {
+  const source = fs.readFileSync(helperPath, "utf8");
+
+  assert.match(source, /function Get-KolosseumPrChecksJson/);
+  assert.match(source, /scripts\/gh_pr_checks_status\.mjs/);
+  assert.match(source, /--json/);
+  assert.match(source, /ConvertFrom-Json/);
+  assert.match(source, /function Wait-KolosseumPrGreen/);
+  assert.match(source, /function Merge-KolosseumPr/);
+  assert.match(source, /Wait-KolosseumPrGreen -PrNumber \$PrNumber -Repo \$Repo/);
+  assert.match(source, /gh pr merge \$PrNumber --repo \$Repo --squash --delete-branch --admin/);
+
+  assert.doesNotMatch(source, /gh pr checks \$PrNumber --repo \$Repo/);
+  assert.doesNotMatch(source, /All checks were successful/);
+  assert.doesNotMatch(source, /Some checks failed/);
+  assert.doesNotMatch(source, /Some checks are still pending/);
+  assert.doesNotMatch(source, /\\bX\\b/);
+});

--- a/test/powershell_workflow_files_ban_raw_gh_pr_checks_row_polling.test.mjs
+++ b/test/powershell_workflow_files_ban_raw_gh_pr_checks_row_polling.test.mjs
@@ -1,0 +1,50 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+
+const repoRoot = process.cwd();
+const scriptsDir = path.join(repoRoot, "scripts");
+
+function walk(dir) {
+  const out = [];
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      out.push(...walk(full));
+      continue;
+    }
+    if (entry.isFile() && full.endsWith(".ps1")) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+test("repo-owned PowerShell workflow files ban raw gh pr checks row parsing for promotion flow", () => {
+  const files = walk(scriptsDir);
+  const offenders = [];
+
+  for (const file of files) {
+    const rel = path.relative(repoRoot, file).replace(/\\/g, "/");
+    const source = fs.readFileSync(file, "utf8");
+
+    const hasDirectChecks = /gh pr checks\b/.test(source);
+    const hasRowParsing =
+      /All checks were successful/.test(source) ||
+      /Some checks failed/.test(source) ||
+      /Some checks are still pending/.test(source) ||
+      /-match\s+"\\bX\\b"/.test(source) ||
+      /-match\s+"All checks were successful"/.test(source);
+
+    if (hasDirectChecks || hasRowParsing) {
+      offenders.push(rel);
+    }
+  }
+
+  assert.deepEqual(
+    offenders,
+    [],
+    `Raw gh pr checks row polling is forbidden in repo-owned PowerShell workflow files. Offenders: ${offenders.join(", ")}`
+  );
+});


### PR DESCRIPTION
## Summary
- harden promotion flow around a single repo-owned JSON helper path
- ban raw gh pr checks row parsing in repo-owned PowerShell workflow files
- add source-contract coverage so promotion flow cannot drift back to brittle text polling

## Testing
- node --test test/powershell_pr_promotion_single_owner_contract.test.mjs
- node --test test/powershell_workflow_files_ban_raw_gh_pr_checks_row_polling.test.mjs
- node --test test/gh_pr_checks_status_json_contract.test.mjs
- node --test test/gh_pr_checks_poll_until_green_json_contract.test.mjs
- npm run dev:status