### PR TITLE
ci(release): add freeze proof chain order verifier

### DIFF
--- a/ci/scripts/run_freeze_proof_chain_order_verifier.mjs
+++ b/ci/scripts/run_freeze_proof_chain_order_verifier.mjs
@@ -1,0 +1,210 @@
+import fs from "node:fs";
+import path from "node:path";
+import crypto from "node:crypto";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const REPO_ROOT = path.resolve(__dirname, "..", "..");
+
+const FREEZE_PROOF_INDEX_PATH = path.join(
+  REPO_ROOT,
+  "docs",
+  "releases",
+  "V1_FREEZE_PROOF_INDEX.json",
+);
+
+const OUTPUT_PATH = path.join(
+  REPO_ROOT,
+  "docs",
+  "releases",
+  "V1_FREEZE_PROOF_CHAIN_ORDER.json",
+);
+
+function normalizeRelative(value) {
+  return String(value).replace(/\\/g, "/");
+}
+
+function readJson(filePath) {
+  return JSON.parse(fs.readFileSync(filePath, "utf8"));
+}
+
+function sha256File(filePath) {
+  const bytes = fs.readFileSync(filePath);
+  return crypto.createHash("sha256").update(bytes).digest("hex");
+}
+
+function ensureArray(value, label) {
+  if (!Array.isArray(value)) {
+    throw new Error(`${label} must be an array`);
+  }
+  return value;
+}
+
+function ensureString(value, label) {
+  if (typeof value !== "string" || value.trim() === "") {
+    throw new Error(`${label} must be a non-empty string`);
+  }
+  return value;
+}
+
+function ensureExists(relPath, label) {
+  const absolutePath = path.join(REPO_ROOT, relPath);
+  if (!fs.existsSync(absolutePath)) {
+    throw new Error(`${label} missing: ${relPath}`);
+  }
+  return absolutePath;
+}
+
+function buildResult() {
+  const indexDoc = readJson(FREEZE_PROOF_INDEX_PATH);
+
+  const proofChain = ensureArray(
+    indexDoc.freeze_proof_chain,
+    "freeze_proof_chain",
+  );
+
+  const nodeByPath = new Map();
+  const duplicatePaths = [];
+  const orphanProofs = [];
+  const outOfOrderDependencies = [];
+  const missingUpstreamNodes = [];
+
+  for (let i = 0; i < proofChain.length; i += 1) {
+    const entry = proofChain[i];
+    if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
+      throw new Error(`freeze_proof_chain[${i}] must be an object`);
+    }
+
+    const proofPath = normalizeRelative(
+      ensureString(entry.path, `freeze_proof_chain[${i}].path`),
+    );
+    const upstreamPaths = ensureArray(
+      entry.upstream_paths ?? [],
+      `freeze_proof_chain[${i}].upstream_paths`,
+    ).map((p, j) =>
+      normalizeRelative(
+        ensureString(
+          p,
+          `freeze_proof_chain[${i}].upstream_paths[${j}]`,
+        ),
+      ),
+    );
+
+    if (nodeByPath.has(proofPath)) {
+      duplicatePaths.push(proofPath);
+      continue;
+    }
+
+    const absolutePath = ensureExists(proofPath, "freeze proof");
+    nodeByPath.set(proofPath, {
+      path: proofPath,
+      order: i,
+      upstream_paths: upstreamPaths,
+      sha256: sha256File(absolutePath),
+    });
+  }
+
+  const nodes = [...nodeByPath.values()].sort((a, b) => a.order - b.order);
+
+  for (const node of nodes) {
+    if (node.upstream_paths.length === 0 && node.order !== 0) {
+      orphanProofs.push(node.path);
+    }
+
+    for (const upstreamPath of node.upstream_paths) {
+      const upstreamNode = nodeByPath.get(upstreamPath);
+      if (!upstreamNode) {
+        missingUpstreamNodes.push({
+          path: node.path,
+          missing_upstream_path: upstreamPath,
+        });
+        continue;
+      }
+
+      if (upstreamNode.order >= node.order) {
+        outOfOrderDependencies.push({
+          path: node.path,
+          upstream_path: upstreamPath,
+          upstream_order: upstreamNode.order,
+          path_order: node.order,
+        });
+      }
+    }
+  }
+
+  const ok =
+    duplicatePaths.length === 0 &&
+    orphanProofs.length === 0 &&
+    missingUpstreamNodes.length === 0 &&
+    outOfOrderDependencies.length === 0;
+
+  return {
+    ok,
+    verifier: "freeze_proof_chain_order",
+    generated_at_utc: new Date().toISOString(),
+    compared_against: {
+      freeze_proof_index: normalizeRelative(
+        path.relative(REPO_ROOT, FREEZE_PROOF_INDEX_PATH),
+      ),
+    },
+    invariants: [
+      "every non-root proof must declare at least one upstream proof stage",
+      "every declared upstream proof stage must exist in the proof chain",
+      "every declared upstream proof stage must appear earlier in the proof chain",
+      "proof chain node paths must be unique",
+    ],
+    proof_chain_nodes: nodes.map((node) => ({
+      path: node.path,
+      order: node.order,
+      upstream_paths: node.upstream_paths,
+      sha256: node.sha256,
+    })),
+    duplicate_paths: duplicatePaths,
+    orphan_proofs: orphanProofs,
+    missing_upstream_nodes: missingUpstreamNodes,
+    out_of_order_dependencies: outOfOrderDependencies,
+  };
+}
+
+function main() {
+  ensureExists(
+    normalizeRelative(path.relative(REPO_ROOT, FREEZE_PROOF_INDEX_PATH)),
+    "freeze proof index",
+  );
+
+  const result = buildResult();
+  fs.writeFileSync(OUTPUT_PATH, JSON.stringify(result, null, 2) + "\n", "utf8");
+
+  if (!result.ok) {
+    const parts = [];
+    if (result.duplicate_paths.length > 0) {
+      parts.push(`duplicate_paths=${result.duplicate_paths.join(", ")}`);
+    }
+    if (result.orphan_proofs.length > 0) {
+      parts.push(`orphan_proofs=${result.orphan_proofs.join(", ")}`);
+    }
+    if (result.missing_upstream_nodes.length > 0) {
+      parts.push(
+        `missing_upstream_nodes=${result.missing_upstream_nodes
+          .map((x) => `${x.path}->${x.missing_upstream_path}`)
+          .join(", ")}`,
+      );
+    }
+    if (result.out_of_order_dependencies.length > 0) {
+      parts.push(
+        `out_of_order_dependencies=${result.out_of_order_dependencies
+          .map((x) => `${x.path}->${x.upstream_path}`)
+          .join(", ")}`,
+      );
+    }
+
+    throw new Error(
+      `freeze proof chain order failed | ${parts.join(" | ")}`,
+    );
+  }
+
+  process.stdout.write(JSON.stringify(result, null, 2) + "\n");
+}
+
+main();

--- a/docs/releases/V1_FREEZE_PROOF_CHAIN_ORDER.json
+++ b/docs/releases/V1_FREEZE_PROOF_CHAIN_ORDER.json
@@ -1,0 +1,141 @@
+{
+  "ok": true,
+  "verifier": "freeze_proof_chain_order",
+  "generated_at_utc": "2026-04-02T14:58:14.993Z",
+  "compared_against": {
+    "freeze_proof_index": "docs/releases/V1_FREEZE_PROOF_INDEX.json"
+  },
+  "invariants": [
+    "every non-root proof must declare at least one upstream proof stage",
+    "every declared upstream proof stage must exist in the proof chain",
+    "every declared upstream proof stage must appear earlier in the proof chain",
+    "proof chain node paths must be unique"
+  ],
+  "proof_chain_nodes": [
+    {
+      "path": "docs/releases/V1_FREEZE_STATE.json",
+      "order": 0,
+      "upstream_paths": [],
+      "sha256": "571202d79cb5a5fb625d48fb85590290c32c197c8282398b876c11af8654c64f"
+    },
+    {
+      "path": "docs/releases/V1_FREEZE_COMMAND_SEQUENCE_GATE.json",
+      "order": 1,
+      "upstream_paths": [
+        "docs/releases/V1_FREEZE_STATE.json"
+      ],
+      "sha256": "2612da1c6f4f189d872eaf176067ddb9e9b2e13f42a841f19b56347008619df9"
+    },
+    {
+      "path": "docs/releases/V1_FREEZE_READINESS.json",
+      "order": 2,
+      "upstream_paths": [
+        "docs/releases/V1_FREEZE_STATE.json",
+        "docs/releases/V1_FREEZE_COMMAND_SEQUENCE_GATE.json"
+      ],
+      "sha256": "ae8a14b89d961da3a6a645dd6e8a8d63e2ee7239737e3ccccbe487ee30c94d9c"
+    },
+    {
+      "path": "docs/releases/V1_FREEZE_EXIT_CRITERIA.json",
+      "order": 3,
+      "upstream_paths": [
+        "docs/releases/V1_FREEZE_READINESS.json"
+      ],
+      "sha256": "a265bb504d6a9c625da23dae641246f316b4fabffb5ad8fc02dae52ba606f5f2"
+    },
+    {
+      "path": "docs/releases/V1_FREEZE_DRIFT_REPORT.json",
+      "order": 4,
+      "upstream_paths": [
+        "docs/releases/V1_FREEZE_STATE.json"
+      ],
+      "sha256": "6955d000fe794128e9301a012aaf98b74811176d5b2a6a37349981c18b5f0e11"
+    },
+    {
+      "path": "docs/releases/V1_FREEZE_DRIFT_SINCE_MERGE_BASE.json",
+      "order": 5,
+      "upstream_paths": [
+        "docs/releases/V1_FREEZE_DRIFT_REPORT.json"
+      ],
+      "sha256": "a77917f53c460b6ef343443ab44979ba238a0dadeef99e023a94e36cde5ceed3"
+    },
+    {
+      "path": "docs/releases/V1_FREEZE_DRIFT_EVIDENCE.json",
+      "order": 6,
+      "upstream_paths": [
+        "docs/releases/V1_FREEZE_DRIFT_SINCE_MERGE_BASE.json"
+      ],
+      "sha256": "88a5c816a2c08a0a92888a51ae65f898381916bf57084d7c4bf8f47abe016dc9"
+    },
+    {
+      "path": "docs/releases/V1_FREEZE_PACKAGING_ARTEFACT_SET.json",
+      "order": 7,
+      "upstream_paths": [
+        "docs/releases/V1_FREEZE_EXIT_CRITERIA.json"
+      ],
+      "sha256": "ffa44acb405d8c8cfdd17f39fad78f3f4b0706626f8377b2f5d6edb0af86af6f"
+    },
+    {
+      "path": "docs/releases/V1_FREEZE_ARTEFACT_SET.json",
+      "order": 8,
+      "upstream_paths": [
+        "docs/releases/V1_FREEZE_PACKAGING_ARTEFACT_SET.json"
+      ],
+      "sha256": "d1fe649ccd544ae063a344283be6983ceab4b76ba3145260edb88f994868a0a6"
+    },
+    {
+      "path": "docs/releases/V1_FREEZE_MAINLINE_ENTRY_GUARD.json",
+      "order": 9,
+      "upstream_paths": [
+        "docs/releases/V1_FREEZE_EXIT_CRITERIA.json"
+      ],
+      "sha256": "17936ae6bfa27ece49ec1236e09d9cd845c57593b0412c2b4e5cdd239984ec31"
+    },
+    {
+      "path": "docs/releases/V1_FREEZE_PACK_REBUILD_CLEANLINESS.json",
+      "order": 10,
+      "upstream_paths": [
+        "docs/releases/V1_FREEZE_PACKAGING_ARTEFACT_SET.json"
+      ],
+      "sha256": "76ff1e35d2368671e6c12678ac35e83a17309edb68c7da680d5f2e5bb40c8c17"
+    },
+    {
+      "path": "docs/releases/V1_FREEZE_EVIDENCE_MANIFEST.json",
+      "order": 11,
+      "upstream_paths": [
+        "docs/releases/V1_FREEZE_READINESS.json",
+        "docs/releases/V1_FREEZE_DRIFT_EVIDENCE.json",
+        "docs/releases/V1_FREEZE_ARTEFACT_SET.json"
+      ],
+      "sha256": "1594988f8bd93cefe76460a8fc99873cbc5ce997ee08542fc55953eb68260b8f"
+    },
+    {
+      "path": "docs/releases/V1_FREEZE_EVIDENCE_MANIFEST_COMPLETENESS.json",
+      "order": 12,
+      "upstream_paths": [
+        "docs/releases/V1_FREEZE_EVIDENCE_MANIFEST.json"
+      ],
+      "sha256": "bfb34b4e208cab19d70c41a9ec1fe02aaceeaa21a179d5492272dd79e48abcfd"
+    },
+    {
+      "path": "docs/releases/V1_FREEZE_EVIDENCE_MANIFEST_SELF_HASH.json",
+      "order": 13,
+      "upstream_paths": [
+        "docs/releases/V1_FREEZE_EVIDENCE_MANIFEST.json"
+      ],
+      "sha256": "db46c08bee649afe9d4c797485ffdb4a5c22b677d8555df43b258d051052e4e1"
+    },
+    {
+      "path": "docs/releases/V1_FREEZE_ROLLBACK_COMPATIBILITY.json",
+      "order": 14,
+      "upstream_paths": [
+        "docs/releases/V1_FREEZE_EVIDENCE_MANIFEST.json"
+      ],
+      "sha256": "b39b43bac039ec5a846aff6c7320a06947f174fac600e0d047668f41811d1038"
+    }
+  ],
+  "duplicate_paths": [],
+  "orphan_proofs": [],
+  "missing_upstream_nodes": [],
+  "out_of_order_dependencies": []
+}

--- a/docs/releases/V1_FREEZE_PROOF_INDEX.json
+++ b/docs/releases/V1_FREEZE_PROOF_INDEX.json
@@ -1,110 +1,203 @@
 {
-    "ok":  true,
-    "verifier_id":  "freeze_proof_index_verifier",
-    "checked_at_utc":  "2026-04-02T13:30:00.000Z",
-    "invariant":  "freeze governance must be inspectable from one authoritative proof map",
-    "proof_entry_count":  13,
-    "proof_entries":  [
-                          {
-                              "slice_id":  "P114",
-                              "proof_surface":  "docs/releases/V1_FREEZE_ROLLBACK_COMPATIBILITY.json",
-                              "invariant":  "freeze rollback must stay compatible with sealed freeze semantics",
-                              "proof_type":  "verifier_report"
-                          },
-                          {
-                              "slice_id":  "P115",
-                              "proof_surface":  "docs/releases/V1_MAINLINE_FREEZE_PRESERVATION.json",
-                              "invariant":  "mainline freeze preservation must remain byte-stable across governed surfaces",
-                              "proof_type":  "verifier_report"
-                          },
-                          {
-                              "slice_id":  "P116",
-                              "proof_surface":  "docs/releases/V1_OPERATOR_FREEZE_ARTEFACT_SET.json",
-                              "invariant":  "operator freeze bundle input surface must stay deterministic and bounded",
-                              "proof_type":  "bundle_spec"
-                          },
-                          {
-                              "slice_id":  "P117",
-                              "proof_surface":  "docs/releases/V1_OPERATOR_FREEZE_BUNDLE_PRESERVATION.json",
-                              "invariant":  "operator freeze bundle rebuild must not drift from governed source artefacts",
-                              "proof_type":  "verifier_report"
-                          },
-                          {
-                              "slice_id":  "P118",
-                              "proof_surface":  "docs/releases/V1_FREEZE_EVIDENCE_MANIFEST_COMPLETENESS.json",
-                              "invariant":  "freeze manifest must fully enumerate governed byte identities",
-                              "proof_type":  "verifier_report"
-                          },
-                          {
-                              "slice_id":  "P119",
-                              "proof_surface":  "docs/releases/V1_FREEZE_EVIDENCE_MANIFEST_SELF_HASH.json",
-                              "invariant":  "freeze evidence manifest cannot drift structurally without fresh governed artefact recomputation",
-                              "proof_type":  "verifier_report"
-                          },
-                          {
-                              "slice_id":  "P120",
-                              "proof_surface":  "docs/releases/V1_OPERATOR_FREEZE_BUNDLE_SURFACE_COMPLETENESS.json",
-                              "invariant":  "handoff bundle must be minimal and sufficient",
-                              "proof_type":  "verifier_report"
-                          },
-                          {
-                              "slice_id":  "P121",
-                              "proof_surface":  "docs/releases/V1_FREEZE_COMMAND_SEQUENCE_GATE.json",
-                              "invariant":  "freeze packaging and preservation checks must not run before freeze state + manifest integrity are established",
-                              "proof_type":  "verifier_report"
-                          },
-                          {
-                              "slice_id":  "P122",
-                              "proof_surface":  "docs/releases/V1_FREEZE_MAINLINE_ENTRY_GUARD.json",
-                              "invariant":  "sealed freeze surfaces cannot change silently on mainline",
-                              "proof_type":  "verifier_report"
-                          },
-                          {
-                              "slice_id":  "P123",
-                              "proof_surface":  "docs/releases/V1_FREEZE_DRIFT_REPORT.json",
-                              "invariant":  "freeze state must be inspectable from one bounded report",
-                              "proof_type":  "aggregate_report"
-                          },
-                          {
-                              "slice_id":  "P124",
-                              "proof_surface":  "docs/releases/V1_FREEZE_EXIT_CRITERIA.json",
-                              "invariant":  "freeze cannot be declared complete while any freeze-proof surface is absent or failing",
-                              "proof_type":  "verifier_report"
-                          },
-                          {
-                              "slice_id":  "P125",
-                              "proof_surface":  "docs/releases/V1_PROMOTION_READINESS.json",
-                              "invariant":  "promotion readiness must depend on completed freeze proof chain",
-                              "proof_type":  "readiness_report"
-                          },
-                          {
-                              "slice_id":  "P126",
-                              "proof_surface":  "docs/releases/V1_FREEZE_PACK_REBUILD_CLEANLINESS.json",
-                              "invariant":  "standard freeze build path must leave clean working tree",
-                              "proof_type":  "verifier_report"
-                          }
-                      ],
-    "freeze_proof_reports":  [
-                                 {
-                                     "path":  "docs/releases/V1_FREEZE_ARTEFACT_SET.json"
-                                 },
-                                 {
-                                     "path":  "docs/releases/V1_FREEZE_DRIFT_EVIDENCE.json"
-                                 },
-                                 {
-                                     "path":  "docs/releases/V1_FREEZE_DRIFT_SINCE_MERGE_BASE.json"
-                                 },
-                                 {
-                                     "path":  "docs/releases/V1_FREEZE_EVIDENCE_MANIFEST.json"
-                                 },
-                                 {
-                                     "path":  "docs/releases/V1_FREEZE_PACKAGING_ARTEFACT_SET.json"
-                                 },
-                                 {
-                                     "path":  "docs/releases/V1_FREEZE_READINESS.json"
-                                 },
-                                 {
-                                     "path":  "docs/releases/V1_FREEZE_STATE.json"
-                                 }
-                             ]
+  "ok": true,
+  "verifier_id": "freeze_proof_index_verifier",
+  "checked_at_utc": "2026-04-02T13:30:00.000Z",
+  "invariant": "freeze governance must be inspectable from one authoritative proof map",
+  "proof_entry_count": 13,
+  "proof_entries": [
+    {
+      "slice_id": "P114",
+      "proof_surface": "docs/releases/V1_FREEZE_ROLLBACK_COMPATIBILITY.json",
+      "invariant": "freeze rollback must stay compatible with sealed freeze semantics",
+      "proof_type": "verifier_report"
+    },
+    {
+      "slice_id": "P115",
+      "proof_surface": "docs/releases/V1_MAINLINE_FREEZE_PRESERVATION.json",
+      "invariant": "mainline freeze preservation must remain byte-stable across governed surfaces",
+      "proof_type": "verifier_report"
+    },
+    {
+      "slice_id": "P116",
+      "proof_surface": "docs/releases/V1_OPERATOR_FREEZE_ARTEFACT_SET.json",
+      "invariant": "operator freeze bundle input surface must stay deterministic and bounded",
+      "proof_type": "bundle_spec"
+    },
+    {
+      "slice_id": "P117",
+      "proof_surface": "docs/releases/V1_OPERATOR_FREEZE_BUNDLE_PRESERVATION.json",
+      "invariant": "operator freeze bundle rebuild must not drift from governed source artefacts",
+      "proof_type": "verifier_report"
+    },
+    {
+      "slice_id": "P118",
+      "proof_surface": "docs/releases/V1_FREEZE_EVIDENCE_MANIFEST_COMPLETENESS.json",
+      "invariant": "freeze manifest must fully enumerate governed byte identities",
+      "proof_type": "verifier_report"
+    },
+    {
+      "slice_id": "P119",
+      "proof_surface": "docs/releases/V1_FREEZE_EVIDENCE_MANIFEST_SELF_HASH.json",
+      "invariant": "freeze evidence manifest cannot drift structurally without fresh governed artefact recomputation",
+      "proof_type": "verifier_report"
+    },
+    {
+      "slice_id": "P120",
+      "proof_surface": "docs/releases/V1_OPERATOR_FREEZE_BUNDLE_SURFACE_COMPLETENESS.json",
+      "invariant": "handoff bundle must be minimal and sufficient",
+      "proof_type": "verifier_report"
+    },
+    {
+      "slice_id": "P121",
+      "proof_surface": "docs/releases/V1_FREEZE_COMMAND_SEQUENCE_GATE.json",
+      "invariant": "freeze packaging and preservation checks must not run before freeze state + manifest integrity are established",
+      "proof_type": "verifier_report"
+    },
+    {
+      "slice_id": "P122",
+      "proof_surface": "docs/releases/V1_FREEZE_MAINLINE_ENTRY_GUARD.json",
+      "invariant": "sealed freeze surfaces cannot change silently on mainline",
+      "proof_type": "verifier_report"
+    },
+    {
+      "slice_id": "P123",
+      "proof_surface": "docs/releases/V1_FREEZE_DRIFT_REPORT.json",
+      "invariant": "freeze state must be inspectable from one bounded report",
+      "proof_type": "aggregate_report"
+    },
+    {
+      "slice_id": "P124",
+      "proof_surface": "docs/releases/V1_FREEZE_EXIT_CRITERIA.json",
+      "invariant": "freeze cannot be declared complete while any freeze-proof surface is absent or failing",
+      "proof_type": "verifier_report"
+    },
+    {
+      "slice_id": "P125",
+      "proof_surface": "docs/releases/V1_PROMOTION_READINESS.json",
+      "invariant": "promotion readiness must depend on completed freeze proof chain",
+      "proof_type": "readiness_report"
+    },
+    {
+      "slice_id": "P126",
+      "proof_surface": "docs/releases/V1_FREEZE_PACK_REBUILD_CLEANLINESS.json",
+      "invariant": "standard freeze build path must leave clean working tree",
+      "proof_type": "verifier_report"
+    }
+  ],
+  "freeze_proof_reports": [
+    {
+      "path": "docs/releases/V1_FREEZE_ARTEFACT_SET.json"
+    },
+    {
+      "path": "docs/releases/V1_FREEZE_DRIFT_EVIDENCE.json"
+    },
+    {
+      "path": "docs/releases/V1_FREEZE_DRIFT_SINCE_MERGE_BASE.json"
+    },
+    {
+      "path": "docs/releases/V1_FREEZE_EVIDENCE_MANIFEST.json"
+    },
+    {
+      "path": "docs/releases/V1_FREEZE_PACKAGING_ARTEFACT_SET.json"
+    },
+    {
+      "path": "docs/releases/V1_FREEZE_READINESS.json"
+    },
+    {
+      "path": "docs/releases/V1_FREEZE_STATE.json"
+    }
+  ],
+  "freeze_proof_chain": [
+    {
+      "path": "docs/releases/V1_FREEZE_STATE.json",
+      "upstream_paths": []
+    },
+    {
+      "path": "docs/releases/V1_FREEZE_COMMAND_SEQUENCE_GATE.json",
+      "upstream_paths": [
+        "docs/releases/V1_FREEZE_STATE.json"
+      ]
+    },
+    {
+      "path": "docs/releases/V1_FREEZE_READINESS.json",
+      "upstream_paths": [
+        "docs/releases/V1_FREEZE_STATE.json",
+        "docs/releases/V1_FREEZE_COMMAND_SEQUENCE_GATE.json"
+      ]
+    },
+    {
+      "path": "docs/releases/V1_FREEZE_EXIT_CRITERIA.json",
+      "upstream_paths": [
+        "docs/releases/V1_FREEZE_READINESS.json"
+      ]
+    },
+    {
+      "path": "docs/releases/V1_FREEZE_DRIFT_REPORT.json",
+      "upstream_paths": [
+        "docs/releases/V1_FREEZE_STATE.json"
+      ]
+    },
+    {
+      "path": "docs/releases/V1_FREEZE_DRIFT_SINCE_MERGE_BASE.json",
+      "upstream_paths": [
+        "docs/releases/V1_FREEZE_DRIFT_REPORT.json"
+      ]
+    },
+    {
+      "path": "docs/releases/V1_FREEZE_DRIFT_EVIDENCE.json",
+      "upstream_paths": [
+        "docs/releases/V1_FREEZE_DRIFT_SINCE_MERGE_BASE.json"
+      ]
+    },
+    {
+      "path": "docs/releases/V1_FREEZE_PACKAGING_ARTEFACT_SET.json",
+      "upstream_paths": [
+        "docs/releases/V1_FREEZE_EXIT_CRITERIA.json"
+      ]
+    },
+    {
+      "path": "docs/releases/V1_FREEZE_ARTEFACT_SET.json",
+      "upstream_paths": [
+        "docs/releases/V1_FREEZE_PACKAGING_ARTEFACT_SET.json"
+      ]
+    },
+    {
+      "path": "docs/releases/V1_FREEZE_MAINLINE_ENTRY_GUARD.json",
+      "upstream_paths": [
+        "docs/releases/V1_FREEZE_EXIT_CRITERIA.json"
+      ]
+    },
+    {
+      "path": "docs/releases/V1_FREEZE_PACK_REBUILD_CLEANLINESS.json",
+      "upstream_paths": [
+        "docs/releases/V1_FREEZE_PACKAGING_ARTEFACT_SET.json"
+      ]
+    },
+    {
+      "path": "docs/releases/V1_FREEZE_EVIDENCE_MANIFEST.json",
+      "upstream_paths": [
+        "docs/releases/V1_FREEZE_READINESS.json",
+        "docs/releases/V1_FREEZE_DRIFT_EVIDENCE.json",
+        "docs/releases/V1_FREEZE_ARTEFACT_SET.json"
+      ]
+    },
+    {
+      "path": "docs/releases/V1_FREEZE_EVIDENCE_MANIFEST_COMPLETENESS.json",
+      "upstream_paths": [
+        "docs/releases/V1_FREEZE_EVIDENCE_MANIFEST.json"
+      ]
+    },
+    {
+      "path": "docs/releases/V1_FREEZE_EVIDENCE_MANIFEST_SELF_HASH.json",
+      "upstream_paths": [
+        "docs/releases/V1_FREEZE_EVIDENCE_MANIFEST.json"
+      ]
+    },
+    {
+      "path": "docs/releases/V1_FREEZE_ROLLBACK_COMPATIBILITY.json",
+      "upstream_paths": [
+        "docs/releases/V1_FREEZE_EVIDENCE_MANIFEST.json"
+      ]
+    }
+  ]
 }

--- a/docs/releases/V1_PACKAGING_SURFACE_REGISTRY.json
+++ b/docs/releases/V1_PACKAGING_SURFACE_REGISTRY.json
@@ -67,6 +67,7 @@
                      "docs/releases/V1_ROLLBACK.md",
                      "docs/releases/V1_ROLLBACK_RUNBOOK.md",
                      "docs/releases/V1_VERSION_AND_TAG.md",
-                     "docs/releases/V1_FREEZE_PROOF_INDEX_COMPLETENESS.json"
+                     "docs/releases/V1_FREEZE_PROOF_INDEX_COMPLETENESS.json",
+                     "docs/releases/V1_FREEZE_PROOF_CHAIN_ORDER.json"
                  ]
 }

--- a/test/freeze_proof_chain_order_verifier.test.mjs
+++ b/test/freeze_proof_chain_order_verifier.test.mjs
@@ -1,0 +1,170 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+
+function writeJson(filePath, value) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, JSON.stringify(value, null, 2) + "\n", "utf8");
+}
+
+function setupRepoFixture() {
+  const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), "freeze-proof-chain-order-"));
+  fs.mkdirSync(path.join(repoRoot, "ci", "scripts"), { recursive: true });
+  fs.mkdirSync(path.join(repoRoot, "docs", "releases"), { recursive: true });
+  fs.mkdirSync(path.join(repoRoot, "test"), { recursive: true });
+
+  const verifierSourcePath = path.resolve(
+    "ci/scripts/run_freeze_proof_chain_order_verifier.mjs",
+  );
+  const verifierDestPath = path.join(
+    repoRoot,
+    "ci",
+    "scripts",
+    "run_freeze_proof_chain_order_verifier.mjs",
+  );
+  fs.copyFileSync(verifierSourcePath, verifierDestPath);
+
+  return { repoRoot, verifierDestPath };
+}
+
+test("freeze proof chain order verifier passes for a lawful dependency chain", () => {
+  const { repoRoot, verifierDestPath } = setupRepoFixture();
+
+  writeJson(path.join(repoRoot, "docs", "releases", "V1_FREEZE_PROOF_INDEX.json"), {
+    freeze_proof_chain: [
+      {
+        path: "docs/releases/V1_FREEZE_STATE.json",
+        upstream_paths: [],
+      },
+      {
+        path: "docs/releases/V1_FREEZE_READINESS.json",
+        upstream_paths: ["docs/releases/V1_FREEZE_STATE.json"],
+      },
+      {
+        path: "docs/releases/V1_FREEZE_EVIDENCE_MANIFEST.json",
+        upstream_paths: ["docs/releases/V1_FREEZE_READINESS.json"],
+      },
+    ],
+  });
+
+  writeJson(path.join(repoRoot, "docs", "releases", "V1_FREEZE_STATE.json"), { ok: true });
+  writeJson(path.join(repoRoot, "docs", "releases", "V1_FREEZE_READINESS.json"), { ok: true });
+  writeJson(path.join(repoRoot, "docs", "releases", "V1_FREEZE_EVIDENCE_MANIFEST.json"), { ok: true });
+
+  const result = spawnSync(process.execPath, [verifierDestPath], {
+    cwd: repoRoot,
+    encoding: "utf8",
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+
+  const outputPath = path.join(repoRoot, "docs", "releases", "V1_FREEZE_PROOF_CHAIN_ORDER.json");
+  const output = JSON.parse(fs.readFileSync(outputPath, "utf8"));
+
+  assert.equal(output.ok, true);
+  assert.deepEqual(output.orphan_proofs, []);
+  assert.deepEqual(output.missing_upstream_nodes, []);
+  assert.deepEqual(output.out_of_order_dependencies, []);
+});
+
+test("freeze proof chain order verifier fails on orphan proof", () => {
+  const { repoRoot, verifierDestPath } = setupRepoFixture();
+
+  writeJson(path.join(repoRoot, "docs", "releases", "V1_FREEZE_PROOF_INDEX.json"), {
+    freeze_proof_chain: [
+      {
+        path: "docs/releases/V1_FREEZE_STATE.json",
+        upstream_paths: [],
+      },
+      {
+        path: "docs/releases/V1_FREEZE_READINESS.json",
+        upstream_paths: [],
+      },
+    ],
+  });
+
+  writeJson(path.join(repoRoot, "docs", "releases", "V1_FREEZE_STATE.json"), { ok: true });
+  writeJson(path.join(repoRoot, "docs", "releases", "V1_FREEZE_READINESS.json"), { ok: true });
+
+  const result = spawnSync(process.execPath, [verifierDestPath], {
+    cwd: repoRoot,
+    encoding: "utf8",
+  });
+
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /orphan_proofs=docs\/releases\/V1_FREEZE_READINESS\.json/);
+
+  const outputPath = path.join(repoRoot, "docs", "releases", "V1_FREEZE_PROOF_CHAIN_ORDER.json");
+  const output = JSON.parse(fs.readFileSync(outputPath, "utf8"));
+  assert.equal(output.ok, false);
+  assert.deepEqual(output.orphan_proofs, ["docs/releases/V1_FREEZE_READINESS.json"]);
+});
+
+test("freeze proof chain order verifier fails on out-of-order dependency", () => {
+  const { repoRoot, verifierDestPath } = setupRepoFixture();
+
+  writeJson(path.join(repoRoot, "docs", "releases", "V1_FREEZE_PROOF_INDEX.json"), {
+    freeze_proof_chain: [
+      {
+        path: "docs/releases/V1_FREEZE_READINESS.json",
+        upstream_paths: ["docs/releases/V1_FREEZE_STATE.json"],
+      },
+      {
+        path: "docs/releases/V1_FREEZE_STATE.json",
+        upstream_paths: [],
+      },
+    ],
+  });
+
+  writeJson(path.join(repoRoot, "docs", "releases", "V1_FREEZE_STATE.json"), { ok: true });
+  writeJson(path.join(repoRoot, "docs", "releases", "V1_FREEZE_READINESS.json"), { ok: true });
+
+  const result = spawnSync(process.execPath, [verifierDestPath], {
+    cwd: repoRoot,
+    encoding: "utf8",
+  });
+
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /out_of_order_dependencies=docs\/releases\/V1_FREEZE_READINESS\.json->docs\/releases\/V1_FREEZE_STATE\.json/);
+
+  const outputPath = path.join(repoRoot, "docs", "releases", "V1_FREEZE_PROOF_CHAIN_ORDER.json");
+  const output = JSON.parse(fs.readFileSync(outputPath, "utf8"));
+  assert.equal(output.ok, false);
+  assert.equal(output.out_of_order_dependencies.length, 1);
+});
+
+test("freeze proof chain order verifier fails on missing upstream proof node", () => {
+  const { repoRoot, verifierDestPath } = setupRepoFixture();
+
+  writeJson(path.join(repoRoot, "docs", "releases", "V1_FREEZE_PROOF_INDEX.json"), {
+    freeze_proof_chain: [
+      {
+        path: "docs/releases/V1_FREEZE_STATE.json",
+        upstream_paths: [],
+      },
+      {
+        path: "docs/releases/V1_FREEZE_READINESS.json",
+        upstream_paths: ["docs/releases/V1_FREEZE_MISSING.json"],
+      },
+    ],
+  });
+
+  writeJson(path.join(repoRoot, "docs", "releases", "V1_FREEZE_STATE.json"), { ok: true });
+  writeJson(path.join(repoRoot, "docs", "releases", "V1_FREEZE_READINESS.json"), { ok: true });
+
+  const result = spawnSync(process.execPath, [verifierDestPath], {
+    cwd: repoRoot,
+    encoding: "utf8",
+  });
+
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /missing_upstream_nodes=docs\/releases\/V1_FREEZE_READINESS\.json->docs\/releases\/V1_FREEZE_MISSING\.json/);
+
+  const outputPath = path.join(repoRoot, "docs", "releases", "V1_FREEZE_PROOF_CHAIN_ORDER.json");
+  const output = JSON.parse(fs.readFileSync(outputPath, "utf8"));
+  assert.equal(output.ok, false);
+  assert.equal(output.missing_upstream_nodes.length, 1);
+});


### PR DESCRIPTION
## Summary
- add freeze proof chain order verifier
- bind explicit upstream proof dependencies into the freeze proof index
- emit freeze proof chain order artefact
- cover orphan, missing-upstream, and out-of-order failure modes with tests

## Proof
- build:fast passed
- test:affected passed
- freeze proof chain order verifier passed
- packaging surface registry guard passed