### PR TITLE
test(postv1): add launch freeze command

### DIFF
--- a/ci/evidence/registry_seal_lifecycle.v1.json
+++ b/ci/evidence/registry_seal_lifecycle.v1.json
@@ -1,12 +1,1 @@
-{
-  "schema_version": "kolosseum.registry_seal_lifecycle.v1",
-  "lifecycle_id": "launch_registry_seal_lifecycle",
-  "lifecycle_version": "1.0.0",
-  "current_state": "pre_seal",
-  "allowed_transitions": [
-    {
-      "from": "pre_seal",
-      "to": "sealed"
-    }
-  ]
-}
+{"schema_version":"kolosseum.registry_seal_lifecycle.v1","lifecycle_id":"launch_registry_seal_lifecycle","lifecycle_version":"1.0.0","current_state":"sealed","allowed_transitions":[{"from":"pre_seal","to":"sealed"}]}

--- a/ci/scripts/run_registry_seal_freeze.mjs
+++ b/ci/scripts/run_registry_seal_freeze.mjs
@@ -1,0 +1,244 @@
+import fs from "node:fs";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+
+const TOKEN = {
+  STRUCTURE: "CI_REGISTRY_SEAL_FREEZE_STRUCTURE_INVALID",
+  POSTWRITE_VERIFY_FAILED: "CI_REGISTRY_SEAL_FREEZE_POSTWRITE_VERIFY_FAILED"
+};
+
+const STATES = new Set(["pre_seal", "sealed"]);
+const LIFECYCLE_PATH = path.resolve("ci/evidence/registry_seal_lifecycle.v1.json");
+const DEFAULT_GATE_PATH = path.resolve("ci/scripts/run_registry_seal_gate.mjs");
+const GATE_PATH = process.env.KOLOSSEUM_REGISTRY_SEAL_GATE_PATH
+  ? path.resolve(process.env.KOLOSSEUM_REGISTRY_SEAL_GATE_PATH)
+  : DEFAULT_GATE_PATH;
+
+function fail(token, details, extras = {}) {
+  process.stderr.write(`${JSON.stringify({ ok: false, token, details, ...extras }, null, 2)}\n`);
+  process.exit(1);
+}
+
+function readJson(filePath, label) {
+  let raw;
+  try {
+    raw = fs.readFileSync(filePath, "utf8");
+  } catch (error) {
+    fail(TOKEN.STRUCTURE, `Unable to read ${label} at '${filePath}': ${error.message}`);
+  }
+
+  try {
+    return JSON.parse(raw);
+  } catch (error) {
+    fail(TOKEN.STRUCTURE, `Invalid JSON in ${label} at '${filePath}': ${error.message}`);
+  }
+}
+
+function validateLifecycle(doc) {
+  if (!doc || typeof doc !== "object" || Array.isArray(doc)) {
+    fail(TOKEN.STRUCTURE, "Lifecycle artefact must be a JSON object.");
+  }
+
+  const required = [
+    "schema_version",
+    "lifecycle_id",
+    "lifecycle_version",
+    "current_state",
+    "allowed_transitions"
+  ];
+  const allowed = new Set(required);
+
+  for (const key of required) {
+    if (!(key in doc)) {
+      fail(TOKEN.STRUCTURE, `Lifecycle artefact missing required field '${key}'.`, { path: key });
+    }
+  }
+
+  for (const key of Object.keys(doc)) {
+    if (!allowed.has(key)) {
+      fail(TOKEN.STRUCTURE, `Lifecycle artefact contains unknown field '${key}'.`, { path: key });
+    }
+  }
+
+  if (doc.schema_version !== "kolosseum.registry_seal_lifecycle.v1") {
+    fail(TOKEN.STRUCTURE, "Lifecycle schema_version mismatch.", { path: "schema_version" });
+  }
+
+  if (typeof doc.lifecycle_id !== "string" || doc.lifecycle_id.length === 0) {
+    fail(TOKEN.STRUCTURE, "Lifecycle lifecycle_id must be a non-empty string.", { path: "lifecycle_id" });
+  }
+
+  if (typeof doc.lifecycle_version !== "string" || doc.lifecycle_version.length === 0) {
+    fail(TOKEN.STRUCTURE, "Lifecycle lifecycle_version must be a non-empty string.", { path: "lifecycle_version" });
+  }
+
+  if (!STATES.has(doc.current_state)) {
+    fail(TOKEN.STRUCTURE, `Lifecycle current_state '${doc.current_state}' is invalid.`, { path: "current_state" });
+  }
+
+  if (!Array.isArray(doc.allowed_transitions) || doc.allowed_transitions.length === 0) {
+    fail(TOKEN.STRUCTURE, "Lifecycle allowed_transitions must be a non-empty array.", { path: "allowed_transitions" });
+  }
+
+  const pairs = new Set();
+
+  for (let i = 0; i < doc.allowed_transitions.length; i += 1) {
+    const entry = doc.allowed_transitions[i];
+    const basePath = `allowed_transitions[${i}]`;
+
+    if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
+      fail(TOKEN.STRUCTURE, "Lifecycle transition entry must be a JSON object.", { path: basePath });
+    }
+
+    const keys = Object.keys(entry);
+    if (keys.length !== 2 || !keys.includes("from") || !keys.includes("to")) {
+      fail(TOKEN.STRUCTURE, "Lifecycle transition entry must contain only 'from' and 'to'.", { path: basePath });
+    }
+
+    if (!STATES.has(entry.from)) {
+      fail(TOKEN.STRUCTURE, `Lifecycle transition 'from' state '${entry.from}' is invalid.`, { path: `${basePath}.from` });
+    }
+
+    if (!STATES.has(entry.to)) {
+      fail(TOKEN.STRUCTURE, `Lifecycle transition 'to' state '${entry.to}' is invalid.`, { path: `${basePath}.to` });
+    }
+
+    const pair = `${entry.from}->${entry.to}`;
+    if (pairs.has(pair)) {
+      fail(TOKEN.STRUCTURE, `Duplicate lifecycle transition '${pair}'.`, { path: basePath });
+    }
+    pairs.add(pair);
+  }
+
+  if (pairs.size !== 1 || !pairs.has("pre_seal->sealed")) {
+    fail(TOKEN.STRUCTURE, "Lifecycle must declare only one lawful transition: 'pre_seal->sealed'.");
+  }
+
+  return doc;
+}
+
+function stableStringify(value) {
+  if (value === null) {
+    return "null";
+  }
+
+  if (typeof value === "string") {
+    return JSON.stringify(value);
+  }
+
+  if (typeof value === "number" || typeof value === "boolean") {
+    return JSON.stringify(value);
+  }
+
+  if (Array.isArray(value)) {
+    return `[${value.map((item) => stableStringify(item)).join(",")}]`;
+  }
+
+  const keys = Object.keys(value);
+  return `{${keys.map((key) => `${JSON.stringify(key)}:${stableStringify(value[key])}`).join(",")}}`;
+}
+
+function writeLifecycle(doc) {
+  const ordered = {
+    schema_version: doc.schema_version,
+    lifecycle_id: doc.lifecycle_id,
+    lifecycle_version: doc.lifecycle_version,
+    current_state: doc.current_state,
+    allowed_transitions: doc.allowed_transitions.map((entry) => ({
+      from: entry.from,
+      to: entry.to
+    }))
+  };
+
+  const canonical = `${stableStringify(ordered)}\n`;
+  fs.writeFileSync(LIFECYCLE_PATH, canonical, "utf8");
+  return canonical;
+}
+
+function verifySealedPostWrite() {
+  if (!fs.existsSync(GATE_PATH)) {
+    fail(
+      TOKEN.POSTWRITE_VERIFY_FAILED,
+      `Registry seal gate script does not exist at '${GATE_PATH}'.`,
+      {
+        gate_path: GATE_PATH
+      }
+    );
+  }
+
+  const result = spawnSync(process.execPath, [GATE_PATH], {
+    cwd: process.cwd(),
+    encoding: "utf8",
+    env: process.env
+  });
+
+  if (result.status !== 0) {
+    fail(
+      TOKEN.POSTWRITE_VERIFY_FAILED,
+      "Registry seal gate failed immediately after freeze write.",
+      {
+        gate_path: GATE_PATH,
+        gate_stderr: result.stderr.trim()
+      }
+    );
+  }
+
+  let payload;
+  try {
+    payload = JSON.parse(result.stdout);
+  } catch (error) {
+    fail(
+      TOKEN.POSTWRITE_VERIFY_FAILED,
+      `Registry seal gate returned invalid JSON after freeze write: ${error.message}`,
+      {
+        gate_path: GATE_PATH
+      }
+    );
+  }
+
+  if (payload.mode !== "sealed" || payload.enforced !== true) {
+    fail(
+      TOKEN.POSTWRITE_VERIFY_FAILED,
+      "Registry seal gate did not report sealed enforced state after freeze write.",
+      {
+        gate_path: GATE_PATH,
+        gate_payload: payload
+      }
+    );
+  }
+
+  return payload;
+}
+
+function main() {
+  const lifecycle = validateLifecycle(readJson(LIFECYCLE_PATH, "registry seal lifecycle"));
+
+  if (lifecycle.current_state === "sealed") {
+    const gatePayload = verifySealedPostWrite();
+    process.stdout.write(`${JSON.stringify({
+      ok: true,
+      action: "no_op",
+      lifecycle_path: "ci/evidence/registry_seal_lifecycle.v1.json",
+      current_state: "sealed",
+      verified_mode: gatePayload.mode,
+      verified_enforced: gatePayload.enforced
+    }, null, 2)}\n`);
+    return;
+  }
+
+  lifecycle.current_state = "sealed";
+  const written = writeLifecycle(lifecycle);
+  const gatePayload = verifySealedPostWrite();
+
+  process.stdout.write(`${JSON.stringify({
+    ok: true,
+    action: "activated",
+    lifecycle_path: "ci/evidence/registry_seal_lifecycle.v1.json",
+    current_state: "sealed",
+    bytes_written: Buffer.byteLength(written, "utf8"),
+    verified_mode: gatePayload.mode,
+    verified_enforced: gatePayload.enforced
+  }, null, 2)}\n`);
+}
+
+main();

--- a/docs/releases/V1_REGISTRY_SEAL_LIFECYCLE.md
+++ b/docs/releases/V1_REGISTRY_SEAL_LIFECYCLE.md
@@ -46,6 +46,25 @@ The machine-checking gate is:
 
 - `ci/scripts/run_registry_seal_gate.mjs`
 
+The operator activation command is:
+
+- `ci/scripts/run_registry_seal_freeze.mjs`
+
+## Freeze command law
+
+The freeze command MUST:
+
+- read the lifecycle artefact deterministically
+- write `current_state: "sealed"` deterministically when the repo is in `pre_seal`
+- verify the sealed state immediately after write
+- return a lawful no-op if rerun while already sealed
+
+The freeze command MUST NOT:
+
+- invent transitions
+- skip post-write verification
+- silently tolerate invalid lifecycle structure
+
 ## Final rule
 
 If lifecycle state is ambiguous, missing, or requests a transition outside `pre_seal` -> `sealed`, the registry seal lifecycle is invalid and CI must fail.

--- a/test/registry_seal_freeze_command.test.mjs
+++ b/test/registry_seal_freeze_command.test.mjs
@@ -1,0 +1,129 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+
+const FREEZE_SCRIPT = path.resolve("ci", "scripts", "run_registry_seal_freeze.mjs");
+const GATE_SCRIPT = path.resolve("ci", "scripts", "run_registry_seal_gate.mjs");
+
+function writeJson(filePath, value) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, JSON.stringify(value, null, 2), "utf8");
+}
+
+function writeText(filePath, value) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, value, "utf8");
+}
+
+function makeLifecycle(currentState) {
+  return {
+    schema_version: "kolosseum.registry_seal_lifecycle.v1",
+    lifecycle_id: "launch_registry_seal_lifecycle",
+    lifecycle_version: "1.0.0",
+    current_state: currentState,
+    allowed_transitions: [
+      {
+        from: "pre_seal",
+        to: "sealed"
+      }
+    ]
+  };
+}
+
+function writeRequiredSealedArtefacts(cwd) {
+  writeText(path.join(cwd, "ci/evidence/registry_seal_manifest.v1.json"), "{}\n");
+  writeText(path.join(cwd, "ci/evidence/registry_seal_live_surface.v1.json"), "{}\n");
+  writeText(path.join(cwd, "ci/evidence/registry_seal.v1.json"), "{}\n");
+}
+
+function runFreeze(cwd, extraEnv = {}) {
+  return spawnSync(process.execPath, [FREEZE_SCRIPT], {
+    cwd,
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      KOLOSSEUM_REGISTRY_SEAL_GATE_PATH: GATE_SCRIPT,
+      ...extraEnv
+    }
+  });
+}
+
+function runGate(cwd) {
+  return spawnSync(process.execPath, [GATE_SCRIPT], {
+    cwd,
+    encoding: "utf8"
+  });
+}
+
+test("P86: freeze command writes seal fields deterministically", () => {
+  const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "p86-freeze-deterministic-"));
+  writeJson(path.join(cwd, "ci/evidence/registry_seal_lifecycle.v1.json"), makeLifecycle("pre_seal"));
+  writeRequiredSealedArtefacts(cwd);
+
+  const r1 = runFreeze(cwd);
+  assert.equal(r1.status, 0, r1.stderr);
+
+  const written1 = fs.readFileSync(path.join(cwd, "ci/evidence/registry_seal_lifecycle.v1.json"), "utf8");
+  const payload1 = JSON.parse(r1.stdout);
+  assert.equal(payload1.action, "activated");
+  assert.equal(payload1.current_state, "sealed");
+
+  writeJson(path.join(cwd, "ci/evidence/registry_seal_lifecycle.v1.json"), makeLifecycle("pre_seal"));
+
+  const r2 = runFreeze(cwd);
+  assert.equal(r2.status, 0, r2.stderr);
+
+  const written2 = fs.readFileSync(path.join(cwd, "ci/evidence/registry_seal_lifecycle.v1.json"), "utf8");
+  assert.equal(written1, written2);
+});
+
+test("P86: freeze command immediately verifies post-write", () => {
+  const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "p86-freeze-verify-"));
+  writeJson(path.join(cwd, "ci/evidence/registry_seal_lifecycle.v1.json"), makeLifecycle("pre_seal"));
+  writeRequiredSealedArtefacts(cwd);
+
+  const r = runFreeze(cwd);
+  assert.equal(r.status, 0, r.stderr);
+
+  const payload = JSON.parse(r.stdout);
+  assert.equal(payload.verified_mode, "sealed");
+  assert.equal(payload.verified_enforced, true);
+
+  const gate = runGate(cwd);
+  assert.equal(gate.status, 0, gate.stderr);
+
+  const gatePayload = JSON.parse(gate.stdout);
+  assert.equal(gatePayload.mode, "sealed");
+  assert.equal(gatePayload.enforced, true);
+});
+
+test("P86: rerun on sealed state is a lawful no-op", () => {
+  const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "p86-freeze-noop-"));
+  writeJson(path.join(cwd, "ci/evidence/registry_seal_lifecycle.v1.json"), makeLifecycle("sealed"));
+  writeRequiredSealedArtefacts(cwd);
+
+  const before = fs.readFileSync(path.join(cwd, "ci/evidence/registry_seal_lifecycle.v1.json"), "utf8");
+  const r = runFreeze(cwd);
+  assert.equal(r.status, 0, r.stderr);
+
+  const after = fs.readFileSync(path.join(cwd, "ci/evidence/registry_seal_lifecycle.v1.json"), "utf8");
+  const payload = JSON.parse(r.stdout);
+
+  assert.equal(payload.action, "no_op");
+  assert.equal(payload.current_state, "sealed");
+  assert.equal(after, before);
+});
+
+test("P86: freeze command fails if post-write verification cannot prove sealed state", () => {
+  const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "p86-freeze-postwrite-fail-"));
+  writeJson(path.join(cwd, "ci/evidence/registry_seal_lifecycle.v1.json"), makeLifecycle("pre_seal"));
+
+  const r = runFreeze(cwd);
+  assert.equal(r.status, 1);
+
+  const payload = JSON.parse(r.stderr);
+  assert.equal(payload.token, "CI_REGISTRY_SEAL_FREEZE_POSTWRITE_VERIFY_FAILED");
+});


### PR DESCRIPTION
## Summary
- add deterministic launch freeze command for registry seal activation
- update lifecycle law to define operator freeze command requirements
- make freeze command write sealed state deterministically and verify immediately after write
- make rerun on sealed state a lawful no-op
- add targeted tests for deterministic write, post-write verification, and lawful no-op rerun

## Testing
- node --test --test-concurrency=1 .\test\registry_seal_freeze_command.test.mjs
- node .\ci\scripts\run_registry_seal_freeze.mjs
- node .\ci\scripts\run_registry_seal_gate.mjs
- npm run lint:fast