### PR TITLE
test(postv1): add exercise substitution graph verifier

### DIFF
--- a/ci/scripts/run_exercise_substitution_graph_verifier.mjs
+++ b/ci/scripts/run_exercise_substitution_graph_verifier.mjs
@@ -1,0 +1,235 @@
+import fs from "node:fs";
+import path from "node:path";
+import process from "node:process";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const DEFAULT_GRAPH_PATH = path.resolve(
+  __dirname,
+  "..",
+  "..",
+  "registries",
+  "exercise",
+  "exercise_substitution_graph.json",
+);
+
+const DEFAULT_EXERCISE_REGISTRY_PATH = path.resolve(
+  __dirname,
+  "..",
+  "..",
+  "registries",
+  "exercise",
+  "exercise.registry.json",
+);
+
+function fail(message) {
+  const error = new Error(message);
+  error.name = "ExerciseSubstitutionGraphError";
+  throw error;
+}
+
+function readJson(filePath) {
+  const raw = fs.readFileSync(filePath, "utf8");
+  return JSON.parse(raw);
+}
+
+export function loadGraph(graphPath = DEFAULT_GRAPH_PATH) {
+  const parsed = readJson(graphPath);
+
+  if (!parsed || typeof parsed !== "object") {
+    fail("Substitution graph must parse to an object.");
+  }
+
+  if (!parsed.edges || typeof parsed.edges !== "object" || Array.isArray(parsed.edges)) {
+    fail("Substitution graph must contain an object at edges.");
+  }
+
+  return parsed;
+}
+
+export function loadExerciseRegistry(registryPath = DEFAULT_EXERCISE_REGISTRY_PATH) {
+  const parsed = readJson(registryPath);
+
+  if (!parsed || typeof parsed !== "object") {
+    fail("Exercise registry must parse to an object.");
+  }
+
+  if (!parsed.entries || typeof parsed.entries !== "object" || Array.isArray(parsed.entries)) {
+    fail("Exercise registry must contain an object at entries.");
+  }
+
+  return parsed;
+}
+
+function getPattern(exercise) {
+  return typeof exercise?.pattern === "string"
+    ? exercise.pattern.trim().toLowerCase()
+    : "";
+}
+
+export function evaluateSubstitutionGraph(graph, exerciseRegistry) {
+  const edges = graph?.edges;
+  const entries = exerciseRegistry?.entries;
+
+  if (!edges || typeof edges !== "object" || Array.isArray(edges)) {
+    fail("Graph edges must be an object keyed by source exercise id.");
+  }
+
+  if (!entries || typeof entries !== "object" || Array.isArray(entries)) {
+    fail("Exercise registry entries must be an object keyed by exercise id.");
+  }
+
+  const problems = [];
+  const validated_edges = [];
+
+  for (const [sourceId, targets] of Object.entries(edges)) {
+    const sourceExercise = entries[sourceId];
+
+    if (!sourceExercise) {
+      problems.push({
+        type: "missing_source",
+        source_id: sourceId,
+      });
+      continue;
+    }
+
+    if (!Array.isArray(targets)) {
+      problems.push({
+        type: "invalid_target_list",
+        source_id: sourceId,
+      });
+      continue;
+    }
+
+    for (const targetId of targets) {
+      if (typeof targetId !== "string" || !targetId.trim()) {
+        problems.push({
+          type: "invalid_target_id",
+          source_id: sourceId,
+          target_id: targetId,
+        });
+        continue;
+      }
+
+      const normalizedTargetId = targetId.trim();
+      const targetExercise = entries[normalizedTargetId];
+
+      if (!targetExercise) {
+        problems.push({
+          type: "missing_target",
+          source_id: sourceId,
+          target_id: normalizedTargetId,
+        });
+        continue;
+      }
+
+      if (sourceId === normalizedTargetId) {
+        problems.push({
+          type: "self_edge",
+          source_id: sourceId,
+          target_id: normalizedTargetId,
+        });
+        continue;
+      }
+
+      const sourcePattern = getPattern(sourceExercise);
+      const targetPattern = getPattern(targetExercise);
+
+      if (!sourcePattern || !targetPattern) {
+        problems.push({
+          type: "missing_pattern",
+          source_id: sourceId,
+          target_id: normalizedTargetId,
+        });
+        continue;
+      }
+
+      if (sourcePattern !== targetPattern) {
+        problems.push({
+          type: "cross_pattern_edge",
+          source_id: sourceId,
+          target_id: normalizedTargetId,
+          source_pattern: sourcePattern,
+          target_pattern: targetPattern,
+        });
+        continue;
+      }
+
+      validated_edges.push({
+        source_id: sourceId,
+        target_id: normalizedTargetId,
+        pattern: sourcePattern,
+      });
+    }
+  }
+
+  return {
+    ok: problems.length === 0,
+    validated_edge_count: validated_edges.length,
+    validated_edges,
+    problems,
+  };
+}
+
+export function verifySubstitutionGraph(
+  graphPath = DEFAULT_GRAPH_PATH,
+  registryPath = DEFAULT_EXERCISE_REGISTRY_PATH,
+) {
+  const graph = loadGraph(graphPath);
+  const exerciseRegistry = loadExerciseRegistry(registryPath);
+  const result = evaluateSubstitutionGraph(graph, exerciseRegistry);
+
+  if (!result.ok) {
+    const summary = result.problems
+      .map((problem) => {
+        switch (problem.type) {
+          case "missing_source":
+            return `missing_source:${problem.source_id}`;
+          case "invalid_target_list":
+            return `invalid_target_list:${problem.source_id}`;
+          case "invalid_target_id":
+            return `invalid_target_id:${problem.source_id}`;
+          case "missing_target":
+            return `missing_target:${problem.source_id}->${problem.target_id}`;
+          case "self_edge":
+            return `self_edge:${problem.source_id}`;
+          case "missing_pattern":
+            return `missing_pattern:${problem.source_id}->${problem.target_id}`;
+          case "cross_pattern_edge":
+            return `cross_pattern:${problem.source_id}->${problem.target_id}`;
+          default:
+            return `unknown_problem:${JSON.stringify(problem)}`;
+        }
+      })
+      .join(" ; ");
+
+    fail(`Substitution graph invalid: ${summary}`);
+  }
+
+  return result;
+}
+
+function main() {
+  const graphPath = process.argv[2]
+    ? path.resolve(process.cwd(), process.argv[2])
+    : DEFAULT_GRAPH_PATH;
+
+  const registryPath = process.argv[3]
+    ? path.resolve(process.cwd(), process.argv[3])
+    : DEFAULT_EXERCISE_REGISTRY_PATH;
+
+  try {
+    const result = verifySubstitutionGraph(graphPath, registryPath);
+    process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    process.stderr.write(`${message}\n`);
+    process.exit(1);
+  }
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === __filename) {
+  main();
+}

--- a/registries/exercise/exercise_substitution_graph.json
+++ b/registries/exercise/exercise_substitution_graph.json
@@ -1,0 +1,15 @@
+{
+  "graph_id": "exercise_substitution_graph",
+  "version": "1.0.0",
+  "edges": {
+    "back_squat": [
+      "goblet_squat"
+    ],
+    "bench_press": [
+      "dumbbell_bench_press"
+    ],
+    "overhead_press": [
+      "dumbbell_overhead_press"
+    ]
+  }
+}

--- a/test/exercise_substitution_graph_verifier.test.mjs
+++ b/test/exercise_substitution_graph_verifier.test.mjs
@@ -1,0 +1,117 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  evaluateSubstitutionGraph,
+} from "../ci/scripts/run_exercise_substitution_graph_verifier.mjs";
+
+function buildExerciseRegistry() {
+  return {
+    registry_id: "exercise",
+    version: "1.0.0",
+    entries: {
+      back_squat: {
+        exercise_id: "back_squat",
+        pattern: "squat",
+      },
+      goblet_squat: {
+        exercise_id: "goblet_squat",
+        pattern: "squat",
+      },
+      bench_press: {
+        exercise_id: "bench_press",
+        pattern: "horizontal_push",
+      },
+      dumbbell_bench_press: {
+        exercise_id: "dumbbell_bench_press",
+        pattern: "horizontal_push",
+      },
+      overhead_press: {
+        exercise_id: "overhead_press",
+        pattern: "vertical_push",
+      },
+      dumbbell_overhead_press: {
+        exercise_id: "dumbbell_overhead_press",
+        pattern: "vertical_push",
+      },
+    },
+  };
+}
+
+test("P71: passes when all substitution edges stay inside pattern", () => {
+  const graph = {
+    graph_id: "exercise_substitution_graph",
+    version: "1.0.0",
+    edges: {
+      back_squat: ["goblet_squat"],
+      bench_press: ["dumbbell_bench_press"],
+      overhead_press: ["dumbbell_overhead_press"],
+    },
+  };
+
+  const result = evaluateSubstitutionGraph(graph, buildExerciseRegistry());
+
+  assert.equal(result.ok, true);
+  assert.equal(result.validated_edge_count, 3);
+  assert.deepEqual(result.problems, []);
+});
+
+test("P71: fails when target exercise is missing", () => {
+  const graph = {
+    graph_id: "exercise_substitution_graph",
+    version: "1.0.0",
+    edges: {
+      back_squat: ["missing_target_exercise"],
+    },
+  };
+
+  const result = evaluateSubstitutionGraph(graph, buildExerciseRegistry());
+
+  assert.equal(result.ok, false);
+  assert.equal(result.problems[0].type, "missing_target");
+});
+
+test("P71: fails when source exercise is missing", () => {
+  const graph = {
+    graph_id: "exercise_substitution_graph",
+    version: "1.0.0",
+    edges: {
+      missing_source_exercise: ["goblet_squat"],
+    },
+  };
+
+  const result = evaluateSubstitutionGraph(graph, buildExerciseRegistry());
+
+  assert.equal(result.ok, false);
+  assert.equal(result.problems[0].type, "missing_source");
+});
+
+test("P71: fails when substitution crosses patterns", () => {
+  const graph = {
+    graph_id: "exercise_substitution_graph",
+    version: "1.0.0",
+    edges: {
+      back_squat: ["bench_press"],
+    },
+  };
+
+  const result = evaluateSubstitutionGraph(graph, buildExerciseRegistry());
+
+  assert.equal(result.ok, false);
+  assert.equal(result.problems[0].type, "cross_pattern_edge");
+});
+
+test("P71: fails on self-edge", () => {
+  const graph = {
+    graph_id: "exercise_substitution_graph",
+    version: "1.0.0",
+    edges: {
+      back_squat: ["back_squat"],
+    },
+  };
+
+  const result = evaluateSubstitutionGraph(graph, buildExerciseRegistry());
+
+  assert.equal(result.ok, false);
+  assert.equal(result.problems[0].type, "self_edge");
+});


### PR DESCRIPTION
## Summary
- add exercise substitution graph artefact
- add substitution graph verifier and targeted tests
- prove substitution edges stay inside exercise pattern

## Proof
- node --test --test-concurrency=1 .\test\exercise_substitution_graph_verifier.test.mjs
- node .\ci\scripts\run_exercise_substitution_graph_verifier.mjs
- node .\ci\guards\evidence_seal_guard.mjs