### PR TITLE
test(postv1): add cross-equipment substitution integrity verifier

### DIFF
--- a/ci/scripts/run_exercise_substitution_integrity_verifier.mjs
+++ b/ci/scripts/run_exercise_substitution_integrity_verifier.mjs
@@ -1,0 +1,344 @@
+import fs from "node:fs";
+import path from "node:path";
+import process from "node:process";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const DEFAULT_GRAPH_PATH = path.resolve(
+  __dirname,
+  "..",
+  "..",
+  "registries",
+  "exercise",
+  "exercise_substitution_graph.json",
+);
+
+const DEFAULT_EXERCISE_REGISTRY_PATH = path.resolve(
+  __dirname,
+  "..",
+  "..",
+  "registries",
+  "exercise",
+  "exercise.registry.json",
+);
+
+const EQUIPMENT_CLASS_RANK = Object.freeze({
+  bodyweight: 1,
+  dumbbell: 2,
+  barbell: 3,
+});
+
+function fail(message) {
+  const error = new Error(message);
+  error.name = "ExerciseSubstitutionIntegrityError";
+  throw error;
+}
+
+function readJson(filePath) {
+  const raw = fs.readFileSync(filePath, "utf8");
+  return JSON.parse(raw);
+}
+
+export function loadGraph(graphPath = DEFAULT_GRAPH_PATH) {
+  const parsed = readJson(graphPath);
+
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    fail("Substitution graph must parse to an object.");
+  }
+
+  if (!parsed.edges || typeof parsed.edges !== "object" || Array.isArray(parsed.edges)) {
+    fail("Substitution graph must contain an object at edges.");
+  }
+
+  return parsed;
+}
+
+export function loadExerciseRegistry(registryPath = DEFAULT_EXERCISE_REGISTRY_PATH) {
+  const parsed = readJson(registryPath);
+
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    fail("Exercise registry must parse to an object.");
+  }
+
+  if (!parsed.entries || typeof parsed.entries !== "object" || Array.isArray(parsed.entries)) {
+    fail("Exercise registry must contain an object at entries.");
+  }
+
+  return parsed;
+}
+
+function normalizeString(value) {
+  return typeof value === "string" ? value.trim().toLowerCase() : "";
+}
+
+function getPattern(exercise) {
+  return normalizeString(exercise?.pattern);
+}
+
+function getEquipmentClass(exercise) {
+  const direct = normalizeString(exercise?.equipment_class);
+  if (direct) {
+    return direct;
+  }
+
+  const tags = Array.isArray(exercise?.equipment_tags)
+    ? exercise.equipment_tags.map((value) => normalizeString(value)).filter(Boolean)
+    : [];
+
+  if (tags.includes("barbell")) {
+    return "barbell";
+  }
+
+  if (tags.includes("dumbbell")) {
+    return "dumbbell";
+  }
+
+  if (tags.includes("bodyweight")) {
+    return "bodyweight";
+  }
+
+  const equipment = Array.isArray(exercise?.equipment)
+    ? exercise.equipment.map((value) => normalizeString(value)).filter(Boolean)
+    : [];
+
+  if (equipment.includes("barbell")) {
+    return "barbell";
+  }
+
+  if (equipment.includes("dumbbell")) {
+    return "dumbbell";
+  }
+
+  if (equipment.includes("bodyweight")) {
+    return "bodyweight";
+  }
+
+  return "";
+}
+
+function getRank(equipmentClass) {
+  return EQUIPMENT_CLASS_RANK[equipmentClass] ?? 0;
+}
+
+function isAllowedEquipmentDowngrade(sourceClass, targetClass) {
+  const sourceRank = getRank(sourceClass);
+  const targetRank = getRank(targetClass);
+
+  if (!sourceRank || !targetRank) {
+    return false;
+  }
+
+  return sourceRank >= targetRank;
+}
+
+export function evaluateSubstitutionIntegrity(graph, exerciseRegistry) {
+  const edges = graph?.edges;
+  const entries = exerciseRegistry?.entries;
+
+  if (!edges || typeof edges !== "object" || Array.isArray(edges)) {
+    fail("Graph edges must be an object keyed by source exercise id.");
+  }
+
+  if (!entries || typeof entries !== "object" || Array.isArray(entries)) {
+    fail("Exercise registry entries must be an object keyed by exercise id.");
+  }
+
+  const problems = [];
+  const validated_edges = [];
+  const seenPairs = new Set();
+
+  for (const [sourceId, targets] of Object.entries(edges)) {
+    const sourceExercise = entries[sourceId];
+
+    if (!sourceExercise) {
+      problems.push({
+        type: "missing_source",
+        source_id: sourceId,
+      });
+      continue;
+    }
+
+    if (!Array.isArray(targets)) {
+      problems.push({
+        type: "invalid_target_list",
+        source_id: sourceId,
+      });
+      continue;
+    }
+
+    for (const rawTargetId of targets) {
+      if (typeof rawTargetId !== "string" || !rawTargetId.trim()) {
+        problems.push({
+          type: "invalid_target_id",
+          source_id: sourceId,
+          target_id: rawTargetId,
+        });
+        continue;
+      }
+
+      const targetId = rawTargetId.trim();
+      const pairKey = `${sourceId}=>${targetId}`;
+
+      if (seenPairs.has(pairKey)) {
+        problems.push({
+          type: "duplicate_edge",
+          source_id: sourceId,
+          target_id: targetId,
+        });
+        continue;
+      }
+
+      seenPairs.add(pairKey);
+
+      const targetExercise = entries[targetId];
+
+      if (!targetExercise) {
+        problems.push({
+          type: "missing_target",
+          source_id: sourceId,
+          target_id: targetId,
+        });
+        continue;
+      }
+
+      if (sourceId === targetId) {
+        problems.push({
+          type: "self_edge",
+          source_id: sourceId,
+          target_id: targetId,
+        });
+        continue;
+      }
+
+      const sourcePattern = getPattern(sourceExercise);
+      const targetPattern = getPattern(targetExercise);
+
+      if (!sourcePattern || !targetPattern) {
+        problems.push({
+          type: "missing_pattern",
+          source_id: sourceId,
+          target_id: targetId,
+        });
+        continue;
+      }
+
+      if (sourcePattern !== targetPattern) {
+        problems.push({
+          type: "movement_intent_mismatch",
+          source_id: sourceId,
+          target_id: targetId,
+          source_pattern: sourcePattern,
+          target_pattern: targetPattern,
+        });
+        continue;
+      }
+
+      const sourceEquipmentClass = getEquipmentClass(sourceExercise);
+      const targetEquipmentClass = getEquipmentClass(targetExercise);
+
+      if (!sourceEquipmentClass || !targetEquipmentClass) {
+        problems.push({
+          type: "missing_equipment_class",
+          source_id: sourceId,
+          target_id: targetId,
+        });
+        continue;
+      }
+
+      if (!isAllowedEquipmentDowngrade(sourceEquipmentClass, targetEquipmentClass)) {
+        problems.push({
+          type: "cross_equipment_direction_invalid",
+          source_id: sourceId,
+          target_id: targetId,
+          source_equipment_class: sourceEquipmentClass,
+          target_equipment_class: targetEquipmentClass,
+        });
+        continue;
+      }
+
+      validated_edges.push({
+        source_id: sourceId,
+        target_id: targetId,
+        pattern: sourcePattern,
+        source_equipment_class: sourceEquipmentClass,
+        target_equipment_class: targetEquipmentClass,
+      });
+    }
+  }
+
+  return {
+    ok: problems.length === 0,
+    validated_edge_count: validated_edges.length,
+    validated_edges,
+    problems,
+  };
+}
+
+export function verifySubstitutionIntegrity(
+  graphPath = DEFAULT_GRAPH_PATH,
+  registryPath = DEFAULT_EXERCISE_REGISTRY_PATH,
+) {
+  const graph = loadGraph(graphPath);
+  const exerciseRegistry = loadExerciseRegistry(registryPath);
+  const result = evaluateSubstitutionIntegrity(graph, exerciseRegistry);
+
+  if (!result.ok) {
+    const summary = result.problems
+      .map((problem) => {
+        switch (problem.type) {
+          case "missing_source":
+            return `missing_source:${problem.source_id}`;
+          case "invalid_target_list":
+            return `invalid_target_list:${problem.source_id}`;
+          case "invalid_target_id":
+            return `invalid_target_id:${problem.source_id}`;
+          case "missing_target":
+            return `missing_target:${problem.source_id}->${problem.target_id}`;
+          case "self_edge":
+            return `self_edge:${problem.source_id}`;
+          case "missing_pattern":
+            return `missing_pattern:${problem.source_id}->${problem.target_id}`;
+          case "movement_intent_mismatch":
+            return `movement_intent_mismatch:${problem.source_id}->${problem.target_id}`;
+          case "missing_equipment_class":
+            return `missing_equipment_class:${problem.source_id}->${problem.target_id}`;
+          case "cross_equipment_direction_invalid":
+            return `cross_equipment_direction_invalid:${problem.source_id}->${problem.target_id}`;
+          case "duplicate_edge":
+            return `duplicate_edge:${problem.source_id}->${problem.target_id}`;
+          default:
+            return `unknown_problem:${JSON.stringify(problem)}`;
+        }
+      })
+      .join(" ; ");
+
+    fail(`Substitution integrity invalid: ${summary}`);
+  }
+
+  return result;
+}
+
+function main() {
+  const graphPath = process.argv[2]
+    ? path.resolve(process.cwd(), process.argv[2])
+    : DEFAULT_GRAPH_PATH;
+
+  const registryPath = process.argv[3]
+    ? path.resolve(process.cwd(), process.argv[3])
+    : DEFAULT_EXERCISE_REGISTRY_PATH;
+
+  try {
+    const result = verifySubstitutionIntegrity(graphPath, registryPath);
+    process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    process.stderr.write(`${message}\n`);
+    process.exit(1);
+  }
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === __filename) {
+  main();
+}

--- a/test/exercise_substitution_integrity_verifier.test.mjs
+++ b/test/exercise_substitution_integrity_verifier.test.mjs
@@ -1,0 +1,144 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  evaluateSubstitutionIntegrity,
+} from "../ci/scripts/run_exercise_substitution_integrity_verifier.mjs";
+
+function buildExerciseRegistry() {
+  return {
+    registry_id: "exercise",
+    version: "1.0.0",
+    entries: {
+      back_squat: {
+        exercise_id: "back_squat",
+        pattern: "squat",
+        equipment_class: "barbell",
+      },
+      dumbbell_squat: {
+        exercise_id: "dumbbell_squat",
+        pattern: "squat",
+        equipment_class: "dumbbell",
+      },
+      bodyweight_squat: {
+        exercise_id: "bodyweight_squat",
+        pattern: "squat",
+        equipment_class: "bodyweight",
+      },
+      bench_press: {
+        exercise_id: "bench_press",
+        pattern: "horizontal_push",
+        equipment_class: "barbell",
+      },
+      dumbbell_bench_press: {
+        exercise_id: "dumbbell_bench_press",
+        pattern: "horizontal_push",
+        equipment_class: "dumbbell",
+      },
+      push_up: {
+        exercise_id: "push_up",
+        pattern: "horizontal_push",
+        equipment_class: "bodyweight",
+      },
+      overhead_press: {
+        exercise_id: "overhead_press",
+        pattern: "vertical_push",
+        equipment_class: "barbell",
+      },
+      dumbbell_overhead_press: {
+        exercise_id: "dumbbell_overhead_press",
+        pattern: "vertical_push",
+        equipment_class: "dumbbell",
+      },
+      pike_push_up: {
+        exercise_id: "pike_push_up",
+        pattern: "vertical_push",
+        equipment_class: "bodyweight",
+      },
+    },
+  };
+}
+
+test("P72: passes for barbell to dumbbell to bodyweight while preserving movement intent", () => {
+  const graph = {
+    graph_id: "exercise_substitution_graph",
+    version: "1.0.0",
+    edges: {
+      back_squat: ["dumbbell_squat", "bodyweight_squat"],
+      dumbbell_squat: ["bodyweight_squat"],
+      bench_press: ["dumbbell_bench_press", "push_up"],
+      dumbbell_bench_press: ["push_up"],
+      overhead_press: ["dumbbell_overhead_press", "pike_push_up"],
+      dumbbell_overhead_press: ["pike_push_up"],
+    },
+  };
+
+  const result = evaluateSubstitutionIntegrity(graph, buildExerciseRegistry());
+
+  assert.equal(result.ok, true);
+  assert.equal(result.validated_edge_count, 9);
+  assert.deepEqual(result.problems, []);
+});
+
+test("P72: fails when movement intent changes across equipment substitution", () => {
+  const graph = {
+    graph_id: "exercise_substitution_graph",
+    version: "1.0.0",
+    edges: {
+      back_squat: ["dumbbell_bench_press"],
+    },
+  };
+
+  const result = evaluateSubstitutionIntegrity(graph, buildExerciseRegistry());
+
+  assert.equal(result.ok, false);
+  assert.equal(result.problems[0].type, "movement_intent_mismatch");
+});
+
+test("P72: fails when substitution tries to move up the equipment ladder", () => {
+  const graph = {
+    graph_id: "exercise_substitution_graph",
+    version: "1.0.0",
+    edges: {
+      push_up: ["dumbbell_bench_press"],
+    },
+  };
+
+  const result = evaluateSubstitutionIntegrity(graph, buildExerciseRegistry());
+
+  assert.equal(result.ok, false);
+  assert.equal(result.problems[0].type, "cross_equipment_direction_invalid");
+});
+
+test("P72: fails when equipment class is missing", () => {
+  const registry = buildExerciseRegistry();
+  delete registry.entries.back_squat.equipment_class;
+
+  const graph = {
+    graph_id: "exercise_substitution_graph",
+    version: "1.0.0",
+    edges: {
+      back_squat: ["dumbbell_squat"],
+    },
+  };
+
+  const result = evaluateSubstitutionIntegrity(graph, registry);
+
+  assert.equal(result.ok, false);
+  assert.equal(result.problems[0].type, "missing_equipment_class");
+});
+
+test("P72: fails on duplicate edge entries", () => {
+  const graph = {
+    graph_id: "exercise_substitution_graph",
+    version: "1.0.0",
+    edges: {
+      bench_press: ["dumbbell_bench_press", "dumbbell_bench_press"],
+    },
+  };
+
+  const result = evaluateSubstitutionIntegrity(graph, buildExerciseRegistry());
+
+  assert.equal(result.ok, false);
+  assert.equal(result.problems[0].type, "duplicate_edge");
+});


### PR DESCRIPTION
## Summary
- add cross-equipment substitution integrity verifier
- prove substitution preserves movement intent across allowed equipment downgrade paths
- keep current repo graph validation honest while adding synthetic bodyweight downgrade proof

## Proof
- node --test --test-concurrency=1 .\test\exercise_substitution_integrity_verifier.test.mjs
- node .\ci\scripts\run_exercise_substitution_integrity_verifier.mjs .\registries\exercise\exercise_substitution_graph.json .\registries\exercise\exercise.registry.json