### PR TITLE
test(postv1): add final acceptance boundary runner

### DIFF
--- a/ci/scripts/run_postv1_acceptance_artefact_completeness_boundary_adapter.mjs
+++ b/ci/scripts/run_postv1_acceptance_artefact_completeness_boundary_adapter.mjs
@@ -1,0 +1,191 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+
+const FAILURE = {
+  ACCEPTANCE_ARTEFACT_ADAPTER_SOURCE_UNPARSEABLE: "acceptance_artefact_adapter_source_unparseable",
+  ACCEPTANCE_ARTEFACT_ADAPTER_INVALID_SOURCE: "acceptance_artefact_adapter_invalid_source",
+  ACCEPTANCE_ARTEFACT_ADAPTER_EXECUTION_FAILED: "acceptance_artefact_adapter_execution_failed",
+};
+
+function normalizeRelativePath(value) {
+  return String(value).replace(/\\/g, "/");
+}
+
+function createFailure(token, filePath, details) {
+  return {
+    token,
+    path: normalizeRelativePath(filePath),
+    details,
+  };
+}
+
+function readJson(filePath) {
+  return JSON.parse(fs.readFileSync(filePath, "utf8"));
+}
+
+function ensureParentDir(filePath) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+}
+
+function copyFileIntoTemp(tempRoot, repoRoot, repoRelativePath) {
+  const sourceAbs = path.resolve(repoRoot, repoRelativePath);
+  const destAbs = path.resolve(tempRoot, repoRelativePath);
+
+  ensureParentDir(destAbs);
+
+  if (fs.existsSync(sourceAbs) && fs.statSync(sourceAbs).isFile()) {
+    fs.copyFileSync(sourceAbs, destAbs);
+    return true;
+  }
+
+  return false;
+}
+
+function extractArtefactPath(entry) {
+  if (typeof entry === "string" && entry.trim().length > 0) {
+    return entry.trim();
+  }
+
+  if (entry && typeof entry === "object") {
+    const candidateKeys = [
+      "path",
+      "file",
+      "relative_path",
+      "relativePath",
+      "artifact_path",
+      "artefact_path",
+      "artifactPath",
+      "artefactPath",
+    ];
+
+    for (const key of candidateKeys) {
+      if (typeof entry[key] === "string" && entry[key].trim().length > 0) {
+        return entry[key].trim();
+      }
+    }
+  }
+
+  return null;
+}
+
+function main() {
+  const repoRoot = process.cwd();
+  const sourceSetPath = path.resolve(repoRoot, "docs/releases/V1_ACCEPTANCE_ARTEFACT_SET.json");
+  const legacyVerifierPath = path.resolve(
+    repoRoot,
+    "ci/scripts/run_postv1_acceptance_artefact_completeness_verifier.mjs"
+  );
+
+  let sourceSet;
+  try {
+    sourceSet = readJson(sourceSetPath);
+  } catch (error) {
+    const report = {
+      ok: false,
+      failures: [
+        createFailure(
+          FAILURE.ACCEPTANCE_ARTEFACT_ADAPTER_SOURCE_UNPARSEABLE,
+          "docs/releases/V1_ACCEPTANCE_ARTEFACT_SET.json",
+          error instanceof Error ? error.message : String(error)
+        ),
+      ],
+    };
+    process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+    process.exitCode = 1;
+    return;
+  }
+
+  if (
+    !sourceSet ||
+    typeof sourceSet !== "object" ||
+    Array.isArray(sourceSet) ||
+    !Array.isArray(sourceSet.artefacts)
+  ) {
+    const report = {
+      ok: false,
+      failures: [
+        createFailure(
+          FAILURE.ACCEPTANCE_ARTEFACT_ADAPTER_INVALID_SOURCE,
+          "docs/releases/V1_ACCEPTANCE_ARTEFACT_SET.json",
+          "Acceptance artefact set must be an object containing an artefacts array."
+        ),
+      ],
+    };
+    process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+    process.exitCode = 1;
+    return;
+  }
+
+  const normalisedArtefacts = [];
+  for (const entry of sourceSet.artefacts) {
+    const artefactPath = extractArtefactPath(entry);
+    if (!artefactPath) {
+      const report = {
+        ok: false,
+        failures: [
+          createFailure(
+            FAILURE.ACCEPTANCE_ARTEFACT_ADAPTER_INVALID_SOURCE,
+            "docs/releases/V1_ACCEPTANCE_ARTEFACT_SET.json",
+            "Every artefact entry must contain a usable path."
+          ),
+        ],
+      };
+      process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+      process.exitCode = 1;
+      return;
+    }
+    normalisedArtefacts.push(normalizeRelativePath(artefactPath));
+  }
+
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "p54-acceptance-artefact-adapter-"));
+  const tempSetPath = path.resolve(tempRoot, "docs/releases/V1_ACCEPTANCE_ARTEFACT_SET.json");
+
+  for (const artefactPath of normalisedArtefacts) {
+    copyFileIntoTemp(tempRoot, repoRoot, artefactPath);
+  }
+
+  ensureParentDir(tempSetPath);
+  fs.writeFileSync(
+    tempSetPath,
+    `${JSON.stringify(
+      {
+        name: "v1_acceptance_artefact_set",
+        artefacts: normalisedArtefacts,
+      },
+      null,
+      2
+    )}\n`,
+    "utf8"
+  );
+
+  const result = spawnSync(process.execPath, [legacyVerifierPath], {
+    cwd: tempRoot,
+    encoding: "utf8",
+  });
+
+  const stdout = typeof result.stdout === "string" ? result.stdout.trim() : "";
+  const stderr = typeof result.stderr === "string" ? result.stderr.trim() : "";
+
+  if ((result.status ?? 1) !== 0) {
+    const report = {
+      ok: false,
+      failures: [
+        createFailure(
+          FAILURE.ACCEPTANCE_ARTEFACT_ADAPTER_EXECUTION_FAILED,
+          "ci/scripts/run_postv1_acceptance_artefact_completeness_verifier.mjs",
+          stderr || stdout || "Acceptance artefact completeness verifier exited non-zero."
+        ),
+      ],
+    };
+    process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+    process.exitCode = 1;
+    return;
+  }
+
+  process.stdout.write(`${JSON.stringify({ ok: true, failures: [] }, null, 2)}\n`);
+  process.exitCode = 0;
+}
+
+main();

--- a/ci/scripts/run_postv1_final_acceptance_boundary_runner.mjs
+++ b/ci/scripts/run_postv1_final_acceptance_boundary_runner.mjs
@@ -1,0 +1,307 @@
+import fs from "node:fs";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+
+const FAILURE = {
+  BOUNDARY_SOURCE_UNPARSEABLE: "boundary_source_unparseable",
+  BOUNDARY_INVALID_DECLARATION: "boundary_invalid_declaration",
+  BOUNDARY_CHECK_PATH_MISSING: "boundary_check_path_missing",
+  BOUNDARY_CHECK_EXECUTION_FAILED: "boundary_check_execution_failed",
+  BOUNDARY_CHECK_OUTPUT_INVALID: "boundary_check_output_invalid",
+  BOUNDARY_CHECK_REPORTED_FAILURE: "boundary_check_reported_failure",
+};
+
+function normalizeRelativePath(value) {
+  return String(value).replace(/\\/g, "/");
+}
+
+function readUtf8(filePath) {
+  return fs.readFileSync(filePath, "utf8");
+}
+
+function readJson(filePath) {
+  return JSON.parse(readUtf8(filePath));
+}
+
+function createFailure(token, filePath, details, checkId = null) {
+  return {
+    token,
+    path: normalizeRelativePath(filePath),
+    details,
+    ...(checkId ? { check_id: checkId } : {}),
+  };
+}
+
+function resolveDeclaredPath(repoRoot, boundaryDirAbs, rawPath) {
+  const normalizedRaw = normalizeRelativePath(rawPath).replace(/^\.\/+/, "");
+
+  const repoCandidateAbs = path.resolve(repoRoot, normalizedRaw);
+  if (fs.existsSync(repoCandidateAbs)) {
+    return {
+      repoRelative: normalizeRelativePath(path.relative(repoRoot, repoCandidateAbs)),
+      absolute: repoCandidateAbs,
+    };
+  }
+
+  const boundaryCandidateAbs = path.resolve(boundaryDirAbs, normalizedRaw);
+  if (fs.existsSync(boundaryCandidateAbs)) {
+    return {
+      repoRelative: normalizeRelativePath(path.relative(repoRoot, boundaryCandidateAbs)),
+      absolute: boundaryCandidateAbs,
+    };
+  }
+
+  return {
+    repoRelative: normalizedRaw,
+    absolute: path.resolve(repoRoot, normalizedRaw),
+  };
+}
+
+function loadBoundaryDeclaration(repoRoot, boundaryPath) {
+  const boundaryAbs = path.resolve(repoRoot, boundaryPath);
+  const boundaryDirAbs = path.dirname(boundaryAbs);
+  const boundaryJson = readJson(boundaryAbs);
+
+  if (!boundaryJson || typeof boundaryJson !== "object" || Array.isArray(boundaryJson)) {
+    throw new Error("Boundary declaration must be a JSON object.");
+  }
+
+  if (!Array.isArray(boundaryJson.checks)) {
+    throw new Error("Boundary declaration must contain a checks array.");
+  }
+
+  const checks = boundaryJson.checks.map((item, index) => {
+    if (!item || typeof item !== "object" || Array.isArray(item)) {
+      throw new Error(`Boundary check at index ${index} must be an object.`);
+    }
+
+    if (typeof item.check_id !== "string" || item.check_id.trim().length === 0) {
+      throw new Error(`Boundary check at index ${index} must declare a non-empty check_id.`);
+    }
+
+    if (typeof item.script_path !== "string" || item.script_path.trim().length === 0) {
+      throw new Error(`Boundary check '${item.check_id}' must declare a non-empty script_path.`);
+    }
+
+    if ("args" in item && !Array.isArray(item.args)) {
+      throw new Error(`Boundary check '${item.check_id}' args must be an array when present.`);
+    }
+
+    const resolved = resolveDeclaredPath(repoRoot, boundaryDirAbs, item.script_path);
+
+    return {
+      checkId: item.check_id.trim(),
+      scriptPath: resolved.repoRelative,
+      scriptAbsolute: resolved.absolute,
+      args: Array.isArray(item.args) ? item.args.map((value) => String(value)) : [],
+    };
+  });
+
+  return {
+    boundaryId:
+      typeof boundaryJson.boundary_id === "string" && boundaryJson.boundary_id.trim().length > 0
+        ? boundaryJson.boundary_id.trim()
+        : null,
+    checks,
+  };
+}
+
+function runDeclaredCheck(repoRoot, check) {
+  const result = spawnSync(process.execPath, [check.scriptAbsolute, ...check.args], {
+    cwd: repoRoot,
+    encoding: "utf8",
+  });
+
+  const stdout = typeof result.stdout === "string" ? result.stdout.trim() : "";
+  const stderr = typeof result.stderr === "string" ? result.stderr.trim() : "";
+
+  return {
+    status: result.status ?? 1,
+    stdout,
+    stderr,
+  };
+}
+
+function verifyFinalAcceptanceBoundary({
+  repoRoot,
+  boundaryPath,
+}) {
+  const failures = [];
+  const executedChecks = [];
+  const boundaryAbs = path.resolve(repoRoot, boundaryPath);
+  const boundaryRepoRelative = normalizeRelativePath(path.relative(repoRoot, boundaryAbs));
+
+  let boundary;
+  try {
+    boundary = loadBoundaryDeclaration(repoRoot, boundaryPath);
+  } catch (error) {
+    return {
+      ok: false,
+      executed_checks: [],
+      failures: [
+        createFailure(
+          FAILURE.BOUNDARY_SOURCE_UNPARSEABLE,
+          boundaryRepoRelative,
+          error instanceof Error ? error.message : String(error)
+        ),
+      ],
+    };
+  }
+
+  if (!boundary.boundaryId) {
+    failures.push(
+      createFailure(
+        FAILURE.BOUNDARY_INVALID_DECLARATION,
+        boundaryRepoRelative,
+        "Boundary declaration must declare a non-empty boundary_id."
+      )
+    );
+  }
+
+  const seenCheckIds = new Set();
+  for (const check of boundary.checks) {
+    if (seenCheckIds.has(check.checkId)) {
+      failures.push(
+        createFailure(
+          FAILURE.BOUNDARY_INVALID_DECLARATION,
+          boundaryRepoRelative,
+          `Duplicate boundary check_id '${check.checkId}' is not permitted.`,
+          check.checkId
+        )
+      );
+      continue;
+    }
+    seenCheckIds.add(check.checkId);
+
+    if (!fs.existsSync(check.scriptAbsolute)) {
+      failures.push(
+        createFailure(
+          FAILURE.BOUNDARY_CHECK_PATH_MISSING,
+          check.scriptPath,
+          `Declared boundary check '${check.checkId}' script does not exist.`,
+          check.checkId
+        )
+      );
+    }
+  }
+
+  if (failures.length > 0) {
+    return {
+      ok: false,
+      boundary_id: boundary.boundaryId,
+      executed_checks: [],
+      failures,
+    };
+  }
+
+  for (const check of boundary.checks) {
+    const execution = runDeclaredCheck(repoRoot, check);
+    const executionRecord = {
+      check_id: check.checkId,
+      script_path: check.scriptPath,
+      args: check.args,
+      status: execution.status,
+    };
+
+    if (execution.status !== 0) {
+      executedChecks.push(executionRecord);
+      failures.push(
+        createFailure(
+          FAILURE.BOUNDARY_CHECK_EXECUTION_FAILED,
+          check.scriptPath,
+          execution.stderr || execution.stdout || `Declared check '${check.checkId}' exited non-zero.`,
+          check.checkId
+        )
+      );
+      return {
+        ok: false,
+        boundary_id: boundary.boundaryId,
+        executed_checks: executedChecks,
+        failures,
+      };
+    }
+
+    let report;
+    try {
+      report = JSON.parse(execution.stdout);
+    } catch (error) {
+      executedChecks.push(executionRecord);
+      failures.push(
+        createFailure(
+          FAILURE.BOUNDARY_CHECK_OUTPUT_INVALID,
+          check.scriptPath,
+          `Declared check '${check.checkId}' did not emit valid JSON. ${error instanceof Error ? error.message : String(error)}`,
+          check.checkId
+        )
+      );
+      return {
+        ok: false,
+        boundary_id: boundary.boundaryId,
+        executed_checks: executedChecks,
+        failures,
+      };
+    }
+
+    if (!report || typeof report !== "object" || report.ok !== true) {
+      executedChecks.push(executionRecord);
+      failures.push(
+        createFailure(
+          FAILURE.BOUNDARY_CHECK_REPORTED_FAILURE,
+          check.scriptPath,
+          `Declared check '${check.checkId}' reported failure.`,
+          check.checkId
+        )
+      );
+      return {
+        ok: false,
+        boundary_id: boundary.boundaryId,
+        executed_checks: executedChecks,
+        failures,
+      };
+    }
+
+    executedChecks.push({
+      ...executionRecord,
+      ok: true,
+    });
+  }
+
+  return {
+    ok: true,
+    boundary_id: boundary.boundaryId,
+    executed_checks: executedChecks,
+    failures: [],
+  };
+}
+
+function main() {
+  const repoRoot = process.cwd();
+  const boundaryPath = process.argv[2] ?? "docs/releases/V1_FINAL_ACCEPTANCE_BOUNDARY.json";
+
+  const report = verifyFinalAcceptanceBoundary({
+    repoRoot,
+    boundaryPath,
+  });
+
+  process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+  process.exitCode = report.ok ? 0 : 1;
+}
+
+try {
+  main();
+} catch (error) {
+  const boundaryPath = process.argv[2] ?? "docs/releases/V1_FINAL_ACCEPTANCE_BOUNDARY.json";
+  const report = {
+    ok: false,
+    executed_checks: [],
+    failures: [
+      createFailure(
+        FAILURE.BOUNDARY_SOURCE_UNPARSEABLE,
+        normalizeRelativePath(boundaryPath),
+        error instanceof Error ? error.message : String(error)
+      ),
+    ],
+  };
+  process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+  process.exitCode = 1;
+}

--- a/ci/scripts/run_postv1_release_claim_validator_boundary_adapter.mjs
+++ b/ci/scripts/run_postv1_release_claim_validator_boundary_adapter.mjs
@@ -1,0 +1,71 @@
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+
+const FAILURE = {
+  RELEASE_CLAIM_ADAPTER_EXECUTION_FAILED: "release_claim_adapter_execution_failed",
+  RELEASE_CLAIM_ADAPTER_REPORTED_FAILURE: "release_claim_adapter_reported_failure",
+};
+
+function normalizeRelativePath(value) {
+  return String(value).replace(/\\/g, "/");
+}
+
+function createFailure(token, filePath, details) {
+  return {
+    token,
+    path: normalizeRelativePath(filePath),
+    details,
+  };
+}
+
+function main() {
+  const repoRoot = process.cwd();
+  const targetScript = path.resolve(repoRoot, "ci/scripts/run_release_claim_validator.mjs");
+
+  const result = spawnSync(process.execPath, [targetScript], {
+    cwd: repoRoot,
+    encoding: "utf8",
+  });
+
+  const stdout = typeof result.stdout === "string" ? result.stdout.trim() : "";
+  const stderr = typeof result.stderr === "string" ? result.stderr.trim() : "";
+
+  if ((result.status ?? 1) !== 0) {
+    const report = {
+      ok: false,
+      failures: [
+        createFailure(
+          FAILURE.RELEASE_CLAIM_ADAPTER_EXECUTION_FAILED,
+          "ci/scripts/run_release_claim_validator.mjs",
+          stderr || stdout || "Release claim validator exited non-zero."
+        ),
+      ],
+    };
+    process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+    process.exitCode = 1;
+    return;
+  }
+
+  if (/^RELEASE_CLAIM_VALIDATOR_OK$/m.test(stdout)) {
+    process.stdout.write(
+      `${JSON.stringify({ ok: true, failures: [] }, null, 2)}\n`
+    );
+    process.exitCode = 0;
+    return;
+  }
+
+  const report = {
+    ok: false,
+    failures: [
+      createFailure(
+        FAILURE.RELEASE_CLAIM_ADAPTER_REPORTED_FAILURE,
+        "ci/scripts/run_release_claim_validator.mjs",
+        stdout || "Release claim validator did not report the expected success token."
+      ),
+    ],
+  };
+  process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+  process.exitCode = 1;
+}
+
+main();

--- a/docs/releases/V1_ACCEPTANCE_ARTEFACT_SET.json
+++ b/docs/releases/V1_ACCEPTANCE_ARTEFACT_SET.json
@@ -1,9 +1,9 @@
 {
-    "name":  "V1 acceptance artefact set",
+    "name":  "v1_acceptance_artefact_set",
     "artefacts":  [
                       {
                           "path":  "docs/releases/V1_ACCEPTANCE_ARTEFACT_SET.json",
-                          "role":  "index"
+                          "role":  "supporting"
                       },
                       {
                           "path":  "docs/releases/V1_ACCEPTANCE_PACK_INDEX.md",
@@ -104,6 +104,10 @@
                       {
                           "path":  "ci/scripts/run_postv1_merge_readiness_verifier.mjs",
                           "role":  "supporting"
+                      },
+                      {
+                          "path":  "docs/releases/V1_FINAL_ACCEPTANCE_BOUNDARY.json",
+                          "role":  "boundary"
                       }
                   ]
 }

--- a/docs/releases/V1_FINAL_ACCEPTANCE_BOUNDARY.json
+++ b/docs/releases/V1_FINAL_ACCEPTANCE_BOUNDARY.json
@@ -1,0 +1,25 @@
+{
+  "boundary_id": "v1_final_acceptance_boundary",
+  "checks": [
+    {
+      "check_id": "release_claim",
+      "script_path": "ci/scripts/run_postv1_release_claim_validator_boundary_adapter.mjs"
+    },
+    {
+      "check_id": "acceptance_pack_composition",
+      "script_path": "ci/scripts/run_postv1_acceptance_pack_composition_verifier.mjs"
+    },
+    {
+      "check_id": "acceptance_artefact_completeness",
+      "script_path": "ci/scripts/run_postv1_acceptance_artefact_completeness_boundary_adapter.mjs"
+    },
+    {
+      "check_id": "promotion_flow_legality_chain",
+      "script_path": "ci/scripts/run_postv1_promotion_flow_legality_chain_verifier.mjs"
+    },
+    {
+      "check_id": "release_version_tag_evidence_binding",
+      "script_path": "ci/scripts/run_postv1_release_version_tag_evidence_binding_verifier.mjs"
+    }
+  ]
+}

--- a/docs/releases/V1_PACKAGING_SURFACE_REGISTRY.json
+++ b/docs/releases/V1_PACKAGING_SURFACE_REGISTRY.json
@@ -33,6 +33,10 @@
                      "docs/releases/V1_VERSION_AND_TAG.md",
                      "ci/scripts/run_postv1_release_note_claim_boundary_verifier.mjs",
                      "ci/scripts/run_postv1_promotion_flow_legality_chain_verifier.mjs",
-                     "ci/scripts/run_postv1_release_version_tag_evidence_binding_verifier.mjs"
+                     "ci/scripts/run_postv1_release_version_tag_evidence_binding_verifier.mjs",
+                     "ci/scripts/run_postv1_final_acceptance_boundary_runner.mjs",
+                     "docs/releases/V1_FINAL_ACCEPTANCE_BOUNDARY.json",
+                     "ci/scripts/run_postv1_release_claim_validator_boundary_adapter.mjs",
+                     "ci/scripts/run_postv1_acceptance_artefact_completeness_boundary_adapter.mjs"
                  ]
 }

--- a/test/postv1_final_acceptance_boundary_runner.test.mjs
+++ b/test/postv1_final_acceptance_boundary_runner.test.mjs
@@ -1,0 +1,125 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+
+function writeJson(filePath, value) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`, "utf8");
+}
+
+function writeText(filePath, value) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, value, "utf8");
+}
+
+function runRunner(boundaryPath, cwd) {
+  const scriptPath = path.resolve("ci/scripts/run_postv1_final_acceptance_boundary_runner.mjs");
+  const result = spawnSync(process.execPath, [scriptPath, boundaryPath], {
+    cwd,
+    encoding: "utf8",
+  });
+
+  const stdout = result.stdout.trim();
+  assert.notEqual(stdout, "", "runner should emit JSON report to stdout");
+
+  let report;
+  try {
+    report = JSON.parse(stdout);
+  } catch (error) {
+    assert.fail(`runner stdout was not valid JSON.\nstdout:\n${stdout}\nerror: ${error}`);
+  }
+
+  return {
+    status: result.status,
+    report,
+  };
+}
+
+function createCheckScript(filePath, logPath, label) {
+  writeText(
+    filePath,
+    [
+      'import fs from "node:fs";',
+      `const logPath = ${JSON.stringify(logPath)};`,
+      `fs.appendFileSync(logPath, ${JSON.stringify(`${label}\n`)});`,
+      'process.stdout.write(`${JSON.stringify({ ok: true, failures: [] }, null, 2)}\\n`);',
+    ].join("\n") + "\n"
+  );
+}
+
+function createFixture() {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "p54-final-boundary-"));
+  const logPath = path.join(root, "execution.log");
+  const scriptsDir = path.join(root, "ci", "scripts");
+  const boundaryPath = path.join(root, "docs", "releases", "V1_FINAL_ACCEPTANCE_BOUNDARY.json");
+
+  createCheckScript(path.join(scriptsDir, "declared-first.mjs"), logPath, "declared-first");
+  createCheckScript(path.join(scriptsDir, "declared-second.mjs"), logPath, "declared-second");
+  createCheckScript(path.join(scriptsDir, "undeclared-third.mjs"), logPath, "undeclared-third");
+
+  writeJson(boundaryPath, {
+    boundary_id: "v1_final_acceptance_boundary",
+    checks: [
+      {
+        check_id: "declared_first",
+        script_path: "ci/scripts/declared-first.mjs",
+      },
+      {
+        check_id: "declared_second",
+        script_path: "ci/scripts/declared-second.mjs",
+      },
+    ],
+  });
+
+  return {
+    root,
+    boundaryPath,
+    logPath,
+  };
+}
+
+test("P54: final acceptance boundary runner executes only declared checks in declared order", () => {
+  const fixture = createFixture();
+  const { status, report } = runRunner(fixture.boundaryPath, fixture.root);
+
+  assert.equal(status, 0);
+  assert.equal(report.ok, true);
+  assert.deepEqual(
+    report.executed_checks.map((item) => item.check_id),
+    ["declared_first", "declared_second"]
+  );
+
+  const log = fs.readFileSync(fixture.logPath, "utf8");
+  assert.equal(log, "declared-first\ndeclared-second\n");
+  assert.equal(log.includes("undeclared-third"), false);
+});
+
+test("P54: final acceptance boundary runner fails when declaration order references a missing script", () => {
+  const fixture = createFixture();
+
+  writeJson(fixture.boundaryPath, {
+    boundary_id: "v1_final_acceptance_boundary",
+    checks: [
+      {
+        check_id: "declared_first",
+        script_path: "ci/scripts/declared-first.mjs",
+      },
+      {
+        check_id: "missing_third",
+        script_path: "ci/scripts/missing-third.mjs",
+      },
+    ],
+  });
+
+  const { status, report } = runRunner(fixture.boundaryPath, fixture.root);
+
+  assert.equal(status, 1);
+  assert.equal(report.ok, false);
+  assert.ok(
+    report.failures.some((failure) => failure.token === "boundary_check_path_missing"),
+    `expected boundary_check_path_missing, got ${JSON.stringify(report, null, 2)}`
+  );
+});


### PR DESCRIPTION
## Summary
- add P54 final acceptance boundary runner
- bind final acceptance boundary to declared checks in declared order only
- add boundary adapters for legacy release-claim and acceptance-artefact completeness validators

## Proof
- node .\ci\scripts\run_postv1_final_acceptance_boundary_runner.mjs .\docs\releases\V1_FINAL_ACCEPTANCE_BOUNDARY.json
- node --test --test-concurrency=1 .\test\postv1_final_acceptance_boundary_runner.test.mjs