### PR TITLE
test(postv1): add packaging surface registry

### DIFF
--- a/docs/releases/V1_PACKAGING_SURFACE_REGISTRY.json
+++ b/docs/releases/V1_PACKAGING_SURFACE_REGISTRY.json
@@ -1,0 +1,23 @@
+{
+  "name": "v1_packaging_surface_registry",
+  "surfaces": [
+    "docs/releases/V1_RELEASE_NOTES.md",
+    "docs/releases/V1_RELEASE_CHECKLIST.md",
+    "docs/releases/V1_VERSION_AND_TAG.md",
+    "docs/releases/V1_ROLLBACK.md",
+    "docs/releases/V1_OPERATOR_RUNBOOK.md",
+    "docs/releases/V1_ACCEPTANCE_SIGNOFF.md",
+    "docs/releases/V1_ACCEPTANCE_PACK_INDEX.md",
+    "docs/releases/V1_PROMOTION_FLOW.md",
+    "docs/releases/V1_PACKAGING_PROMOTION_PR_BODY_TEMPLATE.md",
+    "docs/releases/V1_MAINLINE_GREEN_RUN_EVIDENCE.md",
+    "docs/releases/V1_RELEASE_ARTEFACT_NAMING_CONTRACT.md",
+    "docs/releases/V1_PACKAGING_EVIDENCE_MANIFEST.json",
+    "ci/scripts/build_postv1_packaging_evidence.mjs",
+    "ci/scripts/run_postv1_packaging_evidence_manifest_verifier.mjs",
+    "ci/scripts/run_postv1_final_acceptance_gate.mjs",
+    "ci/scripts/run_postv1_merge_readiness_verifier.mjs",
+    "ci/scripts/run_postv1_mainline_post_merge_verification.mjs",
+    "ci/scripts/run_release_claim_validator.mjs"
+  ]
+}

--- a/test/postv1_packaging_surface_registry.test.mjs
+++ b/test/postv1_packaging_surface_registry.test.mjs
@@ -1,0 +1,66 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+
+const REGISTRY_PATH = 'docs/releases/V1_PACKAGING_SURFACE_REGISTRY.json';
+
+test('P37: packaging surface registry exists', () => {
+  assert.equal(fs.existsSync(REGISTRY_PATH), true);
+});
+
+test('P37: packaging surface registry entries correspond to real repo files only', () => {
+  const raw = fs.readFileSync(REGISTRY_PATH, 'utf8');
+  const parsed = JSON.parse(raw);
+
+  assert.equal(parsed.name, 'v1_packaging_surface_registry');
+  assert.ok(Array.isArray(parsed.surfaces), 'surfaces must be an array');
+  assert.ok(parsed.surfaces.length > 0, 'surfaces must not be empty');
+
+  const sorted = [...parsed.surfaces].sort();
+  const unique = [...new Set(parsed.surfaces)].sort();
+
+  assert.deepEqual(sorted, unique, 'surface entries must be unique');
+
+  const bannedExactEntries = new Set([
+    'artifacts/postv1_packaging_evidence',
+    'docs/releases',
+    'docs/releases/',
+    'ci/scripts',
+    'ci/scripts/',
+    'deploy',
+    'rollout',
+    'publish',
+  ]);
+
+  const bannedPathSegments = new Set([
+    'deploy',
+    'rollout',
+    'publish',
+  ]);
+
+  for (const filePath of parsed.surfaces) {
+    assert.equal(typeof filePath, 'string', `surface path must be a string: ${filePath}`);
+    assert.ok(filePath.length > 0, 'surface path must not be empty');
+    assert.equal(filePath.includes('\\'), false, `surface path must use forward slashes: ${filePath}`);
+    assert.equal(filePath.endsWith('/'), false, `surface path must be a file, not a directory: ${filePath}`);
+    assert.equal(filePath.startsWith('./'), false, `surface path must be repo-relative without ./ prefix: ${filePath}`);
+    assert.equal(filePath.startsWith('/'), false, `surface path must not be absolute: ${filePath}`);
+    assert.equal(fs.existsSync(filePath), true, `missing registry surface: ${filePath}`);
+    assert.equal(fs.statSync(filePath).isFile(), true, `registry surface must be a file: ${filePath}`);
+
+    assert.equal(
+      bannedExactEntries.has(filePath.toLowerCase()),
+      false,
+      `registry surface must be a concrete file path, not a banned root/action token: ${filePath}`,
+    );
+
+    const segments = filePath.toLowerCase().split('/');
+    for (const segment of segments) {
+      assert.equal(
+        bannedPathSegments.has(segment),
+        false,
+        `registry surface must not include banned action path segment "${segment}": ${filePath}`,
+      );
+    }
+  }
+});


### PR DESCRIPTION
## Summary
- add V1 packaging surface registry
- prove the registry contains only concrete repo file surfaces
- reject directory roots and banned action tokens while allowing lawful file paths under docs/releases and ci/scripts

## Proof
- npm exec tsc -- -p tsconfig.json
- node --test --test-concurrency=1 .\test\postv1_packaging_surface_registry.test.mjs