### PR TITLE
test(postv1): add mainline post-merge verification script

### DIFF
--- a/ci/scripts/run_postv1_mainline_post_merge_verification.mjs
+++ b/ci/scripts/run_postv1_mainline_post_merge_verification.mjs
@@ -1,0 +1,31 @@
+import { execFileSync } from 'node:child_process';
+
+function run(bin, args) {
+  return execFileSync(bin, args, {
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  }).trim();
+}
+
+function runInherited(bin, args) {
+  execFileSync(bin, args, {
+    stdio: 'inherit',
+  });
+}
+
+function fail(message) {
+  console.error(message);
+  process.exit(1);
+}
+
+const branch = run('git', ['branch', '--show-current']);
+if (!branch) fail('Missing current branch');
+if (branch !== 'main') fail(`Post-merge verification must run on main, got ${branch}`);
+
+const status = run('git', ['status', '--short']);
+if (status !== '') fail('Working tree must be clean');
+
+runInherited('npm', ['run', 'lint:fast']);
+runInherited('npm', ['run', 'build:fast']);
+
+console.log('POSTV1_MAINLINE_POST_MERGE_VERIFICATION_OK');

--- a/test/postv1_mainline_post_merge_verification.test.mjs
+++ b/test/postv1_mainline_post_merge_verification.test.mjs
@@ -1,0 +1,46 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+
+const SCRIPT_PATH = 'ci/scripts/run_postv1_mainline_post_merge_verification.mjs';
+
+test('P34: mainline post-merge verification script exists', () => {
+  assert.equal(fs.existsSync(SCRIPT_PATH), true);
+});
+
+test('P34: mainline post-merge verification script uses only existing repo-known verification commands', () => {
+  const source = fs.readFileSync(SCRIPT_PATH, 'utf8');
+
+  const requiredTokens = [
+    "git', ['branch', '--show-current']",
+    "git', ['status', '--short']",
+    "npm', ['run', 'lint:fast']",
+    "npm', ['run', 'build:fast']",
+    'POSTV1_MAINLINE_POST_MERGE_VERIFICATION_OK',
+  ];
+
+  for (const token of requiredTokens) {
+    assert.match(source, new RegExp(token.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
+  }
+
+  const forbiddenTokens = [
+    "npm', ['run', 'green:ci']",
+    "npm', ['run', 'test:ci']",
+    "npm', ['run', 'e2e:golden']",
+    "gh ",
+    'gh pr',
+    'gh run',
+    'merge --',
+    'gh pr merge',
+    '--admin',
+    '--delete-branch',
+    'deployment',
+    'rollout',
+    'publish',
+    'hosted availability',
+  ];
+
+  for (const token of forbiddenTokens) {
+    assert.doesNotMatch(source.toLowerCase(), new RegExp(token.toLowerCase().replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
+  }
+});


### PR DESCRIPTION
## Summary
- add mainline post-merge verification script
- constrain it to existing repo-known verification commands only
- prove source contract and then run it on clean merged main

## Testing
- npm exec tsc -- -p tsconfig.json
- node --test --test-concurrency=1 .\test\postv1_mainline_post_merge_verification.test.mjs