### PR TITLE
test(postv1): add mainline verification dependency lock

### DIFF
--- a/ci/scripts/run_postv1_mainline_verification_dependency_verifier.mjs
+++ b/ci/scripts/run_postv1_mainline_verification_dependency_verifier.mjs
@@ -1,0 +1,102 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+const DEFAULT_BOUNDARY_PATH = 'docs/releases/V1_RELEASE_OPERATIONS_BOUNDARY.json';
+const DEFAULT_MAINLINE_SCRIPT_PATH = 'ci/scripts/run_postv1_mainline_post_merge_verification.mjs';
+
+function fail(message) {
+  console.error(`mainline_verification_dependency: FAIL - ${message}`);
+  process.exit(1);
+}
+
+function ok(message) {
+  console.log(`OK: mainline_verification_dependency (${message})`);
+}
+
+function readJson(absPath) {
+  try {
+    return JSON.parse(fs.readFileSync(absPath, 'utf8'));
+  } catch (error) {
+    fail(`invalid JSON at ${path.relative(process.cwd(), absPath)}: ${error instanceof Error ? error.message : String(error)}`);
+  }
+}
+
+function parseNodeStringLiterals(source) {
+  const literals = new Set();
+  const regex = /'([^'\r\n]+)'|"([^"\r\n]+)"/g;
+
+  for (const match of source.matchAll(regex)) {
+    const value = match[1] ?? match[2] ?? '';
+    if (value.length > 0) {
+      literals.add(value);
+    }
+  }
+
+  return [...literals];
+}
+
+function normalizeBoundaryEntries(parsed) {
+  const allowed = new Set();
+
+  const arrays = [
+    parsed?.artefacts,
+    parsed?.allowed_surfaces,
+    parsed?.surfaces,
+    parsed?.files,
+    parsed?.scripts,
+    parsed?.docs
+  ].filter(Array.isArray);
+
+  for (const entries of arrays) {
+    for (const value of entries) {
+      if (typeof value !== 'string' || value.length === 0) {
+        fail(`boundary entry must be a non-empty string: ${String(value)}`);
+      }
+      allowed.add(value);
+    }
+  }
+
+  if (allowed.size === 0) {
+    fail('release operations boundary must declare at least one allowed surface');
+  }
+
+  return [...allowed].sort();
+}
+
+function discoverRepoPathDependencies(source) {
+  return parseNodeStringLiterals(source)
+    .filter((value) => /^(docs\/releases|ci\/scripts)\//.test(value))
+    .sort();
+}
+
+function main() {
+  const boundaryArg = process.argv[2] ?? DEFAULT_BOUNDARY_PATH;
+  const scriptArg = process.argv[3] ?? DEFAULT_MAINLINE_SCRIPT_PATH;
+
+  const boundaryPath = path.resolve(boundaryArg);
+  const scriptPath = path.resolve(scriptArg);
+
+  if (!fs.existsSync(boundaryPath)) {
+    fail(`missing release operations boundary: ${path.relative(process.cwd(), boundaryPath)}`);
+  }
+
+  if (!fs.existsSync(scriptPath)) {
+    fail(`missing mainline verification script: ${path.relative(process.cwd(), scriptPath)}`);
+  }
+
+  const boundaryParsed = readJson(boundaryPath);
+  const allowedSurfaces = normalizeBoundaryEntries(boundaryParsed);
+  const allowedSet = new Set(allowedSurfaces);
+
+  const scriptSource = fs.readFileSync(scriptPath, 'utf8');
+  const discoveredDependencies = discoverRepoPathDependencies(scriptSource);
+  const undeclared = discoveredDependencies.filter((value) => !allowedSet.has(value));
+
+  if (undeclared.length > 0) {
+    fail(`undeclared dependency surface(s): ${undeclared.join(', ')}`);
+  }
+
+  ok(`all mainline verification dependency surfaces declared (${discoveredDependencies.length} dependencies checked)`);
+}
+
+main();

--- a/docs/releases/V1_PACKAGING_SURFACE_REGISTRY.json
+++ b/docs/releases/V1_PACKAGING_SURFACE_REGISTRY.json
@@ -6,6 +6,7 @@
     "ci/scripts/run_postv1_evidence_surface_verifier.mjs",
     "ci/scripts/run_postv1_final_acceptance_gate.mjs",
     "ci/scripts/run_postv1_mainline_post_merge_verification.mjs",
+    "ci/scripts/run_postv1_mainline_verification_dependency_verifier.mjs",
     "ci/scripts/run_postv1_merge_readiness_verifier.mjs",
     "ci/scripts/run_postv1_packaging_evidence_manifest_verifier.mjs",
     "ci/scripts/run_postv1_promotion_artefact_completeness_verifier.mjs",

--- a/test/postv1_mainline_verification_dependency_verifier.test.mjs
+++ b/test/postv1_mainline_verification_dependency_verifier.test.mjs
@@ -1,0 +1,67 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+
+const SCRIPT_PATH = path.resolve('ci/scripts/run_postv1_mainline_verification_dependency_verifier.mjs');
+const BOUNDARY_PATH = path.resolve('docs/releases/V1_RELEASE_OPERATIONS_BOUNDARY.json');
+const MAINLINE_SCRIPT_PATH = path.resolve('ci/scripts/run_postv1_mainline_post_merge_verification.mjs');
+
+function runVerifier(boundaryPath, scriptPath) {
+  return spawnSync(
+    process.execPath,
+    [SCRIPT_PATH, boundaryPath, scriptPath],
+    { encoding: 'utf8' }
+  );
+}
+
+test('P48: mainline verification dependency verifier passes on repo surfaces', () => {
+  const result = runVerifier(BOUNDARY_PATH, MAINLINE_SCRIPT_PATH);
+  assert.equal(result.status, 0, `expected verifier to pass\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`);
+  assert.match(result.stdout, /OK: mainline_verification_dependency/);
+});
+
+test('P48: mainline verification dependency verifier fails on undeclared dependency surface', () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'postv1-mainline-dependency-'));
+  const boundaryCopyPath = path.join(tmpDir, 'V1_RELEASE_OPERATIONS_BOUNDARY.json');
+  const mainlineCopyPath = path.join(tmpDir, 'run_postv1_mainline_post_merge_verification.mjs');
+
+  const boundary = JSON.parse(fs.readFileSync(BOUNDARY_PATH, 'utf8'));
+
+  if (Array.isArray(boundary.artefacts) && !boundary.artefacts.includes('docs/releases/V1_RELEASE_OPERATIONS_BOUNDARY.json')) {
+    boundary.artefacts = [...boundary.artefacts, 'docs/releases/V1_RELEASE_OPERATIONS_BOUNDARY.json'];
+  }
+  if (Array.isArray(boundary.allowed_surfaces) && !boundary.allowed_surfaces.includes('docs/releases/V1_RELEASE_OPERATIONS_BOUNDARY.json')) {
+    boundary.allowed_surfaces = [...boundary.allowed_surfaces, 'docs/releases/V1_RELEASE_OPERATIONS_BOUNDARY.json'];
+  }
+  if (Array.isArray(boundary.surfaces) && !boundary.surfaces.includes('docs/releases/V1_RELEASE_OPERATIONS_BOUNDARY.json')) {
+    boundary.surfaces = [...boundary.surfaces, 'docs/releases/V1_RELEASE_OPERATIONS_BOUNDARY.json'];
+  }
+  if (Array.isArray(boundary.files) && !boundary.files.includes('docs/releases/V1_RELEASE_OPERATIONS_BOUNDARY.json')) {
+    boundary.files = [...boundary.files, 'docs/releases/V1_RELEASE_OPERATIONS_BOUNDARY.json'];
+  }
+  if (Array.isArray(boundary.docs) && !boundary.docs.includes('docs/releases/V1_RELEASE_OPERATIONS_BOUNDARY.json')) {
+    boundary.docs = [...boundary.docs, 'docs/releases/V1_RELEASE_OPERATIONS_BOUNDARY.json'];
+  }
+
+  fs.writeFileSync(boundaryCopyPath, `${JSON.stringify(boundary, null, 2)}\n`, 'utf8');
+
+  const source = [
+    "import fs from 'node:fs';",
+    "const declared = 'docs/releases/V1_RELEASE_OPERATIONS_BOUNDARY.json';",
+    "const stray = 'docs/releases/V1_UNDECLARED_DEPENDENCY.md';",
+    "void fs.existsSync(declared);",
+    "void fs.existsSync(stray);"
+  ].join('\n');
+
+  fs.writeFileSync(mainlineCopyPath, `${source}\n`, 'utf8');
+
+  const result = runVerifier(boundaryCopyPath, mainlineCopyPath);
+  assert.notEqual(result.status, 0, 'expected verifier to fail');
+  assert.match(
+    `${result.stdout}\n${result.stderr}`,
+    /undeclared dependency surface\(s\): docs\/releases\/V1_UNDECLARED_DEPENDENCY\.md/
+  );
+});


### PR DESCRIPTION
## Summary
- add post-v1 mainline verification dependency verifier
- prove undeclared literal repo-path dependency surfaces are rejected
- register the verifier in the packaging surface registry
- add negative test for undeclared dependency surface failure

## Proof
- node .\ci\guards\postv1_packaging_surface_registry_guard.mjs
- npm exec tsc -- -p tsconfig.json
- node --test --test-concurrency=1 .\test\postv1_mainline_verification_dependency_verifier.test.mjs
- node .\ci\scripts\run_postv1_mainline_verification_dependency_verifier.mjs