### PR TITLE
test(postv1): add release operations boundary

### DIFF
--- a/ci/scripts/run_postv1_release_operations_boundary.mjs
+++ b/ci/scripts/run_postv1_release_operations_boundary.mjs
@@ -1,0 +1,93 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+const DEFAULT_BOUNDARY_PATH = 'docs/releases/V1_RELEASE_OPERATIONS_BOUNDARY.json';
+
+function fail(message) {
+  console.error(`release_operations_boundary: FAIL - ${message}`);
+  process.exit(1);
+}
+
+function ok(message) {
+  console.log(`OK: release_operations_boundary (${message})`);
+}
+
+function readJson(absPath) {
+  try {
+    return JSON.parse(fs.readFileSync(absPath, 'utf8'));
+  } catch (error) {
+    fail(`invalid JSON at ${path.relative(process.cwd(), absPath)}: ${error instanceof Error ? error.message : String(error)}`);
+  }
+}
+
+function ensureStringArray(value, label) {
+  if (!Array.isArray(value) || value.length === 0) {
+    fail(`${label} must be a non-empty array`);
+  }
+  for (const item of value) {
+    if (typeof item !== 'string' || item.length === 0) {
+      fail(`${label} entries must be non-empty strings`);
+    }
+  }
+}
+
+function main() {
+  const boundaryArg = process.argv[2] ?? DEFAULT_BOUNDARY_PATH;
+  const boundaryPath = path.resolve(boundaryArg);
+
+  if (!fs.existsSync(boundaryPath)) {
+    fail(`missing boundary file: ${path.relative(process.cwd(), boundaryPath)}`);
+  }
+
+  const boundary = readJson(boundaryPath);
+
+  if (boundary?.name !== 'v1_release_operations_boundary') {
+    fail('boundary name must be "v1_release_operations_boundary"');
+  }
+
+  ensureStringArray(boundary.claims, 'claims');
+  ensureStringArray(boundary.surfaces, 'surfaces');
+
+  const claimSet = new Set(boundary.claims);
+  if (claimSet.size !== boundary.claims.length) {
+    fail('claims must be unique');
+  }
+
+  const surfaceSet = new Set(boundary.surfaces);
+  if (surfaceSet.size !== boundary.surfaces.length) {
+    fail('surfaces must be unique');
+  }
+
+  const requiredClaims = [
+    'post_v1_packaging_surface',
+    'post_v1_evidence_surface',
+    'post_v1_acceptance_surface',
+    'post_v1_promotion_surface'
+  ];
+
+  for (const claim of requiredClaims) {
+    if (!claimSet.has(claim)) {
+      fail(`missing required claim: ${claim}`);
+    }
+  }
+
+  for (const relPath of boundary.surfaces) {
+    if (relPath.includes('\u005c')) {
+      fail(`surface must use forward slashes: ${relPath}`);
+    }
+    if (relPath.endsWith('/')) {
+      fail(`surface must be a file, not directory: ${relPath}`);
+    }
+    const absPath = path.resolve(relPath);
+    if (!fs.existsSync(absPath)) {
+      fail(`missing claimed surface: ${relPath}`);
+    }
+    if (!fs.statSync(absPath).isFile()) {
+      fail(`claimed surface is not a file: ${relPath}`);
+    }
+  }
+
+  ok(`boundary verified (${boundary.claims.length} claims, ${boundary.surfaces.length} surfaces)`);
+}
+
+main();

--- a/docs/releases/V1_PACKAGING_SURFACE_REGISTRY.json
+++ b/docs/releases/V1_PACKAGING_SURFACE_REGISTRY.json
@@ -6,6 +6,7 @@
                      "ci/scripts/run_postv1_mainline_post_merge_verification.mjs",
                      "ci/scripts/run_postv1_merge_readiness_verifier.mjs",
                      "ci/scripts/run_postv1_packaging_evidence_manifest_verifier.mjs",
+                     "ci/scripts/run_postv1_release_operations_boundary.mjs",
                      "ci/scripts/run_release_claim_validator.mjs",
                      "docs/releases/V1_ACCEPTANCE_PACK_INDEX.md",
                      "docs/releases/V1_ACCEPTANCE_SIGNOFF.md",
@@ -19,6 +20,7 @@
                      "docs/releases/V1_RELEASE_ARTEFACT_NAMING_CONTRACT.md",
                      "docs/releases/V1_RELEASE_CHECKLIST.md",
                      "docs/releases/V1_RELEASE_NOTES.md",
+                     "docs/releases/V1_RELEASE_OPERATIONS_BOUNDARY.json",
                      "docs/releases/V1_ROLLBACK.md",
                      "docs/releases/V1_VERSION_AND_TAG.md"
                  ]

--- a/docs/releases/V1_RELEASE_OPERATIONS_BOUNDARY.json
+++ b/docs/releases/V1_RELEASE_OPERATIONS_BOUNDARY.json
@@ -1,0 +1,31 @@
+{
+  "name": "v1_release_operations_boundary",
+  "claims": [
+    "post_v1_packaging_surface",
+    "post_v1_evidence_surface",
+    "post_v1_acceptance_surface",
+    "post_v1_promotion_surface"
+  ],
+  "surfaces": [
+    "docs/releases/V1_PACKAGING_SURFACE_REGISTRY.json",
+    "docs/releases/V1_OPERATOR_EXECUTION_ORDER.md",
+    "docs/releases/V1_ACCEPTANCE_PACK_INDEX.md",
+    "docs/releases/V1_ACCEPTANCE_SIGNOFF.md",
+    "docs/releases/V1_MAINLINE_GREEN_RUN_EVIDENCE.md",
+    "docs/releases/V1_OPERATOR_RUNBOOK.md",
+    "docs/releases/V1_PACKAGING_EVIDENCE_MANIFEST.json",
+    "docs/releases/V1_PACKAGING_PROMOTION_PR_BODY_TEMPLATE.md",
+    "docs/releases/V1_PROMOTION_FLOW.md",
+    "docs/releases/V1_RELEASE_ARTEFACT_NAMING_CONTRACT.md",
+    "docs/releases/V1_RELEASE_CHECKLIST.md",
+    "docs/releases/V1_RELEASE_NOTES.md",
+    "docs/releases/V1_ROLLBACK.md",
+    "docs/releases/V1_VERSION_AND_TAG.md",
+    "ci/scripts/build_postv1_packaging_evidence.mjs",
+    "ci/scripts/run_postv1_final_acceptance_gate.mjs",
+    "ci/scripts/run_postv1_mainline_post_merge_verification.mjs",
+    "ci/scripts/run_postv1_merge_readiness_verifier.mjs",
+    "ci/scripts/run_postv1_packaging_evidence_manifest_verifier.mjs",
+    "ci/scripts/run_release_claim_validator.mjs"
+  ]
+}

--- a/test/postv1_release_operations_boundary.test.mjs
+++ b/test/postv1_release_operations_boundary.test.mjs
@@ -1,0 +1,44 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+
+const SCRIPT_PATH = path.resolve('ci/scripts/run_postv1_release_operations_boundary.mjs');
+const BOUNDARY_PATH = path.resolve('docs/releases/V1_RELEASE_OPERATIONS_BOUNDARY.json');
+
+function runVerifier(boundaryPath) {
+  return spawnSync(
+    process.execPath,
+    [SCRIPT_PATH, boundaryPath],
+    { encoding: 'utf8' }
+  );
+}
+
+test('P40: release operations boundary file exists', () => {
+  assert.equal(fs.existsSync(BOUNDARY_PATH), true);
+});
+
+test('P40: release operations boundary verifier passes on repo boundary', () => {
+  const result = runVerifier(BOUNDARY_PATH);
+  assert.equal(result.status, 0, `expected verifier to pass\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`);
+  assert.match(result.stdout, /OK: release_operations_boundary/);
+});
+
+test('P40: release operations boundary verifier fails on missing claimed surface', () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'postv1-release-operations-boundary-'));
+  const badBoundaryPath = path.join(tmpDir, 'boundary.json');
+
+  const parsed = JSON.parse(fs.readFileSync(BOUNDARY_PATH, 'utf8'));
+  parsed.surfaces = [...parsed.surfaces, 'docs/releases/V1_DOES_NOT_EXIST.md'];
+
+  fs.writeFileSync(badBoundaryPath, `${JSON.stringify(parsed, null, 2)}\n`, 'utf8');
+
+  const result = runVerifier(badBoundaryPath);
+  assert.notEqual(result.status, 0, 'expected verifier to fail');
+  assert.match(
+    `${result.stdout}\n${result.stderr}`,
+    /missing claimed surface: docs\/releases\/V1_DOES_NOT_EXIST\.md/
+  );
+});


### PR DESCRIPTION
## Summary
- add V1 release operations boundary
- add verifier for claimed release operations surfaces
- add boundary script and boundary document to the packaging surface registry so the declared release surface stays repo-complete

## Proof
- npm exec tsc -- -p tsconfig.json
- node --test --test-concurrency=1 .\test\postv1_packaging_surface_registry.test.mjs
- node --test --test-concurrency=1 .\test\postv1_packaging_surface_registry_guard.test.mjs
- node --test --test-concurrency=1 .\test\postv1_release_operations_boundary.test.mjs
- node .\ci\scripts\run_postv1_release_operations_boundary.mjs
- node .\ci\guards\postv1_packaging_surface_registry_guard.mjs