### PR TITLE
fix(postv1): make mainline post-merge verification shell-safe on windows

### DIFF
--- a/ci/scripts/run_postv1_mainline_post_merge_verification.mjs
+++ b/ci/scripts/run_postv1_mainline_post_merge_verification.mjs
@@ -7,8 +7,15 @@ function run(bin, args) {
   }).trim();
 }
 
-function runInherited(bin, args) {
-  execFileSync(bin, args, {
+function runCommand(command) {
+  if (process.platform === 'win32') {
+    execFileSync('cmd.exe', ['/d', '/s', '/c', command], {
+      stdio: 'inherit',
+    });
+    return;
+  }
+
+  execFileSync('npm', command.split(' '), {
     stdio: 'inherit',
   });
 }
@@ -25,9 +32,7 @@ if (branch !== 'main') fail(`Post-merge verification must run on main, got ${bra
 const status = run('git', ['status', '--short']);
 if (status !== '') fail('Working tree must be clean');
 
-const npmBin = process.platform === 'win32' ? 'npm.cmd' : 'npm';
-
-runInherited(npmBin, ['run', 'lint:fast']);
-runInherited(npmBin, ['run', 'build:fast']);
+runCommand('npm run lint:fast');
+runCommand('npm run build:fast');
 
 console.log('POSTV1_MAINLINE_POST_MERGE_VERIFICATION_OK');

--- a/test/postv1_mainline_post_merge_verification.test.mjs
+++ b/test/postv1_mainline_post_merge_verification.test.mjs
@@ -4,19 +4,20 @@ import fs from 'node:fs';
 
 const SCRIPT_PATH = 'ci/scripts/run_postv1_mainline_post_merge_verification.mjs';
 
-test('P34f1: mainline post-merge verification script exists', () => {
+test('P34f2: mainline post-merge verification script exists', () => {
   assert.equal(fs.existsSync(SCRIPT_PATH), true);
 });
 
-test('P34f1: mainline post-merge verification script uses only existing repo-known verification commands', () => {
+test('P34f2: mainline post-merge verification script uses only existing repo-known verification commands', () => {
   const source = fs.readFileSync(SCRIPT_PATH, 'utf8');
 
   const requiredTokens = [
     "git', ['branch', '--show-current']",
     "git', ['status', '--short']",
-    "process.platform === 'win32' ? 'npm.cmd' : 'npm'",
-    "['run', 'lint:fast']",
-    "['run', 'build:fast']",
+    "execFileSync('cmd.exe', ['/d', '/s', '/c', command]",
+    "execFileSync('npm', command.split(' ')",
+    "runCommand('npm run lint:fast')",
+    "runCommand('npm run build:fast')",
     'POSTV1_MAINLINE_POST_MERGE_VERIFICATION_OK',
   ];
 
@@ -25,12 +26,10 @@ test('P34f1: mainline post-merge verification script uses only existing repo-kno
   }
 
   const forbiddenTokens = [
+    "execFileSync('npm.cmd'",
     "npm', ['run', 'green:ci']",
     "npm', ['run', 'test:ci']",
     "npm', ['run', 'e2e:golden']",
-    "npm.cmd', ['run', 'green:ci']",
-    "npm.cmd', ['run', 'test:ci']",
-    "npm.cmd', ['run', 'e2e:golden']",
     'gh ',
     'gh pr',
     'gh run',


### PR DESCRIPTION
## Summary
- make the mainline post-merge verification script invoke npm through cmd.exe on Windows
- preserve the existing repo-known verification command set
- tighten the source-contract test to pin the shell-safe Windows path

## Testing
- npm exec tsc -- -p tsconfig.json
- node --test --test-concurrency=1 .\test\postv1_mainline_post_merge_verification.test.mjs