### PR TITLE
fix(postv1): make mainline post-merge verification npm runner windows-safe

### DIFF
--- a/ci/scripts/run_postv1_mainline_post_merge_verification.mjs
+++ b/ci/scripts/run_postv1_mainline_post_merge_verification.mjs
@@ -25,7 +25,9 @@ if (branch !== 'main') fail(`Post-merge verification must run on main, got ${bra
 const status = run('git', ['status', '--short']);
 if (status !== '') fail('Working tree must be clean');
 
-runInherited('npm', ['run', 'lint:fast']);
-runInherited('npm', ['run', 'build:fast']);
+const npmBin = process.platform === 'win32' ? 'npm.cmd' : 'npm';
+
+runInherited(npmBin, ['run', 'lint:fast']);
+runInherited(npmBin, ['run', 'build:fast']);
 
 console.log('POSTV1_MAINLINE_POST_MERGE_VERIFICATION_OK');

--- a/test/postv1_mainline_post_merge_verification.test.mjs
+++ b/test/postv1_mainline_post_merge_verification.test.mjs
@@ -4,18 +4,19 @@ import fs from 'node:fs';
 
 const SCRIPT_PATH = 'ci/scripts/run_postv1_mainline_post_merge_verification.mjs';
 
-test('P34: mainline post-merge verification script exists', () => {
+test('P34f1: mainline post-merge verification script exists', () => {
   assert.equal(fs.existsSync(SCRIPT_PATH), true);
 });
 
-test('P34: mainline post-merge verification script uses only existing repo-known verification commands', () => {
+test('P34f1: mainline post-merge verification script uses only existing repo-known verification commands', () => {
   const source = fs.readFileSync(SCRIPT_PATH, 'utf8');
 
   const requiredTokens = [
     "git', ['branch', '--show-current']",
     "git', ['status', '--short']",
-    "npm', ['run', 'lint:fast']",
-    "npm', ['run', 'build:fast']",
+    "process.platform === 'win32' ? 'npm.cmd' : 'npm'",
+    "['run', 'lint:fast']",
+    "['run', 'build:fast']",
     'POSTV1_MAINLINE_POST_MERGE_VERIFICATION_OK',
   ];
 
@@ -27,7 +28,10 @@ test('P34: mainline post-merge verification script uses only existing repo-known
     "npm', ['run', 'green:ci']",
     "npm', ['run', 'test:ci']",
     "npm', ['run', 'e2e:golden']",
-    "gh ",
+    "npm.cmd', ['run', 'green:ci']",
+    "npm.cmd', ['run', 'test:ci']",
+    "npm.cmd', ['run', 'e2e:golden']",
+    'gh ',
     'gh pr',
     'gh run',
     'merge --',


### PR DESCRIPTION
## Summary
- make the mainline post-merge verification script resolve npm correctly on Windows
- preserve the existing repo-known verification command set
- tighten the source-contract test to pin the platform-specific npm runner

## Testing
- npm exec tsc -- -p tsconfig.json
- node --test --test-concurrency=1 .\test\postv1_mainline_post_merge_verification.test.mjs