### PR TITLE
test(postv1): add final acceptance gate

### DIFF
--- a/ci/scripts/run_postv1_final_acceptance_gate.mjs
+++ b/ci/scripts/run_postv1_final_acceptance_gate.mjs
@@ -1,0 +1,62 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+
+const ACCEPTANCE_SURFACES = [
+  'docs/releases/V1_ACCEPTANCE_SIGNOFF.md',
+  'docs/releases/V1_RELEASE_CHECKLIST.md',
+  'docs/releases/V1_OPERATOR_RUNBOOK.md',
+  'docs/releases/V1_ROLLBACK.md',
+  'docs/releases/V1_PACKAGING_EVIDENCE_MANIFEST.json',
+  'docs/releases/V1_ACCEPTANCE_PACK_INDEX.md',
+];
+
+const PROVEN_INTERNAL_SURFACES = [
+  'ci/scripts/build_postv1_packaging_evidence.mjs',
+  'ci/scripts/run_postv1_packaging_evidence_manifest_verifier.mjs',
+];
+
+function requireExistingFile(filePath) {
+  if (!fs.existsSync(filePath)) {
+    console.error(`Missing required internal acceptance surface: ${filePath}`);
+    process.exit(1);
+  }
+}
+
+function runNodeSurface(scriptPath, expectedMarker) {
+  const result = spawnSync(process.execPath, [scriptPath], {
+    encoding: 'utf8',
+  });
+
+  if (result.status !== 0) {
+    console.error(result.stderr || result.stdout || `Failed internal surface: ${scriptPath}`);
+    process.exit(result.status ?? 1);
+  }
+
+  if (!result.stdout.includes(expectedMarker)) {
+    console.error(`Internal surface did not emit expected marker ${expectedMarker}: ${scriptPath}`);
+    process.exit(1);
+  }
+
+  process.stdout.write(result.stdout);
+}
+
+for (const filePath of ACCEPTANCE_SURFACES) {
+  requireExistingFile(filePath);
+}
+
+for (const scriptPath of PROVEN_INTERNAL_SURFACES) {
+  requireExistingFile(scriptPath);
+}
+
+runNodeSurface(
+  'ci/scripts/build_postv1_packaging_evidence.mjs',
+  'POSTV1_PACKAGING_EVIDENCE_COLLECTED',
+);
+
+runNodeSurface(
+  'ci/scripts/run_postv1_packaging_evidence_manifest_verifier.mjs',
+  'POSTV1_PACKAGING_EVIDENCE_MANIFEST_VERIFIER_OK',
+);
+
+console.log('POSTV1_FINAL_ACCEPTANCE_GATE_GREEN');

--- a/test/postv1_final_acceptance_gate.test.mjs
+++ b/test/postv1_final_acceptance_gate.test.mjs
@@ -1,0 +1,70 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+
+const SCRIPT_PATH = 'ci/scripts/run_postv1_final_acceptance_gate.mjs';
+
+test('P30: final acceptance gate exists', () => {
+  assert.equal(fs.existsSync(SCRIPT_PATH), true);
+});
+
+test('P30: final acceptance gate calls only proven internal surfaces', () => {
+  const source = fs.readFileSync(SCRIPT_PATH, 'utf8');
+
+  const expectedCalledSurfaces = [
+    'ci/scripts/build_postv1_packaging_evidence.mjs',
+    'ci/scripts/run_postv1_packaging_evidence_manifest_verifier.mjs',
+  ].sort();
+
+  const calledSurfaces = [...source.matchAll(/runNodeSurface\(\s*'([^']+)'/g)]
+    .map((match) => match[1])
+    .sort();
+
+  assert.deepEqual(calledSurfaces, expectedCalledSurfaces);
+
+  const expectedAcceptanceSurfaces = [
+    'docs/releases/V1_ACCEPTANCE_SIGNOFF.md',
+    'docs/releases/V1_RELEASE_CHECKLIST.md',
+    'docs/releases/V1_OPERATOR_RUNBOOK.md',
+    'docs/releases/V1_ROLLBACK.md',
+    'docs/releases/V1_PACKAGING_EVIDENCE_MANIFEST.json',
+    'docs/releases/V1_ACCEPTANCE_PACK_INDEX.md',
+  ].sort();
+
+  const acceptanceSurfaceBlockMatch = source.match(/const ACCEPTANCE_SURFACES = \[(.*?)\];/s);
+  assert.ok(acceptanceSurfaceBlockMatch, 'missing ACCEPTANCE_SURFACES block');
+
+  const acceptanceSurfaces = [...acceptanceSurfaceBlockMatch[1].matchAll(/'([^']+)'/g)]
+    .map((match) => match[1])
+    .sort();
+
+  assert.deepEqual(acceptanceSurfaces, expectedAcceptanceSurfaces);
+
+  for (const file of expectedAcceptanceSurfaces) {
+    assert.equal(fs.existsSync(file), true, `missing internal acceptance surface: ${file}`);
+  }
+
+  for (const file of expectedCalledSurfaces) {
+    assert.equal(fs.existsSync(file), true, `missing proven internal surface: ${file}`);
+  }
+});
+
+test('P30: final acceptance gate runs green and emits success marker', () => {
+  const outDir = path.join('artifacts', 'postv1_packaging_evidence');
+  fs.rmSync(outDir, { recursive: true, force: true });
+
+  try {
+    const result = spawnSync(process.execPath, [SCRIPT_PATH], {
+      encoding: 'utf8',
+    });
+
+    assert.equal(result.status, 0, result.stderr || result.stdout);
+    assert.match(result.stdout, /POSTV1_PACKAGING_EVIDENCE_COLLECTED/);
+    assert.match(result.stdout, /POSTV1_PACKAGING_EVIDENCE_MANIFEST_VERIFIER_OK/);
+    assert.match(result.stdout, /POSTV1_FINAL_ACCEPTANCE_GATE_GREEN/);
+  } finally {
+    fs.rmSync(outDir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary
- add final internal acceptance gate runner
- prove the gate calls only proven internal surfaces
- prove the gate runs green and emits a final success marker

## Testing
- npm exec tsc -- -p tsconfig.json
- node --test --test-concurrency=1 .\test\postv1_final_acceptance_gate.test.mjs