### PR TITLE
test(postv1): add operator runbook scope lock

### DIFF
--- a/docs/releases/V1_OPERATOR_RUNBOOK.md
+++ b/docs/releases/V1_OPERATOR_RUNBOOK.md
@@ -31,3 +31,10 @@ It does not imply automated deployment, automated publication, or automated roll
 - no automatic deployment is claimed here
 - no automatic publication is claimed here
 - no automatic rollback is claimed here
+## Runbook scope
+
+This runbook is limited to declared release operations boundary content only.
+
+This runbook does not introduce any extra operational surface outside the declared boundary.
+
+All operator actions in this runbook must map to repo-declared release artefacts, checks, or operator steps.

--- a/test/postv1_operator_runbook_scope_lock.test.mjs
+++ b/test/postv1_operator_runbook_scope_lock.test.mjs
@@ -1,0 +1,43 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const RUNBOOK_PATH = path.resolve('docs/releases/V1_OPERATOR_RUNBOOK.md');
+
+function readRunbook() {
+  return fs.readFileSync(RUNBOOK_PATH, 'utf8');
+}
+
+test('P49: operator runbook exists', () => {
+  assert.equal(fs.existsSync(RUNBOOK_PATH), true, 'expected operator runbook to exist');
+  assert.equal(fs.statSync(RUNBOOK_PATH).isFile(), true, 'expected operator runbook path to be a file');
+});
+
+test('P49: operator runbook scope is locked to declared operations boundary content only', () => {
+  const content = readRunbook();
+
+  assert.match(
+    content,
+    /## Runbook scope/i,
+    'expected "Runbook scope" section'
+  );
+
+  assert.match(
+    content,
+    /this runbook is limited to declared release operations boundary content only/i,
+    'expected explicit boundary-only scope statement'
+  );
+
+  assert.match(
+    content,
+    /does not introduce any extra operational surface outside the declared boundary/i,
+    'expected explicit exclusion of extra operational surface'
+  );
+
+  assert.match(
+    content,
+    /all operator actions in this runbook must map to repo-declared release artefacts, checks, or operator steps/i,
+    'expected explicit repo-declared mapping statement'
+  );
+});


### PR DESCRIPTION
## Summary
- constrain the operator runbook to declared release operations boundary content only
- explicitly exclude extra operational surface outside the declared boundary
- add proof test that the runbook scope lock exists and contains the required limits

## Proof
- npm exec tsc -- -p tsconfig.json
- node --test --test-concurrency=1 .\test\postv1_operator_runbook_scope_lock.test.mjs