### PR TITLE
test(registry): upgrade live seal surface to exact registry files

### DIFF
--- a/ci/evidence/registry_seal_live_surface.v1.json
+++ b/ci/evidence/registry_seal_live_surface.v1.json
@@ -5,13 +5,22 @@
   "seal_scope": "registry_bundle",
   "entries": [
     {
-      "path": "registries/registry_bundle.json"
+      "path": "registries/activity/activity.registry.json"
     },
     {
-      "path": "ci/schemas/registry_seal.v1.schema.json"
+      "path": "registries/exercise/exercise.registry.json"
     },
     {
-      "path": "ci/evidence/registry_seal.v1.json"
+      "path": "registries/exercise/exercise_substitution_graph.json"
+    },
+    {
+      "path": "registries/exercise/exercise_warmup_mapping.registry.json"
+    },
+    {
+      "path": "registries/movement/movement.registry.json"
+    },
+    {
+      "path": "registries/program/program.registry.json"
     }
   ]
 }

--- a/ci/evidence/registry_seal_manifest.v1.json
+++ b/ci/evidence/registry_seal_manifest.v1.json
@@ -5,13 +5,22 @@
   "seal_scope": "registry_bundle",
   "entries": [
     {
-      "path": "registries/registry_bundle.json"
+      "path": "registries/activity/activity.registry.json"
     },
     {
-      "path": "ci/schemas/registry_seal.v1.schema.json"
+      "path": "registries/exercise/exercise.registry.json"
     },
     {
-      "path": "ci/evidence/registry_seal.v1.json"
+      "path": "registries/exercise/exercise_substitution_graph.json"
+    },
+    {
+      "path": "registries/exercise/exercise_warmup_mapping.registry.json"
+    },
+    {
+      "path": "registries/movement/movement.registry.json"
+    },
+    {
+      "path": "registries/program/program.registry.json"
     }
   ]
 }

--- a/ci/evidence/registry_seal_snapshot.v1.json
+++ b/ci/evidence/registry_seal_snapshot.v1.json
@@ -1,20 +1,32 @@
 {
-    "schema_version":  "kolosseum.registry_seal_snapshot.v1",
-    "snapshot_id":  "launch_registry_seal_snapshot",
-    "snapshot_version":  "1.0.0",
-    "seal_scope":  "registry_bundle",
-    "entries":  [
-                    {
-                        "path":  "registries/registry_bundle.json",
-                        "sha256":  "3ae38479b85aad2bbf03ec1ea9613d17d9ee97997b529bacbfdd9d41773e61df"
-                    },
-                    {
-                        "path":  "ci/schemas/registry_seal.v1.schema.json",
-                        "sha256":  "82e3dfa3130e3e35215944cc747078919e9bdc7d13cb000f8154949fadbfafd5"
-                    },
-                    {
-                        "path":  "ci/evidence/registry_seal.v1.json",
-                        "sha256":  "ece8776943e96fd1f229ba547ab38be1106c1d33118843f5acfa3e9e1c074153"
-                    }
-                ]
+  "schema_version": "kolosseum.registry_seal_snapshot.v1",
+  "snapshot_id": "launch_registry_seal_snapshot",
+  "snapshot_version": "1.0.0",
+  "seal_scope": "registry_bundle",
+  "entries": [
+    {
+      "path": "registries/activity/activity.registry.json",
+      "sha256": "b50c8b5568d0b47dae29f7cba5435fe85b7a2df28dec06db3ae6b4579437c126"
+    },
+    {
+      "path": "registries/exercise/exercise.registry.json",
+      "sha256": "69d778018220fca668afb2ddb915da24e0fd146f8e58c5e8b138fd1cfa54e514"
+    },
+    {
+      "path": "registries/exercise/exercise_substitution_graph.json",
+      "sha256": "8d97eab5a2149e6e8634f7bf82f3179ae78c2906825bc46fe6588c1d984852c9"
+    },
+    {
+      "path": "registries/exercise/exercise_warmup_mapping.registry.json",
+      "sha256": "11f7c41e7b87f8bf0fc9a7470c777497dd5081b5aa6a7d59c6ac5e044ef16829"
+    },
+    {
+      "path": "registries/movement/movement.registry.json",
+      "sha256": "e98a7e0dd6be1bf6c1020cddfd394f6682e0ee2044acb193e0f196a36a6aa8d0"
+    },
+    {
+      "path": "registries/program/program.registry.json",
+      "sha256": "f7c43076c43c54048c3a2c80f8c29cea224f8447051b56f7598187abc0f5437c"
+    }
+  ]
 }

--- a/ci/scripts/run_registry_seal_manifest_verifier.mjs
+++ b/ci/scripts/run_registry_seal_manifest_verifier.mjs
@@ -111,7 +111,7 @@ function validateSnapshot(snapshot, manifest) {
     fail(TOKEN.STRUCTURE, "Snapshot must be a JSON object.");
   }
 
-  const required = ["schema_version", "manifest_id", "manifest_version", "seal_scope", "entries"];
+  const required = ["schema_version", "snapshot_id", "snapshot_version", "seal_scope", "entries"];
   const allowed = new Set(required);
 
   for (const key of required) {
@@ -130,12 +130,16 @@ function validateSnapshot(snapshot, manifest) {
     fail(TOKEN.STRUCTURE, "Snapshot schema_version mismatch.", { path: "schema_version" });
   }
 
-  if (snapshot.manifest_id !== manifest.manifest_id) {
-    fail(TOKEN.STRUCTURE, "Snapshot manifest_id mismatch.", { path: "manifest_id" });
+  if (typeof snapshot.snapshot_id !== "string" || snapshot.snapshot_id.length === 0) {
+    fail(TOKEN.STRUCTURE, "Snapshot snapshot_id must be a non-empty string.", { path: "snapshot_id" });
   }
 
-  if (snapshot.manifest_version !== manifest.manifest_version) {
-    fail(TOKEN.STRUCTURE, "Snapshot manifest_version mismatch.", { path: "manifest_version" });
+  if (snapshot.snapshot_version !== manifest.manifest_version) {
+    fail(TOKEN.STRUCTURE, "Snapshot snapshot_version mismatch.", {
+      path: "snapshot_version",
+      expected_snapshot_version: manifest.manifest_version,
+      actual_snapshot_version: snapshot.snapshot_version
+    });
   }
 
   if (snapshot.seal_scope !== manifest.seal_scope) {
@@ -225,6 +229,8 @@ function main() {
     ok: true,
     manifest_id: manifest.manifest_id,
     manifest_version: manifest.manifest_version,
+    snapshot_id: snapshot.snapshot_id,
+    snapshot_version: snapshot.snapshot_version,
     entry_count: expectedEntries.length
   }, null, 2)}\n`);
 }

--- a/ci/scripts/write_registry_seal_snapshot_from_manifest.mjs
+++ b/ci/scripts/write_registry_seal_snapshot_from_manifest.mjs
@@ -38,8 +38,8 @@ const manifest = readJson(manifestPath, "manifest");
 
 const snapshot = {
   schema_version: "kolosseum.registry_seal_snapshot.v1",
-  manifest_id: manifest.manifest_id,
-  manifest_version: manifest.manifest_version,
+  snapshot_id: "launch_registry_seal_snapshot",
+  snapshot_version: manifest.manifest_version,
   seal_scope: manifest.seal_scope,
   entries: manifest.entries.map((entry) => {
     const filePath = path.resolve(entry.path);

--- a/test/registry_seal_live_surface_contract_upgrade.test.mjs
+++ b/test/registry_seal_live_surface_contract_upgrade.test.mjs
@@ -1,0 +1,107 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+
+function writeJson(filePath, value) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, JSON.stringify(value, null, 2));
+}
+
+function makeRoot() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), "p94a-live-surface-"));
+}
+
+function runVerifier(root) {
+  return spawnSync(
+    process.execPath,
+    [path.resolve("ci/scripts/run_registry_seal_scope_completeness_verifier.mjs")],
+    {
+      cwd: root,
+      encoding: "utf8"
+    }
+  );
+}
+
+test("passes when manifest and live surface both enumerate exact registry files", () => {
+  const root = makeRoot();
+
+  const paths = [
+    "registries/activity/activity.registry.json",
+    "registries/exercise/exercise.registry.json",
+    "registries/exercise/exercise_substitution_graph.json",
+    "registries/exercise/exercise_warmup_mapping.registry.json",
+    "registries/movement/movement.registry.json",
+    "registries/program/program.registry.json"
+  ];
+
+  for (const rel of paths) {
+    const abs = path.join(root, rel);
+    fs.mkdirSync(path.dirname(abs), { recursive: true });
+    fs.writeFileSync(abs, "{}\n");
+  }
+
+  writeJson(path.join(root, "ci", "evidence", "registry_seal_manifest.v1.json"), {
+    schema_version: "kolosseum.registry_seal_manifest.v1",
+    manifest_id: "launch_registry_surface",
+    manifest_version: "1.0.0",
+    seal_scope: "registry_bundle",
+    entries: paths.map((p) => ({ path: p }))
+  });
+
+  writeJson(path.join(root, "ci", "evidence", "registry_seal_live_surface.v1.json"), {
+    schema_version: "kolosseum.registry_seal_live_surface.v1",
+    surface_id: "launch_registry_live_surface",
+    surface_version: "1.0.0",
+    seal_scope: "registry_bundle",
+    entries: paths.map((p) => ({ path: p }))
+  });
+
+  const result = runVerifier(root);
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  const payload = JSON.parse(result.stdout);
+  assert.equal(payload.ok, true);
+  assert.equal(payload.manifest_entry_count, paths.length);
+  assert.equal(payload.live_surface_entry_count, paths.length);
+});
+
+test("fails when live surface contains an exact registry file not in manifest", () => {
+  const root = makeRoot();
+
+  const manifestPaths = [
+    "registries/activity/activity.registry.json"
+  ];
+
+  const livePaths = [
+    "registries/activity/activity.registry.json",
+    "registries/movement/movement.registry.json"
+  ];
+
+  for (const rel of livePaths) {
+    const abs = path.join(root, rel);
+    fs.mkdirSync(path.dirname(abs), { recursive: true });
+    fs.writeFileSync(abs, "{}\n");
+  }
+
+  writeJson(path.join(root, "ci", "evidence", "registry_seal_manifest.v1.json"), {
+    schema_version: "kolosseum.registry_seal_manifest.v1",
+    manifest_id: "launch_registry_surface",
+    manifest_version: "1.0.0",
+    seal_scope: "registry_bundle",
+    entries: manifestPaths.map((p) => ({ path: p }))
+  });
+
+  writeJson(path.join(root, "ci", "evidence", "registry_seal_live_surface.v1.json"), {
+    schema_version: "kolosseum.registry_seal_live_surface.v1",
+    surface_id: "launch_registry_live_surface",
+    surface_version: "1.0.0",
+    seal_scope: "registry_bundle",
+    entries: livePaths.map((p) => ({ path: p }))
+  });
+
+  const result = runVerifier(root);
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /Live launch registry surface file 'registries\/movement\/movement\.registry\.json' is not listed in seal manifest/);
+});


### PR DESCRIPTION
## Summary
- upgrade registry seal live surface to exact registry file scope
- upgrade registry seal manifest and snapshot to exact registry file scope
- align snapshot generation and manifest verification contracts
- add targeted live surface contract upgrade test

## Testing
- node --test .\test\registry_seal_live_surface_contract_upgrade.test.mjs
- node .\ci\scripts\run_registry_seal_manifest_verifier.mjs
- node .\ci\scripts\run_registry_seal_scope_completeness_verifier.mjs
- node .\ci\scripts\run_registry_seal_drift_diff_reporter.mjs
- node .\ci\scripts\run_registry_seal_gate.mjs
- npm run lint:fast
- npm run test:one -- .\test\registry_seal_live_surface_contract_upgrade.test.mjs
- npm run dev:status