### PR TITLE
docs(release): add operator freeze runbook

### DIFF
--- a/ci/scripts/run_operator_freeze_runbook_verifier.mjs
+++ b/ci/scripts/run_operator_freeze_runbook_verifier.mjs
@@ -1,0 +1,56 @@
+import fs from "node:fs";
+import path from "node:path";
+
+const RUNBOOK_PATH = path.resolve("docs/releases/V1_OPERATOR_FREEZE_RUNBOOK.md");
+
+const REQUIRED_SNIPPETS = [
+  "node .\\ci\\scripts\\run_registry_seal_manifest_verifier.mjs",
+  "node .\\ci\\scripts\\run_registry_seal_scope_completeness_verifier.mjs",
+  "node .\\ci\\scripts\\run_registry_seal_drift_diff_reporter.mjs",
+  "node .\\ci\\scripts\\run_registry_seal_gate.mjs",
+  "node .\\ci\\scripts\\run_registry_seal_freeze.mjs",
+  "Unfreeze is not allowed.",
+  "Only lawful transition: pre_seal -> sealed."
+];
+
+function fail(token, details) {
+  process.stderr.write(JSON.stringify({ ok: false, token, details }, null, 2) + "\\n");
+  process.exit(1);
+}
+
+if (!fs.existsSync(RUNBOOK_PATH)) {
+  fail(
+    "CI_OPERATOR_FREEZE_RUNBOOK_MISSING",
+    "docs/releases/V1_OPERATOR_FREEZE_RUNBOOK.md is missing."
+  );
+}
+
+const text = fs.readFileSync(RUNBOOK_PATH, "utf8");
+
+for (const snippet of REQUIRED_SNIPPETS) {
+  if (!text.includes(snippet)) {
+    fail(
+      "CI_OPERATOR_FREEZE_RUNBOOK_MISMATCH",
+      `Missing required runbook snippet: ${snippet}`
+    );
+  }
+}
+
+if (/sealed\s*->\s*pre_seal/i.test(text) || /pre_seal\s*<-\s*sealed/i.test(text)) {
+  fail(
+    "CI_OPERATOR_FREEZE_RUNBOOK_CONTRADICTION",
+    "Reverse lifecycle transition is forbidden."
+  );
+}
+
+if (/unfreeze/i.test(text) && !text.includes("Unfreeze is not allowed.")) {
+  fail(
+    "CI_OPERATOR_FREEZE_RUNBOOK_CONTRADICTION",
+    "Runbook mentions unfreeze without the required prohibition."
+  );
+}
+
+process.stdout.write(JSON.stringify({
+  ok: true,
+  runbook_path: "docs/releases/V1_OPERATOR_FREEZE_RUNBOOK.md"
+}, null, 2) + "\\n");

--- a/docs/releases/V1_OPERATOR_FREEZE_RUNBOOK.md
+++ b/docs/releases/V1_OPERATOR_FREEZE_RUNBOOK.md
@@ -1,0 +1,51 @@
+# V1 Operator Freeze Runbook
+
+## Purpose
+
+Give one canonical operator flow for freeze, verify, and explicit no-unfreeze handling.
+
+## Invariant
+
+- operator flow is fixed and auditable
+- Unfreeze is not allowed.
+- Only lawful transition: pre_seal -> sealed.
+
+## Canonical command sequence
+
+```powershell
+Set-Location C:\Users\rober\kolosseum
+$ErrorActionPreference = "Stop"
+$PSNativeCommandUseErrorActionPreference = $true
+Set-StrictMode -Version Latest
+
+node .\ci\scripts\run_registry_seal_manifest_verifier.mjs
+node .\ci\scripts\run_registry_seal_scope_completeness_verifier.mjs
+node .\ci\scripts\run_registry_seal_drift_diff_reporter.mjs
+node .\ci\scripts\run_registry_seal_gate.mjs
+node .\ci\scripts\run_registry_seal_freeze.mjs
+node .\ci\scripts\run_registry_seal_gate.mjs
+node .\ci\scripts\run_registry_seal_drift_diff_reporter.mjs
+```
+
+## Operator interpretation
+
+1. Verify manifest integrity first.
+2. Verify live surface completeness against manifest.
+3. Verify no drift exists before freeze.
+4. Verify current lifecycle/gate state.
+5. Execute freeze.
+6. Re-verify gate after freeze.
+7. Re-verify drift after freeze.
+
+## Forbidden actions
+
+- Do not invent alternate freeze command sequences.
+- Do not skip the pre-freeze verification steps.
+- Do not attempt reverse transition.
+- Do not document or execute any unfreeze flow.
+
+## Lawful lifecycle
+
+- pre_seal -> sealed
+- sealed -> pre_seal is forbidden
+- Unfreeze is not allowed.

--- a/docs/releases/V1_PACKAGING_SURFACE_REGISTRY.json
+++ b/docs/releases/V1_PACKAGING_SURFACE_REGISTRY.json
@@ -27,6 +27,7 @@
                      "docs/releases/V1_FINAL_ACCEPTANCE_BOUNDARY.json",
                      "docs/releases/V1_MAINLINE_GREEN_RUN_EVIDENCE.md",
                      "docs/releases/V1_OPERATOR_EXECUTION_ORDER.md",
+                     "docs/releases/V1_OPERATOR_FREEZE_RUNBOOK.md",
                      "docs/releases/V1_OPERATOR_RUNBOOK.md",
                      "docs/releases/V1_PACKAGING_EVIDENCE_MANIFEST.json",
                      "docs/releases/V1_PACKAGING_PROMOTION_PR_BODY_TEMPLATE.md",

--- a/test/operator_freeze_runbook_verifier.test.mjs
+++ b/test/operator_freeze_runbook_verifier.test.mjs
@@ -1,0 +1,78 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+
+const verifierPath = path.resolve("ci/scripts/run_operator_freeze_runbook_verifier.mjs");
+
+function writeUtf8(filePath, content) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, content, "utf8");
+}
+
+function makeRoot() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), "p96-operator-freeze-runbook-"));
+}
+
+function runVerifier(root) {
+  return spawnSync(process.execPath, [verifierPath], {
+    cwd: root,
+    encoding: "utf8"
+  });
+}
+
+test("passes when canonical operator freeze runbook is present", () => {
+  const root = makeRoot();
+
+  writeUtf8(
+    path.join(root, "docs", "releases", "V1_OPERATOR_FREEZE_RUNBOOK.md"),
+    [
+      "# V1 Operator Freeze Runbook",
+      "",
+      "node .\\\\ci\\\\scripts\\\\run_registry_seal_manifest_verifier.mjs",
+      "node .\\\\ci\\\\scripts\\\\run_registry_seal_scope_completeness_verifier.mjs",
+      "node .\\\\ci\\\\scripts\\\\run_registry_seal_drift_diff_reporter.mjs",
+      "node .\\\\ci\\\\scripts\\\\run_registry_seal_gate.mjs",
+      "node .\\\\ci\\\\scripts\\\\run_registry_seal_freeze.mjs",
+      "Unfreeze is not allowed.",
+      "Only lawful transition: pre_seal -> sealed."
+    ].join("\\n") + "\\n"
+  );
+
+  const result = runVerifier(root);
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  const payload = JSON.parse(result.stdout);
+  assert.equal(payload.ok, true);
+});
+
+test("fails when runbook is missing", () => {
+  const root = makeRoot();
+  const result = runVerifier(root);
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /CI_OPERATOR_FREEZE_RUNBOOK_MISSING/);
+});
+
+test("fails when contradictory instructions appear", () => {
+  const root = makeRoot();
+
+  writeUtf8(
+    path.join(root, "docs", "releases", "V1_OPERATOR_FREEZE_RUNBOOK.md"),
+    [
+      "# V1 Operator Freeze Runbook",
+      "",
+      "node .\\\\ci\\\\scripts\\\\run_registry_seal_manifest_verifier.mjs",
+      "node .\\\\ci\\\\scripts\\\\run_registry_seal_scope_completeness_verifier.mjs",
+      "node .\\\\ci\\\\scripts\\\\run_registry_seal_drift_diff_reporter.mjs",
+      "node .\\\\ci\\\\scripts\\\\run_registry_seal_gate.mjs",
+      "node .\\\\ci\\\\scripts\\\\run_registry_seal_freeze.mjs",
+      "Only lawful transition: pre_seal -> sealed.",
+      "sealed -> pre_seal"
+    ].join("\\n") + "\\n"
+  );
+
+  const result = runVerifier(root);
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /CI_OPERATOR_FREEZE_RUNBOOK_CONTRADICTION/);
+});


### PR DESCRIPTION
## Summary
- add canonical operator freeze runbook
- verify required freeze command sequence is documented
- fail when contradictory lifecycle instructions appear
- add targeted runbook verifier test
- register the runbook in the packaging surface registry

## Testing
- node --test .\test\operator_freeze_runbook_verifier.test.mjs
- node .\ci\scripts\run_operator_freeze_runbook_verifier.mjs
- npm run lint:fast
- npm run test:one -- .\test\operator_freeze_runbook_verifier.test.mjs
- npm run dev:status