### PR TITLE
docs(postv1): add operator execution order note

### DIFF
--- a/docs/releases/V1_OPERATOR_EXECUTION_ORDER.md
+++ b/docs/releases/V1_OPERATOR_EXECUTION_ORDER.md
@@ -1,0 +1,60 @@
+# V1 Operator Execution Order
+
+## Purpose
+Define the **only valid execution sequence** for post-v1 packaging and promotion.
+
+This is a **linear, non-branching contract**.
+
+No step may be skipped, reordered, or conditionally executed.
+
+---
+
+## Execution Order
+
+1. Build packaging evidence  
+   → ci/scripts/build_postv1_packaging_evidence.mjs
+
+2. Verify packaging evidence manifest  
+   → ci/scripts/run_postv1_packaging_evidence_manifest_verifier.mjs
+
+3. Run final acceptance gate  
+   → ci/scripts/run_postv1_final_acceptance_gate.mjs
+
+4. Perform release claim validation  
+   → ci/scripts/run_release_claim_validator.mjs
+
+5. Confirm merge readiness  
+   → ci/scripts/run_postv1_merge_readiness_verifier.mjs
+
+6. Execute mainline post-merge verification  
+   → ci/scripts/run_postv1_mainline_post_merge_verification.mjs
+
+---
+
+## Invariants
+
+- Order is strictly linear
+- No branching or optional paths
+- All steps must exist in repo
+- All steps must succeed before proceeding
+
+---
+
+## Violation Conditions
+
+The sequence is invalid if:
+- any step is missing
+- any step is reordered
+- any step is duplicated
+- any additional step is inserted
+
+---
+
+## Authority
+
+This document is enforced by:
+- packaging surface registry
+- packaging registry guard
+- execution order test (P39)
+
+This file is the **single source of truth** for operator sequencing.

--- a/docs/releases/V1_PACKAGING_SURFACE_REGISTRY.json
+++ b/docs/releases/V1_PACKAGING_SURFACE_REGISTRY.json
@@ -11,6 +11,7 @@
                      "docs/releases/V1_ACCEPTANCE_SIGNOFF.md",
                      "docs/releases/V1_ARTEFACT_MANIFEST.json",
                      "docs/releases/V1_MAINLINE_GREEN_RUN_EVIDENCE.md",
+                     "docs/releases/V1_OPERATOR_EXECUTION_ORDER.md",
                      "docs/releases/V1_OPERATOR_RUNBOOK.md",
                      "docs/releases/V1_PACKAGING_EVIDENCE_MANIFEST.json",
                      "docs/releases/V1_PACKAGING_PROMOTION_PR_BODY_TEMPLATE.md",

--- a/test/postv1_operator_execution_order.test.mjs
+++ b/test/postv1_operator_execution_order.test.mjs
@@ -1,0 +1,40 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+
+const DOC_PATH = "docs/releases/V1_OPERATOR_EXECUTION_ORDER.md";
+
+const EXPECTED_SEQUENCE = [
+  "ci/scripts/build_postv1_packaging_evidence.mjs",
+  "ci/scripts/run_postv1_packaging_evidence_manifest_verifier.mjs",
+  "ci/scripts/run_postv1_final_acceptance_gate.mjs",
+  "ci/scripts/run_release_claim_validator.mjs",
+  "ci/scripts/run_postv1_merge_readiness_verifier.mjs",
+  "ci/scripts/run_postv1_mainline_post_merge_verification.mjs"
+];
+
+test("P39: execution order doc exists", () => {
+  assert.ok(fs.existsSync(DOC_PATH), "execution order doc must exist");
+});
+
+test("P39: execution order is linear and exact", () => {
+  const content = fs.readFileSync(DOC_PATH, "utf8");
+
+  const found = EXPECTED_SEQUENCE.map(step => {
+    const idx = content.indexOf(step);
+    assert.notEqual(idx, -1, `missing step in doc: ${step}`);
+    return { step, idx };
+  });
+
+  // ensure strict ordering
+  for (let i = 1; i < found.length; i++) {
+    assert.ok(
+      found[i].idx > found[i - 1].idx,
+      `execution order violated: ${found[i].step}`
+    );
+  }
+
+  // ensure no duplicates
+  const unique = new Set(EXPECTED_SEQUENCE);
+  assert.equal(unique.size, EXPECTED_SEQUENCE.length, "duplicate steps not allowed");
+});


### PR DESCRIPTION
## Summary
- add V1 operator execution order note
- define exact linear operator order for packaging, verification, signoff, and promotion
- add V1_OPERATOR_EXECUTION_ORDER.md to the packaging surface registry so the repo-known execution surface stays complete

## Proof
- npm exec tsc -- -p tsconfig.json
- node --test --test-concurrency=1 .\test\postv1_packaging_surface_registry.test.mjs
- node --test --test-concurrency=1 .\test\postv1_packaging_surface_registry_guard.test.mjs
- node --test --test-concurrency=1 .\test\postv1_operator_execution_order.test.mjs
- node .\ci\guards\postv1_packaging_surface_registry_guard.mjs