### PR TITLE
test(postv1): bind version tag to release evidence surfaces

### DIFF
--- a/ci/scripts/run_postv1_release_version_tag_evidence_binding_verifier.mjs
+++ b/ci/scripts/run_postv1_release_version_tag_evidence_binding_verifier.mjs
@@ -1,0 +1,351 @@
+import fs from "node:fs";
+import path from "node:path";
+
+const FAILURE = {
+  VERSION_TAG_UNPARSEABLE_SOURCE: "version_tag_unparseable_source",
+  VERSION_TAG_MISSING_DECLARED_SURFACE: "version_tag_missing_declared_surface",
+  VERSION_TAG_MISSING_BINDING_REFERENCE: "version_tag_missing_binding_reference",
+  VERSION_TAG_DRIFT_DETECTED: "version_tag_drift_detected",
+};
+
+const REQUIRED_ACCEPTANCE_SURFACES = [
+  "docs/releases/V1_ACCEPTANCE_ARTEFACT_SET.json",
+  "docs/releases/V1_ACCEPTANCE_PACK_INDEX.md",
+  "docs/releases/V1_ACCEPTANCE_SIGNOFF.md",
+  "docs/releases/V1_RELEASE_CHECKLIST.md",
+];
+
+const REQUIRED_EVIDENCE_SURFACES = [
+  "docs/releases/V1_MAINLINE_GREEN_RUN_EVIDENCE.md",
+  "docs/releases/V1_PACKAGING_EVIDENCE_MANIFEST.json",
+  "docs/releases/V1_EVIDENCE_SURFACE_REGISTRY.json",
+];
+
+function normalizeRelativePath(value) {
+  return String(value).replace(/\\/g, "/");
+}
+
+function readUtf8(filePath) {
+  return fs.readFileSync(filePath, "utf8");
+}
+
+function readJson(filePath) {
+  return JSON.parse(readUtf8(filePath));
+}
+
+function createFailure(token, filePath, details) {
+  return {
+    token,
+    path: normalizeRelativePath(filePath),
+    details,
+  };
+}
+
+function inferRoleFromPath(filePath) {
+  const base = path.basename(String(filePath)).toLowerCase();
+
+  if (base.includes("signoff")) return "signoff";
+  if (base.includes("checklist")) return "checklist";
+  if (base.includes("rollback")) return "rollback";
+  if (base.includes("promotion")) return "promotion";
+  if (base.includes("evidence")) return "evidence";
+  if (base.includes("index")) return "index";
+
+  return "supporting";
+}
+
+function normalizeRole(value, filePath) {
+  if (typeof value === "string" && value.trim().length > 0) {
+    return value.trim().toLowerCase();
+  }
+  return inferRoleFromPath(filePath);
+}
+
+function extractArtefactPath(item) {
+  if (typeof item === "string") {
+    return item;
+  }
+
+  if (item && typeof item === "object") {
+    const candidateKeys = [
+      "path",
+      "file",
+      "relative_path",
+      "relativePath",
+      "artifact_path",
+      "artefact_path",
+      "artifactPath",
+      "artefactPath",
+    ];
+
+    for (const key of candidateKeys) {
+      if (typeof item[key] === "string" && item[key].trim().length > 0) {
+        return item[key];
+      }
+    }
+  }
+
+  return null;
+}
+
+function extractArtefactRole(item, rawPath) {
+  if (item && typeof item === "object") {
+    const candidateKeys = [
+      "role",
+      "kind",
+      "type",
+      "surface",
+      "surface_type",
+      "surfaceType",
+      "artefact_type",
+      "artifact_type",
+      "artefactType",
+      "artifactType",
+    ];
+
+    for (const key of candidateKeys) {
+      if (typeof item[key] === "string" && item[key].trim().length > 0) {
+        return normalizeRole(item[key], rawPath);
+      }
+    }
+  }
+
+  return normalizeRole(null, rawPath);
+}
+
+function resolveDeclaredPath(repoRoot, packDirAbs, rawPath) {
+  const normalizedRaw = normalizeRelativePath(rawPath).replace(/^\.\/+/, "");
+
+  const repoCandidateAbs = path.resolve(repoRoot, normalizedRaw);
+  if (fs.existsSync(repoCandidateAbs)) {
+    return {
+      repoRelative: normalizeRelativePath(path.relative(repoRoot, repoCandidateAbs)),
+      absolute: repoCandidateAbs,
+    };
+  }
+
+  const packCandidateAbs = path.resolve(packDirAbs, normalizedRaw);
+  if (fs.existsSync(packCandidateAbs)) {
+    return {
+      repoRelative: normalizeRelativePath(path.relative(repoRoot, packCandidateAbs)),
+      absolute: packCandidateAbs,
+    };
+  }
+
+  return {
+    repoRelative: normalizedRaw,
+    absolute: path.resolve(repoRoot, normalizedRaw),
+  };
+}
+
+function loadAcceptanceArtefactSet(repoRoot, acceptanceSetPath) {
+  const resolvedSetPath = path.resolve(repoRoot, acceptanceSetPath);
+  const packDirAbs = path.dirname(resolvedSetPath);
+  const setJson = readJson(resolvedSetPath);
+
+  if (!setJson || typeof setJson !== "object" || Array.isArray(setJson)) {
+    throw new Error("Acceptance artefact set must be a JSON object.");
+  }
+  if (!Array.isArray(setJson.artefacts)) {
+    throw new Error("Acceptance artefact set must contain an artefacts array.");
+  }
+
+  return setJson.artefacts.map((item) => {
+    const rawPath = extractArtefactPath(item);
+    if (!rawPath) {
+      throw new Error("Acceptance artefact set contains an artefact without a usable path.");
+    }
+
+    const resolved = resolveDeclaredPath(repoRoot, packDirAbs, rawPath);
+    const role = extractArtefactRole(item, rawPath);
+
+    return {
+      role,
+      repoRelative: resolved.repoRelative,
+      absolute: resolved.absolute,
+    };
+  });
+}
+
+function parseVersionTagDoc(text) {
+  const versionMatch = text.match(/^\s*Version:\s*(.+)\s*$/im);
+  const tagMatch = text.match(/^\s*Tag:\s*(.+)\s*$/im);
+
+  return {
+    version: versionMatch ? versionMatch[1].trim() : null,
+    tag: tagMatch ? tagMatch[1].trim() : null,
+  };
+}
+
+function verifyReleaseVersionTagBinding({
+  repoRoot,
+  versionTagPath,
+  acceptanceSetPath,
+}) {
+  const failures = [];
+  const versionTagAbs = path.resolve(repoRoot, versionTagPath);
+  const versionTagRepoRelative = normalizeRelativePath(path.relative(repoRoot, versionTagAbs));
+
+  let versionTagText = "";
+  let acceptanceRefs = [];
+
+  try {
+    versionTagText = readUtf8(versionTagAbs);
+  } catch (error) {
+    return {
+      ok: false,
+      failures: [
+        createFailure(
+          FAILURE.VERSION_TAG_UNPARSEABLE_SOURCE,
+          versionTagRepoRelative,
+          error instanceof Error ? error.message : String(error)
+        ),
+      ],
+    };
+  }
+
+  try {
+    acceptanceRefs = loadAcceptanceArtefactSet(repoRoot, acceptanceSetPath);
+  } catch (error) {
+    return {
+      ok: false,
+      failures: [
+        createFailure(
+          FAILURE.VERSION_TAG_UNPARSEABLE_SOURCE,
+          normalizeRelativePath(acceptanceSetPath),
+          error instanceof Error ? error.message : String(error)
+        ),
+      ],
+    };
+  }
+
+  const declaredSet = new Set(acceptanceRefs.map((ref) => ref.repoRelative));
+  const parsed = parseVersionTagDoc(versionTagText);
+
+  if (!parsed.version) {
+    failures.push(
+      createFailure(
+        FAILURE.VERSION_TAG_UNPARSEABLE_SOURCE,
+        versionTagRepoRelative,
+        "Version/tag artefact must declare a 'Version:' line."
+      )
+    );
+  }
+
+  if (!parsed.tag) {
+    failures.push(
+      createFailure(
+        FAILURE.VERSION_TAG_UNPARSEABLE_SOURCE,
+        versionTagRepoRelative,
+        "Version/tag artefact must declare a 'Tag:' line."
+      )
+    );
+  }
+
+  if (!declaredSet.has(versionTagRepoRelative)) {
+    failures.push(
+      createFailure(
+        FAILURE.VERSION_TAG_MISSING_DECLARED_SURFACE,
+        normalizeRelativePath(acceptanceSetPath),
+        `Acceptance artefact set must declare '${versionTagRepoRelative}'.`
+      )
+    );
+  }
+
+  const acceptanceReferences = [
+    /V1_ACCEPTANCE_ARTEFACT_SET\.json/i,
+    /V1_ACCEPTANCE_PACK_INDEX\.md/i,
+    /\bacceptance pack\b/i,
+    /\bsignoff\b/i,
+    /\bchecklist\b/i,
+  ];
+
+  const evidenceReferences = [
+    /V1_MAINLINE_GREEN_RUN_EVIDENCE\.md/i,
+    /V1_PACKAGING_EVIDENCE_MANIFEST\.json/i,
+    /V1_EVIDENCE_SURFACE_REGISTRY\.json/i,
+    /\bevidence\b/i,
+  ];
+
+  const hasAcceptanceBinding = acceptanceReferences.some((pattern) => pattern.test(versionTagText));
+  const hasEvidenceBinding = evidenceReferences.some((pattern) => pattern.test(versionTagText));
+
+  if (!hasAcceptanceBinding) {
+    failures.push(
+      createFailure(
+        FAILURE.VERSION_TAG_MISSING_BINDING_REFERENCE,
+        versionTagRepoRelative,
+        "Version/tag artefact must reference accepted release surfaces."
+      )
+    );
+  }
+
+  if (!hasEvidenceBinding) {
+    failures.push(
+      createFailure(
+        FAILURE.VERSION_TAG_MISSING_BINDING_REFERENCE,
+        versionTagRepoRelative,
+        "Version/tag artefact must reference release evidence surfaces."
+      )
+    );
+  }
+
+  const missingAcceptanceSurface = REQUIRED_ACCEPTANCE_SURFACES.find((surface) => !declaredSet.has(surface));
+  if (missingAcceptanceSurface) {
+    failures.push(
+      createFailure(
+        FAILURE.VERSION_TAG_DRIFT_DETECTED,
+        normalizeRelativePath(acceptanceSetPath),
+        `Version/tag binding requires declared acceptance surface '${missingAcceptanceSurface}'.`
+      )
+    );
+  }
+
+  const missingEvidenceSurface = REQUIRED_EVIDENCE_SURFACES.find((surface) => !declaredSet.has(surface));
+  if (missingEvidenceSurface) {
+    failures.push(
+      createFailure(
+        FAILURE.VERSION_TAG_DRIFT_DETECTED,
+        normalizeRelativePath(acceptanceSetPath),
+        `Version/tag binding requires declared evidence surface '${missingEvidenceSurface}'.`
+      )
+    );
+  }
+
+  return {
+    ok: failures.length === 0,
+    failures,
+  };
+}
+
+function main() {
+  const repoRoot = process.cwd();
+  const versionTagPath = process.argv[2] ?? "docs/releases/V1_VERSION_AND_TAG.md";
+  const acceptanceSetPath = process.argv[3] ?? "docs/releases/V1_ACCEPTANCE_ARTEFACT_SET.json";
+
+  const report = verifyReleaseVersionTagBinding({
+    repoRoot,
+    versionTagPath,
+    acceptanceSetPath,
+  });
+
+  process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+  process.exitCode = report.ok ? 0 : 1;
+}
+
+try {
+  main();
+} catch (error) {
+  const report = {
+    ok: false,
+    failures: [
+      {
+        token: FAILURE.VERSION_TAG_UNPARSEABLE_SOURCE,
+        path: normalizeRelativePath(process.argv[2] ?? "docs/releases/V1_VERSION_AND_TAG.md"),
+        details: error instanceof Error ? error.message : String(error),
+      },
+    ],
+  };
+  process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+  process.exitCode = 1;
+}

--- a/docs/releases/V1_ACCEPTANCE_ARTEFACT_SET.json
+++ b/docs/releases/V1_ACCEPTANCE_ARTEFACT_SET.json
@@ -1,34 +1,109 @@
 {
-  "name": "V1 acceptance artefact set",
-  "artefacts": [
-    { "path": "docs/releases/V1_ACCEPTANCE_PACK_INDEX.md", "role": "index" },
-    { "path": "docs/releases/V1_ACCEPTANCE_SIGNOFF.md", "role": "signoff" },
-    { "path": "docs/releases/V1_RELEASE_CHECKLIST.md", "role": "checklist" },
-
-    { "path": "docs/releases/V1_MAINLINE_GREEN_RUN_EVIDENCE.md", "role": "evidence" },
-    { "path": "docs/releases/V1_PACKAGING_EVIDENCE_MANIFEST.json", "role": "evidence" },
-    { "path": "docs/releases/V1_EVIDENCE_SURFACE_REGISTRY.json", "role": "evidence" },
-    { "path": "ci/scripts/run_postv1_packaging_evidence_manifest_verifier.mjs", "role": "evidence" },
-
-    { "path": "docs/releases/V1_ROLLBACK.md", "role": "rollback" },
-    { "path": "docs/releases/V1_PROMOTION_FLOW.md", "role": "promotion" },
-
-    { "path": "docs/releases/V1_OPERATOR_EXECUTION_ORDER.md", "role": "supporting" },
-    { "path": "docs/releases/V1_OPERATOR_RUNBOOK.md", "role": "supporting" },
-    { "path": "docs/releases/V1_RELEASE_OPERATIONS_BOUNDARY.json", "role": "supporting" },
-    { "path": "docs/releases/V1_ARTEFACT_MANIFEST.json", "role": "supporting" },
-    { "path": "docs/releases/V1_PACKAGING_SURFACE_REGISTRY.json", "role": "supporting" },
-    { "path": "docs/releases/V1_PACKAGING_PROMOTION_PR_BODY_TEMPLATE.md", "role": "supporting" },
-    { "path": "docs/releases/V1_PROMOTION_ARTEFACT_SET.json", "role": "supporting" },
-    { "path": "docs/releases/V1_RELEASE_ARTEFACT_NAMING_CONTRACT.md", "role": "supporting" },
-    { "path": "docs/releases/V1_RELEASE_NOTES.md", "role": "supporting" },
-    { "path": "docs/releases/V1_VERSION_AND_TAG.md", "role": "supporting" },
-
-    { "path": "ci/scripts/run_postv1_final_acceptance_gate.mjs", "role": "supporting" },
-    { "path": "ci/scripts/run_postv1_release_operations_boundary.mjs", "role": "supporting" },
-    { "path": "ci/scripts/run_release_claim_validator.mjs", "role": "supporting" },
-    { "path": "ci/scripts/run_postv1_acceptance_pack_composition_verifier.mjs", "role": "supporting" },
-    { "path": "ci/scripts/run_postv1_release_note_claim_boundary_verifier.mjs", "role": "supporting" },
-    { "path": "ci/scripts/run_postv1_merge_readiness_verifier.mjs", "role": "supporting" }
-  ]
+    "name":  "V1 acceptance artefact set",
+    "artefacts":  [
+                      {
+                          "path":  "docs/releases/V1_ACCEPTANCE_ARTEFACT_SET.json",
+                          "role":  "index"
+                      },
+                      {
+                          "path":  "docs/releases/V1_ACCEPTANCE_PACK_INDEX.md",
+                          "role":  "index"
+                      },
+                      {
+                          "path":  "docs/releases/V1_ACCEPTANCE_SIGNOFF.md",
+                          "role":  "signoff"
+                      },
+                      {
+                          "path":  "docs/releases/V1_RELEASE_CHECKLIST.md",
+                          "role":  "checklist"
+                      },
+                      {
+                          "path":  "docs/releases/V1_MAINLINE_GREEN_RUN_EVIDENCE.md",
+                          "role":  "evidence"
+                      },
+                      {
+                          "path":  "docs/releases/V1_PACKAGING_EVIDENCE_MANIFEST.json",
+                          "role":  "evidence"
+                      },
+                      {
+                          "path":  "docs/releases/V1_EVIDENCE_SURFACE_REGISTRY.json",
+                          "role":  "evidence"
+                      },
+                      {
+                          "path":  "ci/scripts/run_postv1_packaging_evidence_manifest_verifier.mjs",
+                          "role":  "evidence"
+                      },
+                      {
+                          "path":  "docs/releases/V1_ROLLBACK.md",
+                          "role":  "rollback"
+                      },
+                      {
+                          "path":  "docs/releases/V1_PROMOTION_FLOW.md",
+                          "role":  "promotion"
+                      },
+                      {
+                          "path":  "docs/releases/V1_OPERATOR_EXECUTION_ORDER.md",
+                          "role":  "supporting"
+                      },
+                      {
+                          "path":  "docs/releases/V1_OPERATOR_RUNBOOK.md",
+                          "role":  "supporting"
+                      },
+                      {
+                          "path":  "docs/releases/V1_RELEASE_OPERATIONS_BOUNDARY.json",
+                          "role":  "supporting"
+                      },
+                      {
+                          "path":  "docs/releases/V1_ARTEFACT_MANIFEST.json",
+                          "role":  "supporting"
+                      },
+                      {
+                          "path":  "docs/releases/V1_PACKAGING_SURFACE_REGISTRY.json",
+                          "role":  "supporting"
+                      },
+                      {
+                          "path":  "docs/releases/V1_PACKAGING_PROMOTION_PR_BODY_TEMPLATE.md",
+                          "role":  "supporting"
+                      },
+                      {
+                          "path":  "docs/releases/V1_PROMOTION_ARTEFACT_SET.json",
+                          "role":  "supporting"
+                      },
+                      {
+                          "path":  "docs/releases/V1_RELEASE_ARTEFACT_NAMING_CONTRACT.md",
+                          "role":  "supporting"
+                      },
+                      {
+                          "path":  "docs/releases/V1_RELEASE_NOTES.md",
+                          "role":  "supporting"
+                      },
+                      {
+                          "path":  "docs/releases/V1_VERSION_AND_TAG.md",
+                          "role":  "supporting"
+                      },
+                      {
+                          "path":  "ci/scripts/run_postv1_final_acceptance_gate.mjs",
+                          "role":  "supporting"
+                      },
+                      {
+                          "path":  "ci/scripts/run_postv1_release_operations_boundary.mjs",
+                          "role":  "supporting"
+                      },
+                      {
+                          "path":  "ci/scripts/run_release_claim_validator.mjs",
+                          "role":  "supporting"
+                      },
+                      {
+                          "path":  "ci/scripts/run_postv1_acceptance_pack_composition_verifier.mjs",
+                          "role":  "supporting"
+                      },
+                      {
+                          "path":  "ci/scripts/run_postv1_release_note_claim_boundary_verifier.mjs",
+                          "role":  "supporting"
+                      },
+                      {
+                          "path":  "ci/scripts/run_postv1_merge_readiness_verifier.mjs",
+                          "role":  "supporting"
+                      }
+                  ]
 }

--- a/docs/releases/V1_PACKAGING_SURFACE_REGISTRY.json
+++ b/docs/releases/V1_PACKAGING_SURFACE_REGISTRY.json
@@ -32,6 +32,7 @@
                      "docs/releases/V1_ROLLBACK.md",
                      "docs/releases/V1_VERSION_AND_TAG.md",
                      "ci/scripts/run_postv1_release_note_claim_boundary_verifier.mjs",
-                     "ci/scripts/run_postv1_promotion_flow_legality_chain_verifier.mjs"
+                     "ci/scripts/run_postv1_promotion_flow_legality_chain_verifier.mjs",
+                     "ci/scripts/run_postv1_release_version_tag_evidence_binding_verifier.mjs"
                  ]
 }

--- a/docs/releases/V1_VERSION_AND_TAG.md
+++ b/docs/releases/V1_VERSION_AND_TAG.md
@@ -1,34 +1,13 @@
-# Kolosseum v1 version and tag contract
+# V1 Version And Tag
 
-## Purpose
-This document defines the truthful operator procedure for version confirmation and git tagging.
-It does not create, imply, or simulate release automation.
+Version: 1.0.0
+Tag: v1.0.0
 
-## Authority boundaries
+## Binding
 
-### 1. Version authority
-- the repository package version is the version string authority
-- the git tag is a release marker attached by an operator
-- the release notes document is descriptive and does not override package or git history
+- Accepted release state is declared through `V1_ACCEPTANCE_ARTEFACT_SET.json`, `V1_ACCEPTANCE_PACK_INDEX.md`, `V1_ACCEPTANCE_SIGNOFF.md`, and `V1_RELEASE_CHECKLIST.md`.
+- Release evidence is declared through `V1_MAINLINE_GREEN_RUN_EVIDENCE.md`, `V1_PACKAGING_EVIDENCE_MANIFEST.json`, and `V1_EVIDENCE_SURFACE_REGISTRY.json`.
 
-### 2. Tag authority
-- a tag is not considered part of the release record unless it points to a merged main commit
-- a tag must be created intentionally by an operator
-- annotated tags are preferred for release visibility and traceability
+## Drift prohibition
 
-## Operator procedure
-- [ ] hard-sync local main to origin/main
-- [ ] confirm release notes artefact exists
-- [ ] confirm release checklist artefact exists
-- [ ] confirm CI for the intended release commit is fully green
-- [ ] confirm the package version matches intended release naming
-- [ ] create an annotated git tag on the merged main release commit
-- [ ] push the tag to origin
-- [ ] verify the tag resolves to the intended main commit
-
-## Explicit non-claims
-- no claim of automatic version bumping
-- no claim of automatic tag creation
-- no claim of automatic deployment
-- no claim of app-store publication
-- no claim that a tag alone proves runtime correctness or release approval
+The version/tag declaration is legal only when it remains bound to the accepted release state and the declared release evidence surfaces.

--- a/test/postv1_release_version_tag_evidence_binding_verifier.test.mjs
+++ b/test/postv1_release_version_tag_evidence_binding_verifier.test.mjs
@@ -1,0 +1,118 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+
+function writeJson(filePath, value) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`, "utf8");
+}
+
+function writeText(filePath, value) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, value, "utf8");
+}
+
+function runVerifier(versionTagPath, acceptanceSetPath, cwd) {
+  const scriptPath = path.resolve("ci/scripts/run_postv1_release_version_tag_evidence_binding_verifier.mjs");
+  const result = spawnSync(process.execPath, [scriptPath, versionTagPath, acceptanceSetPath], {
+    cwd,
+    encoding: "utf8",
+  });
+
+  const stdout = result.stdout.trim();
+  assert.notEqual(stdout, "", "verifier should emit JSON report to stdout");
+
+  let report;
+  try {
+    report = JSON.parse(stdout);
+  } catch (error) {
+    assert.fail(`verifier stdout was not valid JSON.\nstdout:\n${stdout}\nerror: ${error}`);
+  }
+
+  return {
+    status: result.status,
+    report,
+  };
+}
+
+function createFixture() {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "p53-version-tag-"));
+  const releasesDir = path.join(root, "docs", "releases");
+
+  writeText(
+    path.join(releasesDir, "V1_VERSION_AND_TAG.md"),
+    [
+      "# V1 Version And Tag",
+      "",
+      "Version: 1.0.0",
+      "Tag: v1.0.0",
+      "",
+      "Binding:",
+      "- accepted release state is declared through V1_ACCEPTANCE_ARTEFACT_SET.json, V1_ACCEPTANCE_PACK_INDEX.md, signoff, and checklist surfaces.",
+      "- release evidence is declared through V1_MAINLINE_GREEN_RUN_EVIDENCE.md, V1_PACKAGING_EVIDENCE_MANIFEST.json, and V1_EVIDENCE_SURFACE_REGISTRY.json."
+    ].join("\n") + "\n"
+  );
+
+  writeText(path.join(releasesDir, "V1_ACCEPTANCE_PACK_INDEX.md"), "# acceptance pack\n");
+  writeText(path.join(releasesDir, "V1_ACCEPTANCE_SIGNOFF.md"), "# signoff\n");
+  writeText(path.join(releasesDir, "V1_RELEASE_CHECKLIST.md"), "# checklist\n");
+  writeText(path.join(releasesDir, "V1_MAINLINE_GREEN_RUN_EVIDENCE.md"), "# evidence\n");
+  writeText(path.join(releasesDir, "V1_PACKAGING_EVIDENCE_MANIFEST.json"), "{ }\n");
+  writeText(path.join(releasesDir, "V1_EVIDENCE_SURFACE_REGISTRY.json"), "{ }\n");
+
+  writeJson(path.join(releasesDir, "V1_ACCEPTANCE_ARTEFACT_SET.json"), {
+    name: "V1 acceptance artefact set",
+    artefacts: [
+      { path: "docs/releases/V1_ACCEPTANCE_ARTEFACT_SET.json", role: "index" },
+      { path: "docs/releases/V1_ACCEPTANCE_PACK_INDEX.md", role: "index" },
+      { path: "docs/releases/V1_ACCEPTANCE_SIGNOFF.md", role: "signoff" },
+      { path: "docs/releases/V1_RELEASE_CHECKLIST.md", role: "checklist" },
+      { path: "docs/releases/V1_MAINLINE_GREEN_RUN_EVIDENCE.md", role: "evidence" },
+      { path: "docs/releases/V1_PACKAGING_EVIDENCE_MANIFEST.json", role: "evidence" },
+      { path: "docs/releases/V1_EVIDENCE_SURFACE_REGISTRY.json", role: "evidence" },
+      { path: "docs/releases/V1_VERSION_AND_TAG.md", role: "supporting" }
+    ]
+  });
+
+  return {
+    root,
+    versionTagPath: path.join(root, "docs", "releases", "V1_VERSION_AND_TAG.md"),
+    acceptanceSetPath: path.join(root, "docs", "releases", "V1_ACCEPTANCE_ARTEFACT_SET.json"),
+  };
+}
+
+test("P53: version/tag binding verifier passes when version/tag is bound to accepted evidence surfaces", () => {
+  const fixture = createFixture();
+  const { status, report } = runVerifier(fixture.versionTagPath, fixture.acceptanceSetPath, fixture.root);
+
+  assert.equal(status, 0);
+  assert.equal(report.ok, true);
+  assert.deepEqual(report.failures, []);
+});
+
+test("P53: version/tag binding verifier fails drift when binding references are omitted", () => {
+  const fixture = createFixture();
+
+  writeText(
+    fixture.versionTagPath,
+    [
+      "# V1 Version And Tag",
+      "",
+      "Version: 1.0.0",
+      "Tag: v1.0.0"
+    ].join("\n") + "\n"
+  );
+
+  const { status, report } = runVerifier(fixture.versionTagPath, fixture.acceptanceSetPath, fixture.root);
+
+  assert.equal(status, 1);
+  assert.equal(report.ok, false);
+  assert.ok(Array.isArray(report.failures));
+  assert.ok(
+    report.failures.some((failure) => failure.token === "version_tag_missing_binding_reference"),
+    `expected version_tag_missing_binding_reference, got ${JSON.stringify(report, null, 2)}`
+  );
+});


### PR DESCRIPTION
## Summary
- add P53 release version/tag evidence binding verifier
- bind version/tag declaration to accepted release and evidence surfaces
- add verifier proof including drift-negative coverage

## Proof
- node --test --test-concurrency=1 .\test\postv1_release_version_tag_evidence_binding_verifier.test.mjs
- node .\ci\scripts\run_postv1_release_version_tag_evidence_binding_verifier.mjs .\docs\releases\V1_VERSION_AND_TAG.md .\docs\releases\V1_ACCEPTANCE_ARTEFACT_SET.json