### PR TITLE
test(postv1): add rollback boundary contract

### DIFF
--- a/docs/releases/V1_ROLLBACK.md
+++ b/docs/releases/V1_ROLLBACK.md
@@ -22,3 +22,10 @@ It is an operator guidance artefact only and does not represent an automated rol
 - no infrastructure rollback mechanism is claimed here
 - no database rollback mechanism is claimed here
 - no guarantee is made that a git tag alone is sufficient for recovery
+## Rollback boundary
+
+Rollback is limited to repo-known rollback artefacts and declared operator steps.
+
+Rollback does not claim any rollback capability outside the declared release boundary.
+
+Rollback claims are limited to files, checks, and steps that exist in this repository and are explicitly declared in the release artefacts.

--- a/test/postv1_rollback_boundary_contract.test.mjs
+++ b/test/postv1_rollback_boundary_contract.test.mjs
@@ -1,0 +1,43 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const ROLLBACK_PATH = path.resolve('docs/releases/V1_ROLLBACK.md');
+
+function readRollback() {
+  return fs.readFileSync(ROLLBACK_PATH, 'utf8');
+}
+
+test('P47: rollback boundary doc exists', () => {
+  assert.equal(fs.existsSync(ROLLBACK_PATH), true, 'expected rollback doc to exist');
+  assert.equal(fs.statSync(ROLLBACK_PATH).isFile(), true, 'expected rollback path to be a file');
+});
+
+test('P47: rollback boundary limits rollback claims to repo-known artefacts and steps', () => {
+  const content = readRollback();
+
+  assert.match(
+    content,
+    /## Rollback boundary/i,
+    'expected "Rollback boundary" section'
+  );
+
+  assert.match(
+    content,
+    /rollback is limited to repo-known rollback artefacts and declared operator steps/i,
+    'expected explicit rollback boundary statement'
+  );
+
+  assert.match(
+    content,
+    /does not claim any rollback capability outside the declared release boundary/i,
+    'expected explicit exclusion of out-of-bound rollback claims'
+  );
+
+  assert.match(
+    content,
+    /rollback claims are limited to files, checks, and steps that exist in this repository and are explicitly declared in the release artefacts/i,
+    'expected explicit repo-known rollback surface statement'
+  );
+});


### PR DESCRIPTION
## Summary
- define rollback scope as repo-known rollback artefacts and declared operator steps only
- explicitly exclude rollback claims outside the declared release boundary
- add proof test that the rollback boundary contract exists and contains the required limits

## Proof
- npm exec tsc -- -p tsconfig.json
- node --test --test-concurrency=1 .\test\postv1_rollback_boundary_contract.test.mjs