### PR TITLE
test(postv1): add merge readiness verifier

### DIFF
--- a/ci/scripts/run_postv1_merge_readiness_verifier.mjs
+++ b/ci/scripts/run_postv1_merge_readiness_verifier.mjs
@@ -1,0 +1,57 @@
+import { execFileSync } from 'node:child_process';
+
+function run(bin, args, options = {}) {
+  return execFileSync(bin, args, {
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+    ...options,
+  }).trim();
+}
+
+function fail(message) {
+  console.error(message);
+  process.exit(1);
+}
+
+const branch = run('git', ['branch', '--show-current']);
+if (!branch) fail('Missing current branch');
+if (branch === 'main') fail('Merge-readiness verifier must not run on main');
+
+const status = run('git', ['status', '--short']);
+if (status !== '') fail('Working tree must be clean');
+
+const prJson = run('gh', [
+  'pr',
+  'view',
+  branch,
+  '--repo',
+  'robertsc2049-bit/kolosseum',
+  '--json',
+  'number,title,state,isDraft,baseRefName,headRefName',
+]);
+
+let pr;
+try {
+  pr = JSON.parse(prJson);
+} catch {
+  fail('Failed to parse PR view JSON');
+}
+
+if (pr.state !== 'OPEN') fail(`PR must be OPEN, got ${pr.state}`);
+if (pr.isDraft) fail('PR must not be draft');
+if (pr.baseRefName !== 'main') fail(`PR base must be main, got ${pr.baseRefName}`);
+if (pr.headRefName !== branch) fail(`PR head must match current branch, got ${pr.headRefName}`);
+
+const checksOutput = run('gh', [
+  'pr',
+  'checks',
+  String(pr.number),
+  '--repo',
+  'robertsc2049-bit/kolosseum',
+]);
+
+if (!checksOutput.includes('All checks were successful')) {
+  fail('PR checks are not fully green');
+}
+
+console.log('POSTV1_MERGE_READINESS_OK');

--- a/test/postv1_merge_readiness_verifier.test.mjs
+++ b/test/postv1_merge_readiness_verifier.test.mjs
@@ -1,0 +1,51 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+
+const SCRIPT_PATH = 'ci/scripts/run_postv1_merge_readiness_verifier.mjs';
+
+test('P33: merge-readiness verifier exists', () => {
+  assert.equal(fs.existsSync(SCRIPT_PATH), true);
+});
+
+test('P33: merge-readiness verifier checks only repo-known readiness conditions', () => {
+  const source = fs.readFileSync(SCRIPT_PATH, 'utf8');
+
+  const requiredChecks = [
+    "git', ['branch', '--show-current']",
+    "git', ['status', '--short']",
+    "gh', [",
+    "'pr'",
+    "'view'",
+    "'checks'",
+    'number,title,state,isDraft,baseRefName,headRefName',
+    'pr.state',
+    'pr.isDraft',
+    'pr.baseRefName',
+    'pr.headRefName',
+    'All checks were successful',
+    'POSTV1_MERGE_READINESS_OK',
+  ];
+
+  for (const token of requiredChecks) {
+    assert.match(source, new RegExp(token.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
+  }
+
+  const forbiddenTerms = [
+    'merge --',
+    'gh pr merge',
+    '--admin',
+    '--delete-branch',
+    'git push',
+    'git reset --hard origin/main',
+    'gh pr checks --watch',
+    'deployment',
+    'rollout',
+    'publish',
+    'hosted availability',
+  ];
+
+  for (const token of forbiddenTerms) {
+    assert.doesNotMatch(source.toLowerCase(), new RegExp(token.toLowerCase().replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
+  }
+});


### PR DESCRIPTION
## Summary
- add post-v1 merge-readiness verifier
- verify only repo-known readiness conditions for promotion branches
- prove the verifier stays non-mutating and non-merge-capable

## Testing
- npm exec tsc -- -p tsconfig.json
- node --test --test-concurrency=1 .\test\postv1_merge_readiness_verifier.test.mjs