### PR TITLE
test(release): bind release notes to active seal manifest

### DIFF
--- a/ci/scripts/run_release_notes_seal_binding_guard.mjs
+++ b/ci/scripts/run_release_notes_seal_binding_guard.mjs
@@ -1,0 +1,113 @@
+import fs from "node:fs";
+import path from "node:path";
+import crypto from "node:crypto";
+import { fileURLToPath } from "node:url";
+
+const DEFAULT_ROOT = process.cwd();
+
+const RELEASE_NOTES_PATH = path.join("docs", "releases", "V1_RELEASE_NOTES.md");
+const SEAL_PATH = path.join("ci", "evidence", "registry_seal_manifest.v1.json");
+
+const TOKEN = {
+  MISSING_NOTES: "CI_RELEASE_NOTES_SEAL_MISSING_NOTES",
+  MISSING_REFERENCE: "CI_RELEASE_NOTES_SEAL_REFERENCE_MISSING",
+  STALE_REFERENCE: "CI_RELEASE_NOTES_SEAL_REFERENCE_STALE",
+  STRUCTURE: "CI_RELEASE_NOTES_SEAL_STRUCTURE_INVALID"
+};
+
+function fail(failures, token, details, extra = {}) {
+  failures.push({ token, details, ...extra });
+}
+
+function readFileSafe(filePath, label) {
+  if (!fs.existsSync(filePath)) {
+    throw new Error(`${label} missing at ${filePath}`);
+  }
+  return fs.readFileSync(filePath, "utf8");
+}
+
+function extractSealReference(notesContent) {
+  const match = notesContent.match(/registry_seal_manifest\.v1\.json\s*:\s*([a-f0-9]{64})/i);
+  return match ? match[1].toLowerCase() : null;
+}
+
+export async function verifyReleaseNotesSealBinding(rootDir = DEFAULT_ROOT) {
+  const failures = [];
+
+  const notesPath = path.join(rootDir, RELEASE_NOTES_PATH);
+  const sealPath = path.join(rootDir, SEAL_PATH);
+
+  if (!fs.existsSync(notesPath)) {
+    fail(failures, TOKEN.MISSING_NOTES, "Release notes file is missing.", {
+      path: RELEASE_NOTES_PATH
+    });
+    return { ok: false, failures };
+  }
+
+  if (!fs.existsSync(sealPath)) {
+    fail(failures, TOKEN.STRUCTURE, "Registry seal manifest is missing.", {
+      path: SEAL_PATH
+    });
+    return { ok: false, failures };
+  }
+
+  const notesContent = readFileSafe(notesPath, "release notes");
+  const sealContent = readFileSafe(sealPath, "registry seal manifest");
+
+  const referencedHash = extractSealReference(notesContent);
+
+  if (!referencedHash) {
+    fail(
+      failures,
+      TOKEN.MISSING_REFERENCE,
+      "Release notes must include 'registry_seal_manifest.v1.json: <sha256>'.",
+      { path: RELEASE_NOTES_PATH }
+    );
+    return { ok: false, failures };
+  }
+
+  const actualHash = crypto.createHash("sha256").update(sealContent).digest("hex");
+
+  if (referencedHash !== actualHash) {
+    fail(
+      failures,
+      TOKEN.STALE_REFERENCE,
+      "Release notes reference does not match the active registry seal manifest.",
+      {
+        path: RELEASE_NOTES_PATH,
+        expected: actualHash,
+        found: referencedHash
+      }
+    );
+  }
+
+  return {
+    ok: failures.length === 0,
+    failures
+  };
+}
+
+async function main() {
+  try {
+    const report = await verifyReleaseNotesSealBinding(DEFAULT_ROOT);
+
+    if (!report.ok) {
+      process.stderr.write(`${JSON.stringify(report, null, 2)}\n`);
+      process.exit(1);
+    }
+
+    process.stdout.write(`${JSON.stringify({ ok: true }, null, 2)}\n`);
+  } catch (error) {
+    process.stderr.write(`${JSON.stringify({
+      ok: false,
+      token: TOKEN.STRUCTURE,
+      details: error instanceof Error ? error.message : String(error)
+    }, null, 2)}\n`);
+    process.exit(1);
+  }
+}
+
+const currentFilePath = fileURLToPath(import.meta.url);
+if (process.argv[1] && path.resolve(process.argv[1]) === currentFilePath) {
+  main();
+}

--- a/docs/releases/V1_RELEASE_NOTES.md
+++ b/docs/releases/V1_RELEASE_NOTES.md
@@ -31,3 +31,6 @@ It must not claim unmerged work, planned work, dormant work, or broader platform
 ## Notes
 These release notes are a packaging artefact, not an authority source.
 If this file conflicts with merged code, tests, CI, or canonical law, this file loses.
+
+## Active registry seal binding
+registry_seal_manifest.v1.json: 7936f1866f49043d9bf4a11a34623b52bfe2e9b384e3731daaa27ea582cbd296

--- a/test/release_notes_seal_binding_guard.test.mjs
+++ b/test/release_notes_seal_binding_guard.test.mjs
@@ -1,0 +1,59 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import crypto from "node:crypto";
+
+import { verifyReleaseNotesSealBinding } from "../ci/scripts/run_release_notes_seal_binding_guard.mjs";
+
+function write(filePath, content) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, content, "utf8");
+}
+
+function makeRoot() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), "p95-seal-binding-"));
+}
+
+test("passes when release notes reference correct seal hash", async () => {
+  const root = makeRoot();
+
+  const sealContent = JSON.stringify({ ok: true }, null, 2);
+  const hash = crypto.createHash("sha256").update(sealContent).digest("hex");
+
+  write(path.join(root, "ci", "evidence", "registry_seal_manifest.v1.json"), sealContent);
+  write(
+    path.join(root, "docs", "releases", "V1_RELEASE_NOTES.md"),
+    `Registry binding` + "\n" + `registry_seal_manifest.v1.json: ${hash}` + "\n"
+  );
+
+  const report = await verifyReleaseNotesSealBinding(root);
+  assert.equal(report.ok, true);
+  assert.deepEqual(report.failures, []);
+});
+
+test("fails when reference is missing", async () => {
+  const root = makeRoot();
+
+  write(path.join(root, "ci", "evidence", "registry_seal_manifest.v1.json"), "{}");
+  write(path.join(root, "docs", "releases", "V1_RELEASE_NOTES.md"), "no reference\n");
+
+  const report = await verifyReleaseNotesSealBinding(root);
+  assert.equal(report.ok, false);
+  assert.match(JSON.stringify(report.failures), /CI_RELEASE_NOTES_SEAL_REFERENCE_MISSING/);
+});
+
+test("fails when reference is stale", async () => {
+  const root = makeRoot();
+
+  write(path.join(root, "ci", "evidence", "registry_seal_manifest.v1.json"), "{}");
+  write(
+    path.join(root, "docs", "releases", "V1_RELEASE_NOTES.md"),
+    "registry_seal_manifest.v1.json: deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef\n"
+  );
+
+  const report = await verifyReleaseNotesSealBinding(root);
+  assert.equal(report.ok, false);
+  assert.match(JSON.stringify(report.failures), /CI_RELEASE_NOTES_SEAL_REFERENCE_STALE/);
+});


### PR DESCRIPTION
## Summary
- add P95 release notes seal binding guard
- require release notes to reference the active registry seal manifest hash
- fail on missing or stale seal reference
- add targeted guard tests

## Testing
- node --test .\test\release_notes_seal_binding_guard.test.mjs
- node .\ci\scripts\run_release_notes_seal_binding_guard.mjs
- npm run lint:fast
- npm run test:one -- .\test\release_notes_seal_binding_guard.test.mjs
- npm run dev:status