### PR TITLE
docs(postv1): add release artefact naming contract

### DIFF
--- a/docs/releases/V1_RELEASE_ARTEFACT_NAMING_CONTRACT.md
+++ b/docs/releases/V1_RELEASE_ARTEFACT_NAMING_CONTRACT.md
@@ -1,0 +1,30 @@
+# V1 release artefact naming contract
+
+This contract standardises naming for current release documents, pack files, and evidence outputs.
+
+## Naming rules
+1. Release-facing documentation under `docs/releases/` uses the `V1_` prefix.
+2. Release document names use uppercase words with underscore separators.
+3. Evidence manifests under `docs/releases/` use descriptive suffixes such as `_MANIFEST`.
+4. Evidence output folders under `artifacts/` use lowercase descriptive names with underscore separators.
+5. Script names under `ci/scripts/` use lowercase descriptive names with the `run_` or `build_` prefix where applicable.
+6. This contract applies to current repo-known release, acceptance, promotion, and evidence surfaces only.
+
+## Current release document examples
+- `V1_RELEASE_NOTES.md`
+- `V1_RELEASE_CHECKLIST.md`
+- `V1_VERSION_AND_TAG.md`
+- `V1_ROLLBACK.md`
+- `V1_OPERATOR_RUNBOOK.md`
+- `V1_ACCEPTANCE_SIGNOFF.md`
+- `V1_ACCEPTANCE_PACK_INDEX.md`
+- `V1_PROMOTION_FLOW.md`
+- `V1_MAINLINE_GREEN_RUN_EVIDENCE.md`
+- `V1_PACKAGING_EVIDENCE_MANIFEST.json`
+
+## Current evidence output example
+- `artifacts/postv1_packaging_evidence`
+
+## Boundary
+This contract is deterministic and current-surface only.
+It does not define future artefact families, external packaging names, publishing names, or deployment names.

--- a/test/postv1_release_artefact_naming_contract.test.mjs
+++ b/test/postv1_release_artefact_naming_contract.test.mjs
@@ -1,0 +1,60 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+
+const DOC_PATH = 'docs/releases/V1_RELEASE_ARTEFACT_NAMING_CONTRACT.md';
+
+test('P36: release artefact naming contract exists', () => {
+  assert.equal(fs.existsSync(DOC_PATH), true);
+});
+
+test('P36: release artefact naming contract stays deterministic and current-surface only', () => {
+  const text = fs.readFileSync(DOC_PATH, 'utf8');
+  const normalized = text.toLowerCase();
+
+  const requiredPhrases = [
+    'standardises naming for current release documents, pack files, and evidence outputs',
+    'uses the `v1_` prefix',
+    'uppercase words with underscore separators',
+    'lowercase descriptive names with underscore separators',
+    'deterministic and current-surface only',
+    'does not define future artefact families, external packaging names, publishing names, or deployment names',
+  ];
+
+  for (const phrase of requiredPhrases) {
+    assert.match(normalized, new RegExp(phrase.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
+  }
+
+  const requiredSurfaces = [
+    'V1_RELEASE_NOTES.md',
+    'V1_RELEASE_CHECKLIST.md',
+    'V1_VERSION_AND_TAG.md',
+    'V1_ROLLBACK.md',
+    'V1_OPERATOR_RUNBOOK.md',
+    'V1_ACCEPTANCE_SIGNOFF.md',
+    'V1_ACCEPTANCE_PACK_INDEX.md',
+    'V1_PROMOTION_FLOW.md',
+    'V1_MAINLINE_GREEN_RUN_EVIDENCE.md',
+    'V1_PACKAGING_EVIDENCE_MANIFEST.json',
+    'artifacts/postv1_packaging_evidence',
+  ];
+
+  for (const token of requiredSurfaces) {
+    assert.match(text, new RegExp(token.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
+  }
+
+  const bannedPhrases = [
+    'v2_',
+    'future release family',
+    'deploy package name',
+    'published artefact name',
+    'customer download name',
+    'app store package',
+    'play store package',
+    'production bundle name',
+  ];
+
+  for (const phrase of bannedPhrases) {
+    assert.doesNotMatch(normalized, new RegExp(phrase.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
+  }
+});


### PR DESCRIPTION
## Summary
- add a naming contract for current release docs, pack files, and evidence outputs
- constrain the contract to deterministic current-surface naming only
- prove the contract does not drift into future-family or external packaging naming

## Testing
- npm exec tsc -- -p tsconfig.json
- node --test --test-concurrency=1 .\test\postv1_release_artefact_naming_contract.test.mjs