### PR TITLE
test(postv1): add promotion flow legality chain verifier

### DIFF
--- a/ci/scripts/run_postv1_promotion_flow_legality_chain_verifier.mjs
+++ b/ci/scripts/run_postv1_promotion_flow_legality_chain_verifier.mjs
@@ -1,0 +1,321 @@
+import fs from "node:fs";
+import path from "node:path";
+
+const FAILURE = {
+  PROMOTION_FLOW_MISSING_DECLARED_PRECONDITION: "promotion_flow_missing_declared_precondition",
+  PROMOTION_FLOW_MISSING_CHAIN_STEP: "promotion_flow_missing_chain_step",
+  PROMOTION_FLOW_ILLEGAL_BYPASS: "promotion_flow_illegal_bypass",
+  PROMOTION_FLOW_UNPARSEABLE_SOURCE: "promotion_flow_unparseable_source",
+};
+
+const REQUIRED_CHAIN_STEPS = [
+  {
+    key: "packaging",
+    pattern: /\bpackaging\b/i,
+    declared: [
+      "docs/releases/V1_PACKAGING_EVIDENCE_MANIFEST.json",
+      "ci/scripts/run_postv1_packaging_evidence_manifest_verifier.mjs",
+      "docs/releases/V1_PACKAGING_SURFACE_REGISTRY.json",
+    ],
+  },
+  {
+    key: "evidence",
+    pattern: /\bevidence\b/i,
+    declared: [
+      "docs/releases/V1_EVIDENCE_SURFACE_REGISTRY.json",
+      "docs/releases/V1_MAINLINE_GREEN_RUN_EVIDENCE.md",
+      "ci/scripts/run_postv1_evidence_surface_verifier.mjs",
+      "ci/scripts/run_postv1_packaging_evidence_manifest_verifier.mjs",
+    ],
+  },
+  {
+    key: "acceptance",
+    pattern: /\bacceptance\b/i,
+    declared: [
+      "docs/releases/V1_ACCEPTANCE_ARTEFACT_SET.json",
+      "docs/releases/V1_ACCEPTANCE_PACK_INDEX.md",
+      "docs/releases/V1_ACCEPTANCE_SIGNOFF.md",
+      "docs/releases/V1_RELEASE_CHECKLIST.md",
+      "ci/scripts/run_postv1_acceptance_pack_composition_verifier.mjs",
+    ],
+  },
+  {
+    key: "merge_readiness",
+    pattern: /\bmerge readiness\b/i,
+    declared: [
+      "ci/scripts/run_postv1_merge_readiness_verifier.mjs",
+    ],
+  },
+];
+
+function normalizeRelativePath(value) {
+  return String(value).replace(/\\/g, "/");
+}
+
+function readUtf8(filePath) {
+  return fs.readFileSync(filePath, "utf8");
+}
+
+function readJson(filePath) {
+  return JSON.parse(readUtf8(filePath));
+}
+
+function createFailure(token, filePath, details) {
+  return {
+    token,
+    path: normalizeRelativePath(filePath),
+    details,
+  };
+}
+
+function resolveDeclaredPath(repoRoot, packDirAbs, rawPath) {
+  const normalizedRaw = normalizeRelativePath(rawPath).replace(/^\.\/+/, "");
+
+  const repoCandidateAbs = path.resolve(repoRoot, normalizedRaw);
+  if (fs.existsSync(repoCandidateAbs)) {
+    return {
+      repoRelative: normalizeRelativePath(path.relative(repoRoot, repoCandidateAbs)),
+      absolute: repoCandidateAbs,
+    };
+  }
+
+  const packCandidateAbs = path.resolve(packDirAbs, normalizedRaw);
+  if (fs.existsSync(packCandidateAbs)) {
+    return {
+      repoRelative: normalizeRelativePath(path.relative(repoRoot, packCandidateAbs)),
+      absolute: packCandidateAbs,
+    };
+  }
+
+  return {
+    repoRelative: normalizedRaw,
+    absolute: path.resolve(repoRoot, normalizedRaw),
+  };
+}
+
+function inferRoleFromPath(filePath) {
+  const base = path.basename(String(filePath)).toLowerCase();
+
+  if (base.includes("signoff")) return "signoff";
+  if (base.includes("checklist")) return "checklist";
+  if (base.includes("rollback")) return "rollback";
+  if (base.includes("promotion")) return "promotion";
+  if (base.includes("evidence")) return "evidence";
+  if (base.includes("index")) return "index";
+
+  return "supporting";
+}
+
+function normalizeRole(value, filePath) {
+  if (typeof value === "string" && value.trim().length > 0) {
+    return value.trim().toLowerCase();
+  }
+  return inferRoleFromPath(filePath);
+}
+
+function extractArtefactPath(item) {
+  if (typeof item === "string") {
+    return item;
+  }
+
+  if (item && typeof item === "object") {
+    const candidateKeys = [
+      "path",
+      "file",
+      "relative_path",
+      "relativePath",
+      "artifact_path",
+      "artefact_path",
+      "artifactPath",
+      "artefactPath",
+    ];
+
+    for (const key of candidateKeys) {
+      if (typeof item[key] === "string" && item[key].trim().length > 0) {
+        return item[key];
+      }
+    }
+  }
+
+  return null;
+}
+
+function extractArtefactRole(item, rawPath) {
+  if (item && typeof item === "object") {
+    const candidateKeys = [
+      "role",
+      "kind",
+      "type",
+      "surface",
+      "surface_type",
+      "surfaceType",
+      "artefact_type",
+      "artifact_type",
+      "artefactType",
+      "artifactType",
+    ];
+
+    for (const key of candidateKeys) {
+      if (typeof item[key] === "string" && item[key].trim().length > 0) {
+        return normalizeRole(item[key], rawPath);
+      }
+    }
+  }
+
+  return normalizeRole(null, rawPath);
+}
+
+function loadAcceptanceArtefactSet(repoRoot, acceptanceSetPath) {
+  const resolvedSetPath = path.resolve(repoRoot, acceptanceSetPath);
+  const packDirAbs = path.dirname(resolvedSetPath);
+  const setJson = readJson(resolvedSetPath);
+
+  if (!setJson || typeof setJson !== "object" || Array.isArray(setJson)) {
+    throw new Error("Acceptance artefact set must be a JSON object.");
+  }
+  if (!Array.isArray(setJson.artefacts)) {
+    throw new Error("Acceptance artefact set must contain an artefacts array.");
+  }
+
+  return setJson.artefacts.map((item) => {
+    const rawPath = extractArtefactPath(item);
+    if (!rawPath) {
+      throw new Error("Acceptance artefact set contains an artefact without a usable path.");
+    }
+
+    const resolved = resolveDeclaredPath(repoRoot, packDirAbs, rawPath);
+    const role = extractArtefactRole(item, rawPath);
+
+    return {
+      role,
+      repoRelative: resolved.repoRelative,
+      absolute: resolved.absolute,
+    };
+  });
+}
+
+function verifyPromotionFlowLegality({
+  repoRoot,
+  promotionFlowPath,
+  acceptanceSetPath,
+}) {
+  const failures = [];
+  const promotionFlowAbs = path.resolve(repoRoot, promotionFlowPath);
+  const promotionFlowRepoRelative = normalizeRelativePath(path.relative(repoRoot, promotionFlowAbs));
+
+  let promotionFlowText = "";
+  let acceptanceRefs = [];
+
+  try {
+    promotionFlowText = readUtf8(promotionFlowAbs);
+  } catch (error) {
+    return {
+      ok: false,
+      failures: [
+        createFailure(
+          FAILURE.PROMOTION_FLOW_UNPARSEABLE_SOURCE,
+          promotionFlowRepoRelative,
+          error instanceof Error ? error.message : String(error)
+        ),
+      ],
+    };
+  }
+
+  try {
+    acceptanceRefs = loadAcceptanceArtefactSet(repoRoot, acceptanceSetPath);
+  } catch (error) {
+    return {
+      ok: false,
+      failures: [
+        createFailure(
+          FAILURE.PROMOTION_FLOW_UNPARSEABLE_SOURCE,
+          normalizeRelativePath(acceptanceSetPath),
+          error instanceof Error ? error.message : String(error)
+        ),
+      ],
+    };
+  }
+
+  const declaredSet = new Set(acceptanceRefs.map((ref) => ref.repoRelative));
+  const stepPositions = [];
+
+  for (const step of REQUIRED_CHAIN_STEPS) {
+    const match = promotionFlowText.match(step.pattern);
+
+    if (!match || match.index === undefined) {
+      failures.push(
+        createFailure(
+          FAILURE.PROMOTION_FLOW_MISSING_CHAIN_STEP,
+          promotionFlowRepoRelative,
+          `Promotion flow must reference '${step.key}'.`
+        )
+      );
+      continue;
+    }
+
+    stepPositions.push({ key: step.key, index: match.index });
+
+    const declaredOk = step.declared.some((requiredPath) => declaredSet.has(normalizeRelativePath(requiredPath)));
+    if (!declaredOk) {
+      failures.push(
+        createFailure(
+          FAILURE.PROMOTION_FLOW_MISSING_DECLARED_PRECONDITION,
+          normalizeRelativePath(acceptanceSetPath),
+          `Promotion flow references '${step.key}' but no legal declared precondition surface for that step is present.`
+        )
+      );
+    }
+  }
+
+  if (stepPositions.length === REQUIRED_CHAIN_STEPS.length) {
+    for (let i = 1; i < stepPositions.length; i++) {
+      if (stepPositions[i - 1].index > stepPositions[i].index) {
+        failures.push(
+          createFailure(
+            FAILURE.PROMOTION_FLOW_ILLEGAL_BYPASS,
+            promotionFlowRepoRelative,
+            `Promotion flow references '${stepPositions[i].key}' before '${stepPositions[i - 1].key}', which implies an illegal bypass.`
+          )
+        );
+        break;
+      }
+    }
+  }
+
+  return {
+    ok: failures.length === 0,
+    failures,
+  };
+}
+
+function main() {
+  const repoRoot = process.cwd();
+  const promotionFlowPath = process.argv[2] ?? "docs/releases/V1_PROMOTION_FLOW.md";
+  const acceptanceSetPath = process.argv[3] ?? "docs/releases/V1_ACCEPTANCE_ARTEFACT_SET.json";
+
+  const report = verifyPromotionFlowLegality({
+    repoRoot,
+    promotionFlowPath,
+    acceptanceSetPath,
+  });
+
+  process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+  process.exitCode = report.ok ? 0 : 1;
+}
+
+try {
+  main();
+} catch (error) {
+  const report = {
+    ok: false,
+    failures: [
+      {
+        token: FAILURE.PROMOTION_FLOW_UNPARSEABLE_SOURCE,
+        path: normalizeRelativePath(process.argv[2] ?? "docs/releases/V1_PROMOTION_FLOW.md"),
+        details: error instanceof Error ? error.message : String(error),
+      },
+    ],
+  };
+  process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+  process.exitCode = 1;
+}

--- a/docs/releases/V1_ACCEPTANCE_ARTEFACT_SET.json
+++ b/docs/releases/V1_ACCEPTANCE_ARTEFACT_SET.json
@@ -26,6 +26,9 @@
 
     { "path": "ci/scripts/run_postv1_final_acceptance_gate.mjs", "role": "supporting" },
     { "path": "ci/scripts/run_postv1_release_operations_boundary.mjs", "role": "supporting" },
-    { "path": "ci/scripts/run_release_claim_validator.mjs", "role": "supporting" }
+    { "path": "ci/scripts/run_release_claim_validator.mjs", "role": "supporting" },
+    { "path": "ci/scripts/run_postv1_acceptance_pack_composition_verifier.mjs", "role": "supporting" },
+    { "path": "ci/scripts/run_postv1_release_note_claim_boundary_verifier.mjs", "role": "supporting" },
+    { "path": "ci/scripts/run_postv1_merge_readiness_verifier.mjs", "role": "supporting" }
   ]
 }

--- a/docs/releases/V1_PACKAGING_SURFACE_REGISTRY.json
+++ b/docs/releases/V1_PACKAGING_SURFACE_REGISTRY.json
@@ -31,6 +31,7 @@
                      "docs/releases/V1_RELEASE_OPERATIONS_BOUNDARY.json",
                      "docs/releases/V1_ROLLBACK.md",
                      "docs/releases/V1_VERSION_AND_TAG.md",
-                     "ci/scripts/run_postv1_release_note_claim_boundary_verifier.mjs"
+                     "ci/scripts/run_postv1_release_note_claim_boundary_verifier.mjs",
+                     "ci/scripts/run_postv1_promotion_flow_legality_chain_verifier.mjs"
                  ]
 }

--- a/docs/releases/V1_PROMOTION_FLOW.md
+++ b/docs/releases/V1_PROMOTION_FLOW.md
@@ -1,18 +1,15 @@
-# V1 promotion flow
+# V1 Promotion Flow
 
-This note records the internal repo-known promotion path from a completed packaging boundary to a merged release branch.
+1. Confirm packaging is complete against the declared packaging surfaces.
+2. Confirm evidence is present and sealed in the declared evidence surfaces.
+3. Confirm acceptance is satisfied through the declared acceptance pack, signoff, and checklist surfaces.
+4. Confirm merge readiness through the declared merge readiness verifier.
+5. Only then promote using the declared promotion surfaces.
 
-## Promotion path
-1. Confirm the packaging boundary proof for the slice is green.
-2. Stage only the intended repo files for that slice.
-3. Commit the slice on its ticket branch.
-4. Push the ticket branch to origin.
-5. Open a pull request into main.
-6. Wait for required pull request checks to pass.
-7. Merge the pull request into main using the repo-approved merge path.
-8. Sync local main to origin/main.
-9. Confirm the pull request is merged and the working tree is clean.
+## Legal chain
 
-## Boundary
-This note describes repository, branch, pull request, and merge steps only.
-It does not describe deployment, rollout, publishing, or customer-facing release activity.
+Promotion is legal only when packaging, evidence, acceptance, and merge readiness are all satisfied in that order.
+
+## Illegal bypass
+
+Promotion cannot bypass packaging, evidence, acceptance, or merge readiness.

--- a/test/postv1_promotion_flow_legality_chain_verifier.test.mjs
+++ b/test/postv1_promotion_flow_legality_chain_verifier.test.mjs
@@ -1,0 +1,128 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+
+function writeJson(filePath, value) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`, "utf8");
+}
+
+function writeText(filePath, value) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, value, "utf8");
+}
+
+function runVerifier(promotionFlowPath, acceptanceSetPath, cwd) {
+  const scriptPath = path.resolve("ci/scripts/run_postv1_promotion_flow_legality_chain_verifier.mjs");
+  const result = spawnSync(process.execPath, [scriptPath, promotionFlowPath, acceptanceSetPath], {
+    cwd,
+    encoding: "utf8",
+  });
+
+  const stdout = result.stdout.trim();
+  assert.notEqual(stdout, "", "verifier should emit JSON report to stdout");
+
+  let report;
+  try {
+    report = JSON.parse(stdout);
+  } catch (error) {
+    assert.fail(`verifier stdout was not valid JSON.\nstdout:\n${stdout}\nerror: ${error}`);
+  }
+
+  return {
+    status: result.status,
+    report,
+  };
+}
+
+function createFixture() {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "p52-promotion-flow-"));
+  const releasesDir = path.join(root, "docs", "releases");
+  const scriptsDir = path.join(root, "ci", "scripts");
+
+  writeText(
+    path.join(releasesDir, "V1_PROMOTION_FLOW.md"),
+    [
+      "# V1 Promotion Flow",
+      "",
+      "1. Complete packaging.",
+      "2. Confirm evidence.",
+      "3. Confirm acceptance.",
+      "4. Confirm merge readiness.",
+      "5. Promote."
+    ].join("\n") + "\n"
+  );
+
+  writeText(path.join(releasesDir, "V1_PACKAGING_EVIDENCE_MANIFEST.json"), "{ }\n");
+  writeText(path.join(releasesDir, "V1_EVIDENCE_SURFACE_REGISTRY.json"), "{ }\n");
+  writeText(path.join(releasesDir, "V1_MAINLINE_GREEN_RUN_EVIDENCE.md"), "# evidence\n");
+  writeText(path.join(releasesDir, "V1_ACCEPTANCE_PACK_INDEX.md"), "# acceptance\n");
+  writeText(path.join(releasesDir, "V1_ACCEPTANCE_SIGNOFF.md"), "# signoff\n");
+  writeText(path.join(releasesDir, "V1_RELEASE_CHECKLIST.md"), "# checklist\n");
+
+  writeText(path.join(scriptsDir, "run_postv1_packaging_evidence_manifest_verifier.mjs"), "// verifier\n");
+  writeText(path.join(scriptsDir, "run_postv1_evidence_surface_verifier.mjs"), "// verifier\n");
+  writeText(path.join(scriptsDir, "run_postv1_acceptance_pack_composition_verifier.mjs"), "// verifier\n");
+  writeText(path.join(scriptsDir, "run_postv1_merge_readiness_verifier.mjs"), "// verifier\n");
+
+  writeJson(path.join(releasesDir, "V1_ACCEPTANCE_ARTEFACT_SET.json"), {
+    name: "V1 acceptance artefact set",
+    artefacts: [
+      { path: "docs/releases/V1_PROMOTION_FLOW.md", role: "promotion" },
+      { path: "docs/releases/V1_PACKAGING_EVIDENCE_MANIFEST.json", role: "supporting" },
+      { path: "docs/releases/V1_EVIDENCE_SURFACE_REGISTRY.json", role: "supporting" },
+      { path: "docs/releases/V1_MAINLINE_GREEN_RUN_EVIDENCE.md", role: "evidence" },
+      { path: "docs/releases/V1_ACCEPTANCE_PACK_INDEX.md", role: "index" },
+      { path: "docs/releases/V1_ACCEPTANCE_SIGNOFF.md", role: "signoff" },
+      { path: "docs/releases/V1_RELEASE_CHECKLIST.md", role: "checklist" },
+      { path: "ci/scripts/run_postv1_packaging_evidence_manifest_verifier.mjs", role: "supporting" },
+      { path: "ci/scripts/run_postv1_evidence_surface_verifier.mjs", role: "supporting" },
+      { path: "ci/scripts/run_postv1_acceptance_pack_composition_verifier.mjs", role: "supporting" },
+      { path: "ci/scripts/run_postv1_merge_readiness_verifier.mjs", role: "supporting" }
+    ]
+  });
+
+  return {
+    root,
+    promotionFlowPath: path.join(root, "docs", "releases", "V1_PROMOTION_FLOW.md"),
+    acceptanceSetPath: path.join(root, "docs", "releases", "V1_ACCEPTANCE_ARTEFACT_SET.json"),
+  };
+}
+
+test("P52: promotion legality verifier passes when the chain is explicit and legally declared", () => {
+  const fixture = createFixture();
+  const { status, report } = runVerifier(fixture.promotionFlowPath, fixture.acceptanceSetPath, fixture.root);
+
+  assert.equal(status, 0);
+  assert.equal(report.ok, true);
+  assert.deepEqual(report.failures, []);
+});
+
+test("P52: promotion legality verifier fails when merge readiness is bypassed", () => {
+  const fixture = createFixture();
+
+  writeText(
+    fixture.promotionFlowPath,
+    [
+      "# V1 Promotion Flow",
+      "",
+      "1. Complete packaging.",
+      "2. Confirm evidence.",
+      "3. Confirm acceptance.",
+      "4. Promote."
+    ].join("\n") + "\n"
+  );
+
+  const { status, report } = runVerifier(fixture.promotionFlowPath, fixture.acceptanceSetPath, fixture.root);
+
+  assert.equal(status, 1);
+  assert.equal(report.ok, false);
+  assert.ok(Array.isArray(report.failures));
+  assert.ok(
+    report.failures.some((failure) => failure.token === "promotion_flow_missing_chain_step"),
+    `expected promotion_flow_missing_chain_step, got ${JSON.stringify(report, null, 2)}`
+  );
+});


### PR DESCRIPTION
## Summary
- add post-v1 promotion flow legality chain verifier
- require promotion flow to reference packaging, evidence, acceptance, and merge readiness in order
- align acceptance artefact set and promotion flow to the legal promotion chain

## Proof
- node --test --test-concurrency=1 .\test\postv1_promotion_flow_legality_chain_verifier.test.mjs
- node .\ci\scripts\run_postv1_promotion_flow_legality_chain_verifier.mjs .\docs\releases\V1_PROMOTION_FLOW.md .\docs\releases\V1_ACCEPTANCE_ARTEFACT_SET.json
- npm run lint:fast