### PR TITLE
docs(postv1): add promotion flow note

### DIFF
--- a/docs/releases/V1_PROMOTION_FLOW.md
+++ b/docs/releases/V1_PROMOTION_FLOW.md
@@ -1,0 +1,18 @@
+# V1 promotion flow
+
+This note records the internal repo-known promotion path from a completed packaging boundary to a merged release branch.
+
+## Promotion path
+1. Confirm the packaging boundary proof for the slice is green.
+2. Stage only the intended repo files for that slice.
+3. Commit the slice on its ticket branch.
+4. Push the ticket branch to origin.
+5. Open a pull request into main.
+6. Wait for required pull request checks to pass.
+7. Merge the pull request into main using the repo-approved merge path.
+8. Sync local main to origin/main.
+9. Confirm the pull request is merged and the working tree is clean.
+
+## Boundary
+This note describes repository, branch, pull request, and merge steps only.
+It does not describe deployment, rollout, publishing, or customer-facing release activity.

--- a/test/postv1_promotion_flow_note.test.mjs
+++ b/test/postv1_promotion_flow_note.test.mjs
@@ -1,0 +1,46 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+
+const DOC_PATH = 'docs/releases/V1_PROMOTION_FLOW.md';
+
+test('P31: promotion-flow doc exists', () => {
+  assert.equal(fs.existsSync(DOC_PATH), true);
+});
+
+test('P31: promotion-flow doc describes repo-known promotion steps only', () => {
+  const text = fs.readFileSync(DOC_PATH, 'utf8');
+  const normalized = text.toLowerCase();
+
+  const requiredPhrases = [
+    'internal repo-known promotion path',
+    'completed packaging boundary',
+    'ticket branch',
+    'pull request into main',
+    'required pull request checks',
+    'merge the pull request into main',
+    'sync local main to origin/main',
+    'working tree is clean',
+    'repository, branch, pull request, and merge steps only',
+    'does not describe deployment, rollout, publishing, or customer-facing release activity',
+  ];
+
+  for (const phrase of requiredPhrases) {
+    assert.match(normalized, new RegExp(phrase.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
+  }
+
+  const forbiddenPhrases = [
+    'deploy to production',
+    'production deployment',
+    'publish release',
+    'customer rollout',
+    'go live',
+    'hosted availability',
+    'app store',
+    'live environment',
+  ];
+
+  for (const phrase of forbiddenPhrases) {
+    assert.doesNotMatch(normalized, new RegExp(phrase.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
+  }
+});


### PR DESCRIPTION
## Summary
- add V1 promotion flow note
- document the repo-known promotion path from completed packaging boundary to merged release branch
- prove the note describes repo-known promotion steps only

## Testing
- npm exec tsc -- -p tsconfig.json
- node --test --test-concurrency=1 .\test\postv1_promotion_flow_note.test.mjs