### PR TITLE
docs(postv1): add mainline green-run evidence note

### DIFF
--- a/docs/releases/V1_MAINLINE_GREEN_RUN_EVIDENCE.md
+++ b/docs/releases/V1_MAINLINE_GREEN_RUN_EVIDENCE.md
@@ -1,0 +1,23 @@
+# V1 mainline green-run evidence
+
+This note records how main green state is captured after a merge.
+
+## Evidence sequence
+1. Merge the approved pull request into `main`.
+2. Sync local `main` to `origin/main`.
+3. Run the repo-known post-merge verification script:
+   - `ci/scripts/run_postv1_mainline_post_merge_verification.mjs`
+4. Confirm the script emits:
+   - `POSTV1_MAINLINE_POST_MERGE_VERIFICATION_OK`
+5. Record the resulting clean local state and current `main` commit as internal green-run evidence.
+
+## Repo-known evidence surfaces
+- `ci/scripts/run_postv1_mainline_post_merge_verification.mjs`
+- `npm run lint:fast`
+- `npm run build:fast`
+- clean `git status --short`
+- current `main` commit after sync
+
+## Boundary
+This note describes internal repository verification only.
+It does not imply deployment success, rollout success, publish completion, hosted availability, or customer-facing release success.

--- a/test/postv1_mainline_green_run_evidence_note.test.mjs
+++ b/test/postv1_mainline_green_run_evidence_note.test.mjs
@@ -1,0 +1,55 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+
+const DOC_PATH = 'docs/releases/V1_MAINLINE_GREEN_RUN_EVIDENCE.md';
+
+test('P35: mainline green-run evidence note exists', () => {
+  assert.equal(fs.existsSync(DOC_PATH), true);
+});
+
+test('P35: mainline green-run evidence note does not imply external deployment success', () => {
+  const text = fs.readFileSync(DOC_PATH, 'utf8');
+  const normalized = text.toLowerCase();
+
+  const requiredPhrases = [
+    'main green state is captured after a merge',
+    'post-merge verification script',
+    'postv1_mainline_post_merge_verification_ok',
+    'clean local state',
+    'current `main` commit',
+    'internal repository verification only',
+    'does not imply deployment success, rollout success, publish completion, hosted availability, or customer-facing release success',
+  ];
+
+  for (const phrase of requiredPhrases) {
+    assert.match(normalized, new RegExp(phrase.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
+  }
+
+  const requiredEvidenceSurfaces = [
+    'ci/scripts/run_postv1_mainline_post_merge_verification.mjs',
+    'npm run lint:fast',
+    'npm run build:fast',
+    'git status --short',
+  ];
+
+  for (const token of requiredEvidenceSurfaces) {
+    assert.match(text, new RegExp(token.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
+  }
+
+  const bannedPhrases = [
+    'deployment succeeded',
+    'rollout succeeded',
+    'published successfully',
+    'release is live',
+    'go live',
+    'available to customers',
+    'production success',
+    'app store',
+    'play store',
+  ];
+
+  for (const phrase of bannedPhrases) {
+    assert.doesNotMatch(normalized, new RegExp(phrase.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
+  }
+});


### PR DESCRIPTION
## Summary
- add a note describing how main green state is recorded after merge
- tie the note to repo-known post-merge verification evidence only
- prove the note does not imply external deployment or release success

## Testing
- npm exec tsc -- -p tsconfig.json
- node --test --test-concurrency=1 .\test\postv1_mainline_green_run_evidence_note.test.mjs