### PR TITLE
test(postv1): close evidence surface

### DIFF
--- a/ci/scripts/run_postv1_evidence_surface_verifier.mjs
+++ b/ci/scripts/run_postv1_evidence_surface_verifier.mjs
@@ -1,0 +1,138 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+const DEFAULT_REGISTRY_PATH = 'docs/releases/V1_EVIDENCE_SURFACE_REGISTRY.json';
+const DEFAULT_SURFACE_ROOT = 'docs/releases';
+const CANONICAL_SURFACE_ROOT = 'docs/releases';
+const REGISTRY_BASENAME = 'V1_EVIDENCE_SURFACE_REGISTRY.json';
+const REGISTRY_CANONICAL_PATH = `${CANONICAL_SURFACE_ROOT}/${REGISTRY_BASENAME}`;
+
+function fail(message) {
+  console.error(`evidence_surface: FAIL - ${message}`);
+  process.exit(1);
+}
+
+function ok(message) {
+  console.log(`OK: evidence_surface (${message})`);
+}
+
+function readJson(absPath) {
+  try {
+    return JSON.parse(fs.readFileSync(absPath, 'utf8'));
+  } catch (error) {
+    fail(`invalid JSON at ${path.relative(process.cwd(), absPath)}: ${error instanceof Error ? error.message : String(error)}`);
+  }
+}
+
+function toPosixRelative(relPath) {
+  return relPath.split(path.sep).join(path.posix.sep);
+}
+
+function isEvidenceSurface(relPath) {
+  const base = path.posix.basename(relPath);
+  return (
+    /^V1_.*EVIDENCE.*\.(md|json)$/.test(base) ||
+    base === 'V1_ARTEFACT_MANIFEST.json'
+  );
+}
+
+function toCanonicalSurfacePath(fileName) {
+  return `${CANONICAL_SURFACE_ROOT}/${fileName}`;
+}
+
+function listEvidenceSurfaces(surfaceRootAbs) {
+  if (!fs.existsSync(surfaceRootAbs)) {
+    fail(`missing evidence surface root: ${path.relative(process.cwd(), surfaceRootAbs)}`);
+  }
+
+  return fs.readdirSync(surfaceRootAbs, { withFileTypes: true })
+    .filter((entry) => entry.isFile())
+    .map((entry) => toCanonicalSurfacePath(entry.name))
+    .filter((relPath) => relPath !== REGISTRY_CANONICAL_PATH)
+    .filter((relPath) => isEvidenceSurface(relPath))
+    .sort();
+}
+
+function readRegistry(registryAbsPath, registryRelPath) {
+  if (!fs.existsSync(registryAbsPath)) {
+    fail(`missing evidence surface registry: ${registryRelPath}`);
+  }
+
+  const parsed = readJson(registryAbsPath);
+
+  if (parsed?.name !== 'v1_evidence_surface_registry') {
+    fail('registry name must be "v1_evidence_surface_registry"');
+  }
+
+  if (!Array.isArray(parsed?.surfaces) || parsed.surfaces.length === 0) {
+    fail('surfaces must be a non-empty array');
+  }
+
+  const normalized = parsed.surfaces.map((value) => {
+    if (typeof value !== 'string' || value.length === 0) {
+      fail(`surface entry must be a non-empty string: ${String(value)}`);
+    }
+    return value;
+  });
+
+  const unique = [...new Set(normalized)].sort();
+  if (unique.length !== normalized.length) {
+    fail('surface entries must be unique');
+  }
+
+  if (unique.includes(registryRelPath) || unique.includes(REGISTRY_CANONICAL_PATH)) {
+    fail(`registry must not include itself as an evidence surface: ${REGISTRY_CANONICAL_PATH}`);
+  }
+
+  for (const relPath of unique) {
+    if (relPath.includes('\u005c')) {
+      fail(`surface path must use forward slashes: ${relPath}`);
+    }
+    if (!relPath.startsWith('docs/releases/')) {
+      fail(`evidence surface must live under docs/releases: ${relPath}`);
+    }
+    if (!isEvidenceSurface(relPath)) {
+      fail(`registry contains non-evidence surface: ${relPath}`);
+    }
+
+    const absPath = path.resolve(relPath);
+    if (!fs.existsSync(absPath)) {
+      fail(`missing declared evidence surface: ${relPath}`);
+    }
+    if (!fs.statSync(absPath).isFile()) {
+      fail(`declared evidence surface is not a file: ${relPath}`);
+    }
+  }
+
+  return unique;
+}
+
+function main() {
+  const registryArg = process.argv[2] ?? DEFAULT_REGISTRY_PATH;
+  const surfaceRootArg = process.argv[3] ?? DEFAULT_SURFACE_ROOT;
+
+  const registryAbsPath = path.resolve(registryArg);
+  const registryRelPath = toPosixRelative(path.relative(process.cwd(), registryAbsPath));
+  const surfaceRootAbs = path.resolve(surfaceRootArg);
+
+  const registryEntries = readRegistry(registryAbsPath, registryRelPath);
+  const discoveredEntries = listEvidenceSurfaces(surfaceRootAbs);
+
+  const registrySet = new Set(registryEntries);
+  const discoveredSet = new Set(discoveredEntries);
+
+  const undeclared = discoveredEntries.filter((relPath) => !registrySet.has(relPath));
+  const missingDeclared = registryEntries.filter((relPath) => !discoveredSet.has(relPath));
+
+  if (undeclared.length > 0) {
+    fail(`undeclared evidence surface(s): ${undeclared.join(', ')}`);
+  }
+
+  if (missingDeclared.length > 0) {
+    fail(`declared evidence surface(s) not discovered in root: ${missingDeclared.join(', ')}`);
+  }
+
+  ok(`registry matches legal evidence surfaces (${registryEntries.length} entries)`);
+}
+
+main();

--- a/docs/releases/V1_EVIDENCE_SURFACE_REGISTRY.json
+++ b/docs/releases/V1_EVIDENCE_SURFACE_REGISTRY.json
@@ -1,0 +1,8 @@
+{
+  "name": "v1_evidence_surface_registry",
+  "surfaces": [
+    "docs/releases/V1_ARTEFACT_MANIFEST.json",
+    "docs/releases/V1_MAINLINE_GREEN_RUN_EVIDENCE.md",
+    "docs/releases/V1_PACKAGING_EVIDENCE_MANIFEST.json"
+  ]
+}

--- a/docs/releases/V1_PACKAGING_SURFACE_REGISTRY.json
+++ b/docs/releases/V1_PACKAGING_SURFACE_REGISTRY.json
@@ -3,6 +3,7 @@
   "surfaces": [
     "ci/scripts/build_postv1_packaging_evidence.mjs",
     "ci/scripts/run_postv1_acceptance_artefact_completeness_verifier.mjs",
+    "ci/scripts/run_postv1_evidence_surface_verifier.mjs",
     "ci/scripts/run_postv1_final_acceptance_gate.mjs",
     "ci/scripts/run_postv1_mainline_post_merge_verification.mjs",
     "ci/scripts/run_postv1_merge_readiness_verifier.mjs",
@@ -14,6 +15,7 @@
     "docs/releases/V1_ACCEPTANCE_PACK_INDEX.md",
     "docs/releases/V1_ACCEPTANCE_SIGNOFF.md",
     "docs/releases/V1_ARTEFACT_MANIFEST.json",
+    "docs/releases/V1_EVIDENCE_SURFACE_REGISTRY.json",
     "docs/releases/V1_MAINLINE_GREEN_RUN_EVIDENCE.md",
     "docs/releases/V1_OPERATOR_EXECUTION_ORDER.md",
     "docs/releases/V1_OPERATOR_RUNBOOK.md",

--- a/test/postv1_evidence_surface_verifier.test.mjs
+++ b/test/postv1_evidence_surface_verifier.test.mjs
@@ -1,0 +1,61 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+
+const SCRIPT_PATH = path.resolve('ci/scripts/run_postv1_evidence_surface_verifier.mjs');
+const REGISTRY_PATH = path.resolve('docs/releases/V1_EVIDENCE_SURFACE_REGISTRY.json');
+const SURFACE_ROOT = path.resolve('docs/releases');
+
+function runVerifier(registryPath, surfaceRoot) {
+  return spawnSync(
+    process.execPath,
+    [SCRIPT_PATH, registryPath, surfaceRoot],
+    { encoding: 'utf8' }
+  );
+}
+
+test('P45: evidence surface verifier passes on repo registry', () => {
+  const result = runVerifier(REGISTRY_PATH, SURFACE_ROOT);
+  assert.equal(result.status, 0, `expected verifier to pass\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`);
+  assert.match(result.stdout, /OK: evidence_surface/);
+});
+
+test('P45: evidence surface verifier fails when a stray evidence file exists', () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'postv1-evidence-surface-'));
+  const releasesDir = path.join(tmpDir, 'docs', 'releases');
+  fs.mkdirSync(releasesDir, { recursive: true });
+
+  const registry = {
+    name: 'v1_evidence_surface_registry',
+    surfaces: [
+      'docs/releases/V1_ARTEFACT_MANIFEST.json',
+      'docs/releases/V1_MAINLINE_GREEN_RUN_EVIDENCE.md',
+      'docs/releases/V1_PACKAGING_EVIDENCE_MANIFEST.json'
+    ]
+  };
+
+  fs.writeFileSync(
+    path.join(releasesDir, 'V1_EVIDENCE_SURFACE_REGISTRY.json'),
+    `${JSON.stringify(registry, null, 2)}\n`,
+    'utf8'
+  );
+
+  fs.writeFileSync(path.join(releasesDir, 'V1_ARTEFACT_MANIFEST.json'), '{}\n', 'utf8');
+  fs.writeFileSync(path.join(releasesDir, 'V1_MAINLINE_GREEN_RUN_EVIDENCE.md'), '# mainline green run\n', 'utf8');
+  fs.writeFileSync(path.join(releasesDir, 'V1_PACKAGING_EVIDENCE_MANIFEST.json'), '{}\n', 'utf8');
+  fs.writeFileSync(path.join(releasesDir, 'V1_INFORMAL_EVIDENCE_NOTE.md'), '# stray evidence\n', 'utf8');
+
+  const result = runVerifier(
+    path.join(releasesDir, 'V1_EVIDENCE_SURFACE_REGISTRY.json'),
+    releasesDir
+  );
+
+  assert.notEqual(result.status, 0, 'expected verifier to fail');
+  assert.match(
+    `${result.stdout}\n${result.stderr}`,
+    /undeclared evidence surface\(s\): docs\/releases\/V1_INFORMAL_EVIDENCE_NOTE\.md/
+  );
+});


### PR DESCRIPTION
## Summary
- add post-v1 evidence surface verifier
- add canonical evidence surface registry
- register new packaging surfaces in the packaging surface registry
- add proof test for pass and stray evidence file failure path

## Proof
- node .\ci\guards\postv1_packaging_surface_registry_guard.mjs
- npm exec tsc -- -p tsconfig.json
- node --test --test-concurrency=1 .\test\postv1_evidence_surface_verifier.test.mjs
- node .\ci\scripts\run_postv1_evidence_surface_verifier.mjs