### PR TITLE
P156: lock neutral session summary API surface

### DIFF
--- a/docs/contracts/v1_neutral_session_summary_api_contract.md
+++ b/docs/contracts/v1_neutral_session_summary_api_contract.md
@@ -1,0 +1,144 @@
+# V1 Neutral Session Summary API Contract
+
+Document ID: v1_neutral_session_summary_api_contract
+Status: Draft for enforcement
+Scope: v0 active boundary only
+Audience: API / UI / CI / tests
+
+## Purpose
+
+Expose exactly one stable, factual, deterministic single-session summary surface for UI and demo use.
+
+This surface is:
+
+- single-session only
+- derived from recorded session/runtime events only
+- factual
+- deterministic
+- no-inference
+- no-advice
+- closed to extra semantic fields
+
+## Route
+
+`GET /sessions/:sessionId/summary`
+
+## Response contract
+
+```json
+{
+  "session_id": "string",
+  "run_id": "string",
+  "status": "ready | in_progress | partial | completed",
+  "prescribed_items_total": 0,
+  "prescribed_items_completed": 0,
+  "prescribed_items_skipped": 0,
+  "prescribed_items_remaining": 0,
+  "extra_work_event_count": 0,
+  "split_event_count": 0,
+  "return_continue_count": 0,
+  "return_skip_count": 0,
+  "runtime_event_count": 0,
+  "started_at_utc": null,
+  "completed_at_utc": null
+}
+```
+
+## Allowed fields (closed set)
+
+- `session_id`
+- `run_id`
+- `status`
+- `prescribed_items_total`
+- `prescribed_items_completed`
+- `prescribed_items_skipped`
+- `prescribed_items_remaining`
+- `extra_work_event_count`
+- `split_event_count`
+- `return_continue_count`
+- `return_skip_count`
+- `runtime_event_count`
+- `started_at_utc`
+- `completed_at_utc`
+
+No other fields are permitted.
+
+## Banned semantic fields
+
+Any appearance of fields like the following is a contract violation:
+
+- `score`
+- `quality`
+- `adherence`
+- `compliance`
+- `performance`
+- `trend`
+- `insight`
+- `recommendation`
+- `next_action`
+- `warning`
+- `risk`
+- `readiness`
+- `fatigue`
+- `improvement`
+- `regression`
+- `summary_text`
+- `interpretation`
+- `reason`
+- `explanation`
+- `projected_*`
+- `estimated_*`
+
+## Determinism rules
+
+The summary must be:
+
+- derived only from session truth plus append-only runtime events
+- identical for identical underlying state
+- byte-stable after canonical JSON serialisation
+- independent of presentation flags, nd_mode, coach notes, payment state, or product flags
+
+## No-inference rules
+
+The summary must not:
+
+- rank
+- score
+- evaluate
+- explain
+- recommend
+- predict
+- infer readiness
+- infer adherence
+- infer quality
+- infer intent
+- infer performance
+
+## Status semantics
+
+Allowed values:
+
+- `ready`
+- `in_progress`
+- `partial`
+- `completed`
+
+No additional status values are permitted.
+
+## Derivation rules
+
+- `prescribed_items_total` = total prescribed executable work items in session truth
+- `prescribed_items_completed` = count of prescribed work items completed in runtime truth
+- `prescribed_items_skipped` = count of prescribed work items skipped or dropped in runtime truth
+- `prescribed_items_remaining` = `prescribed_items_total - prescribed_items_completed - prescribed_items_skipped`
+- `extra_work_event_count` = count of extra-work runtime events only
+- `split_event_count` = count of session split events only
+- `return_continue_count` = count of return-continue decisions only
+- `return_skip_count` = count of return-skip decisions only
+- `runtime_event_count` = total count of accepted runtime events
+- `started_at_utc` = first runtime timestamp that lawfully marks session start, else `null`
+- `completed_at_utc` = terminal completion timestamp if completed, else `null`
+
+## Final rule
+
+If a desired UI field cannot be derived mechanically from existing session truth and runtime events, it does not belong in this API.

--- a/src/api/session_summary_read_model.ts
+++ b/src/api/session_summary_read_model.ts
@@ -1,0 +1,192 @@
+export type NeutralSessionSummaryStatus =
+  | "ready"
+  | "in_progress"
+  | "partial"
+  | "completed";
+
+export type NeutralSessionSummary = {
+  session_id: string;
+  run_id: string;
+  status: NeutralSessionSummaryStatus;
+  prescribed_items_total: number;
+  prescribed_items_completed: number;
+  prescribed_items_skipped: number;
+  prescribed_items_remaining: number;
+  extra_work_event_count: number;
+  split_event_count: number;
+  return_continue_count: number;
+  return_skip_count: number;
+  runtime_event_count: number;
+  started_at_utc: string | null;
+  completed_at_utc: string | null;
+};
+
+type RuntimeEventLike = {
+  event_type?: string;
+  timestamp_utc?: string | null;
+  at_utc?: string | null;
+  occurred_at_utc?: string | null;
+};
+
+type SessionStateLike = {
+  session_id: string;
+  run_id: string;
+  execution_status?: string;
+  trace?: {
+    remaining_ids?: string[];
+    completed_ids?: string[];
+    dropped_ids?: string[];
+    event_count?: number;
+  };
+  planned_work_item_ids?: string[];
+  work_item_ids?: string[];
+  started_at_utc?: string | null;
+  completed_at_utc?: string | null;
+};
+
+const ALLOWED_KEYS = [
+  "session_id",
+  "run_id",
+  "status",
+  "prescribed_items_total",
+  "prescribed_items_completed",
+  "prescribed_items_skipped",
+  "prescribed_items_remaining",
+  "extra_work_event_count",
+  "split_event_count",
+  "return_continue_count",
+  "return_skip_count",
+  "runtime_event_count",
+  "started_at_utc",
+  "completed_at_utc",
+] as const;
+
+const BANNED_SEMANTIC_KEYS = [
+  "score",
+  "quality",
+  "adherence",
+  "compliance",
+  "performance",
+  "trend",
+  "insight",
+  "recommendation",
+  "next_action",
+  "warning",
+  "risk",
+  "readiness",
+  "fatigue",
+  "improvement",
+  "regression",
+  "summary_text",
+  "interpretation",
+  "reason",
+  "explanation",
+] as const;
+
+function toArray(value: unknown): string[] {
+  return Array.isArray(value) ? value.filter((x): x is string => typeof x === "string") : [];
+}
+
+function firstTimestamp(events: RuntimeEventLike[]): string | null {
+  for (const event of events) {
+    const ts = event.timestamp_utc ?? event.at_utc ?? event.occurred_at_utc ?? null;
+    if (typeof ts === "string" && ts.length > 0) {
+      return ts;
+    }
+  }
+  return null;
+}
+
+function deriveStatus(raw: unknown): NeutralSessionSummaryStatus {
+  if (raw === "completed") return "completed";
+  if (raw === "partial") return "partial";
+  if (raw === "in_progress") return "in_progress";
+  return "ready";
+}
+
+function countEvents(events: RuntimeEventLike[], acceptedTypes: ReadonlySet<string>): number {
+  let count = 0;
+  for (const event of events) {
+    const eventType = typeof event.event_type === "string" ? event.event_type : "";
+    if (acceptedTypes.has(eventType)) {
+      count += 1;
+    }
+  }
+  return count;
+}
+
+function enforceContractShape(summary: NeutralSessionSummary): NeutralSessionSummary {
+  const summaryKeys = Object.keys(summary).sort();
+  const allowedKeys = [...ALLOWED_KEYS].sort();
+
+  if (summaryKeys.length !== allowedKeys.length) {
+    throw new Error("neutral_session_summary_contract_key_count_mismatch");
+  }
+
+  for (let i = 0; i < allowedKeys.length; i += 1) {
+    if (summaryKeys[i] !== allowedKeys[i]) {
+      throw new Error(`neutral_session_summary_contract_key_mismatch:${summaryKeys[i] ?? "missing"}:${allowedKeys[i]}`);
+    }
+  }
+
+  for (const banned of BANNED_SEMANTIC_KEYS) {
+    if (Object.prototype.hasOwnProperty.call(summary, banned)) {
+      throw new Error(`neutral_session_summary_banned_semantic_key:${banned}`);
+    }
+  }
+
+  return summary;
+}
+
+export function getNeutralSessionSummaryAllowedKeys(): readonly string[] {
+  return ALLOWED_KEYS;
+}
+
+export function getNeutralSessionSummaryBannedSemanticKeys(): readonly string[] {
+  return BANNED_SEMANTIC_KEYS;
+}
+
+export function buildNeutralSessionSummary(
+  sessionState: SessionStateLike,
+  runtimeEvents: RuntimeEventLike[],
+): NeutralSessionSummary {
+  const completedIds = toArray(sessionState.trace?.completed_ids);
+  const droppedIds = toArray(sessionState.trace?.dropped_ids);
+  const remainingIds = toArray(sessionState.trace?.remaining_ids);
+  const plannedIds = toArray(sessionState.planned_work_item_ids);
+  const workItemIds = toArray(sessionState.work_item_ids);
+
+  const prescribedItemsTotal =
+    plannedIds.length > 0
+      ? plannedIds.length
+      : workItemIds.length > 0
+        ? workItemIds.length
+        : completedIds.length + droppedIds.length + remainingIds.length;
+
+  const prescribedItemsCompleted = completedIds.length;
+  const prescribedItemsSkipped = droppedIds.length;
+  const prescribedItemsRemaining =
+    prescribedItemsTotal - prescribedItemsCompleted - prescribedItemsSkipped;
+
+  const summary: NeutralSessionSummary = {
+    session_id: sessionState.session_id,
+    run_id: sessionState.run_id,
+    status: deriveStatus(sessionState.execution_status),
+    prescribed_items_total: prescribedItemsTotal,
+    prescribed_items_completed: prescribedItemsCompleted,
+    prescribed_items_skipped: prescribedItemsSkipped,
+    prescribed_items_remaining: prescribedItemsRemaining < 0 ? 0 : prescribedItemsRemaining,
+    extra_work_event_count: countEvents(runtimeEvents, new Set(["EXTRA_WORK", "ADD_EXTRA_WORK", "EXTRA_WORK_RECORDED"])),
+    split_event_count: countEvents(runtimeEvents, new Set(["SPLIT_SESSION"])),
+    return_continue_count: countEvents(runtimeEvents, new Set(["RETURN_CONTINUE"])),
+    return_skip_count: countEvents(runtimeEvents, new Set(["RETURN_SKIP"])),
+    runtime_event_count:
+      typeof sessionState.trace?.event_count === "number"
+        ? sessionState.trace.event_count
+        : runtimeEvents.length,
+    started_at_utc: sessionState.started_at_utc ?? firstTimestamp(runtimeEvents) ?? null,
+    completed_at_utc: sessionState.completed_at_utc ?? null,
+  };
+
+  return enforceContractShape(summary);
+}

--- a/src/api/sessions.summary.handlers.ts
+++ b/src/api/sessions.summary.handlers.ts
@@ -1,0 +1,67 @@
+import { buildNeutralSessionSummary } from "./session_summary_read_model";
+
+type RuntimeEventLike = {
+  event_type?: string;
+  timestamp_utc?: string | null;
+  at_utc?: string | null;
+  occurred_at_utc?: string | null;
+};
+
+type SessionStateLike = {
+  session_id: string;
+  run_id: string;
+  execution_status?: string;
+  trace?: {
+    remaining_ids?: string[];
+    completed_ids?: string[];
+    dropped_ids?: string[];
+    event_count?: number;
+  };
+  planned_work_item_ids?: string[];
+  work_item_ids?: string[];
+  started_at_utc?: string | null;
+  completed_at_utc?: string | null;
+};
+
+type SessionStateStore = {
+  getSessionStateBySessionId(sessionId: string): Promise<SessionStateLike | null>;
+};
+
+type SessionEventsStore = {
+  listRuntimeEventsBySessionId(sessionId: string): Promise<RuntimeEventLike[]>;
+};
+
+type ReqLike = {
+  params?: Record<string, string | undefined>;
+};
+
+type ResLike = {
+  status(code: number): ResLike;
+  json(payload: unknown): void;
+};
+
+export function createGetNeutralSessionSummaryHandler(deps: {
+  sessionStateStore: SessionStateStore;
+  sessionEventsStore: SessionEventsStore;
+}) {
+  return async function getNeutralSessionSummary(req: ReqLike, res: ResLike): Promise<void> {
+    const sessionId = req.params?.sessionId;
+
+    if (!sessionId) {
+      res.status(400).json({ error: "missing_session_id" });
+      return;
+    }
+
+    const sessionState = await deps.sessionStateStore.getSessionStateBySessionId(sessionId);
+
+    if (!sessionState) {
+      res.status(404).json({ error: "session_not_found" });
+      return;
+    }
+
+    const runtimeEvents = await deps.sessionEventsStore.listRuntimeEventsBySessionId(sessionId);
+    const summary = buildNeutralSessionSummary(sessionState, runtimeEvents);
+
+    res.status(200).json(summary);
+  };
+}

--- a/test/session_summary_read_model.test.mjs
+++ b/test/session_summary_read_model.test.mjs
@@ -1,0 +1,143 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+const mod = await import("../src/api/session_summary_read_model.ts");
+const {
+  buildNeutralSessionSummary,
+  getNeutralSessionSummaryAllowedKeys,
+  getNeutralSessionSummaryBannedSemanticKeys,
+} = mod;
+
+test("buildNeutralSessionSummary derives a factual deterministic single-session summary", () => {
+  const sessionState = {
+    session_id: "session_001",
+    run_id: "run_001",
+    execution_status: "partial",
+    trace: {
+      completed_ids: ["w1", "w2"],
+      dropped_ids: ["w3"],
+      remaining_ids: ["w4"],
+      event_count: 6,
+    },
+    planned_work_item_ids: ["w1", "w2", "w3", "w4"],
+  };
+
+  const runtimeEvents = [
+    { event_type: "START_SESSION", timestamp_utc: "2026-04-04T12:00:00Z" },
+    { event_type: "EXTRA_WORK", timestamp_utc: "2026-04-04T12:10:00Z" },
+    { event_type: "SPLIT_SESSION", timestamp_utc: "2026-04-04T12:15:00Z" },
+    { event_type: "RETURN_CONTINUE", timestamp_utc: "2026-04-04T12:20:00Z" },
+    { event_type: "RETURN_SKIP", timestamp_utc: "2026-04-04T12:25:00Z" },
+    { event_type: "EXTRA_WORK_RECORDED", timestamp_utc: "2026-04-04T12:30:00Z" },
+  ];
+
+  const actual = buildNeutralSessionSummary(sessionState, runtimeEvents);
+
+  assert.deepEqual(actual, {
+    session_id: "session_001",
+    run_id: "run_001",
+    status: "partial",
+    prescribed_items_total: 4,
+    prescribed_items_completed: 2,
+    prescribed_items_skipped: 1,
+    prescribed_items_remaining: 1,
+    extra_work_event_count: 2,
+    split_event_count: 1,
+    return_continue_count: 1,
+    return_skip_count: 1,
+    runtime_event_count: 6,
+    started_at_utc: "2026-04-04T12:00:00Z",
+    completed_at_utc: null,
+  });
+});
+
+test("buildNeutralSessionSummary is stable for identical inputs", () => {
+  const sessionState = {
+    session_id: "session_002",
+    run_id: "run_002",
+    execution_status: "completed",
+    trace: {
+      completed_ids: ["a", "b"],
+      dropped_ids: [],
+      remaining_ids: [],
+      event_count: 2,
+    },
+    planned_work_item_ids: ["a", "b"],
+    completed_at_utc: "2026-04-04T12:45:00Z",
+  };
+
+  const runtimeEvents = [
+    { event_type: "START_SESSION", timestamp_utc: "2026-04-04T12:00:00Z" },
+    { event_type: "COMPLETE_SESSION", timestamp_utc: "2026-04-04T12:45:00Z" },
+  ];
+
+  const first = buildNeutralSessionSummary(sessionState, runtimeEvents);
+  const second = buildNeutralSessionSummary(sessionState, runtimeEvents);
+
+  assert.equal(JSON.stringify(first), JSON.stringify(second));
+});
+
+test("Neutral session summary allowed keys are exact and pinned", () => {
+  assert.deepEqual(getNeutralSessionSummaryAllowedKeys(), [
+    "session_id",
+    "run_id",
+    "status",
+    "prescribed_items_total",
+    "prescribed_items_completed",
+    "prescribed_items_skipped",
+    "prescribed_items_remaining",
+    "extra_work_event_count",
+    "split_event_count",
+    "return_continue_count",
+    "return_skip_count",
+    "runtime_event_count",
+    "started_at_utc",
+    "completed_at_utc",
+  ]);
+});
+
+test("Neutral session summary banned semantic keys are pinned", () => {
+  assert.deepEqual(getNeutralSessionSummaryBannedSemanticKeys(), [
+    "score",
+    "quality",
+    "adherence",
+    "compliance",
+    "performance",
+    "trend",
+    "insight",
+    "recommendation",
+    "next_action",
+    "warning",
+    "risk",
+    "readiness",
+    "fatigue",
+    "improvement",
+    "regression",
+    "summary_text",
+    "interpretation",
+    "reason",
+    "explanation",
+  ]);
+});
+
+test("Neutral session summary shape rejects extra semantic fields", () => {
+  const sessionState = {
+    session_id: "session_003",
+    run_id: "run_003",
+    execution_status: "ready",
+    trace: {
+      completed_ids: [],
+      dropped_ids: [],
+      remaining_ids: [],
+      event_count: 0,
+    },
+    planned_work_item_ids: [],
+  };
+
+  const runtimeEvents = [];
+  const summary = buildNeutralSessionSummary(sessionState, runtimeEvents);
+
+  for (const key of getNeutralSessionSummaryBannedSemanticKeys()) {
+    assert.equal(Object.prototype.hasOwnProperty.call(summary, key), false);
+  }
+});

--- a/test/sessions.summary.route.test.mjs
+++ b/test/sessions.summary.route.test.mjs
@@ -1,0 +1,123 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+const mod = await import("../src/api/sessions.summary.handlers.ts");
+const { createGetNeutralSessionSummaryHandler } = mod;
+
+function createResCapture() {
+  const state = {
+    statusCode: 200,
+    payload: undefined,
+  };
+
+  return {
+    state,
+    res: {
+      status(code) {
+        state.statusCode = code;
+        return this;
+      },
+      json(payload) {
+        state.payload = payload;
+      },
+    },
+  };
+}
+
+test("GET neutral session summary returns the exact pinned factual DTO", async () => {
+  const handler = createGetNeutralSessionSummaryHandler({
+    sessionStateStore: {
+      async getSessionStateBySessionId(sessionId) {
+        assert.equal(sessionId, "session_100");
+        return {
+          session_id: "session_100",
+          run_id: "run_100",
+          execution_status: "in_progress",
+          trace: {
+            completed_ids: ["x1"],
+            dropped_ids: [],
+            remaining_ids: ["x2"],
+            event_count: 3,
+          },
+          planned_work_item_ids: ["x1", "x2"],
+        };
+      },
+    },
+    sessionEventsStore: {
+      async listRuntimeEventsBySessionId(sessionId) {
+        assert.equal(sessionId, "session_100");
+        return [
+          { event_type: "START_SESSION", timestamp_utc: "2026-04-04T12:00:00Z" },
+          { event_type: "EXTRA_WORK", timestamp_utc: "2026-04-04T12:05:00Z" },
+          { event_type: "RETURN_CONTINUE", timestamp_utc: "2026-04-04T12:10:00Z" },
+        ];
+      },
+    },
+  });
+
+  const { state, res } = createResCapture();
+
+  await handler({ params: { sessionId: "session_100" } }, res);
+
+  assert.equal(state.statusCode, 200);
+  assert.deepEqual(state.payload, {
+    session_id: "session_100",
+    run_id: "run_100",
+    status: "in_progress",
+    prescribed_items_total: 2,
+    prescribed_items_completed: 1,
+    prescribed_items_skipped: 0,
+    prescribed_items_remaining: 1,
+    extra_work_event_count: 1,
+    split_event_count: 0,
+    return_continue_count: 1,
+    return_skip_count: 0,
+    runtime_event_count: 3,
+    started_at_utc: "2026-04-04T12:00:00Z",
+    completed_at_utc: null,
+  });
+});
+
+test("GET neutral session summary returns 404 when session does not exist", async () => {
+  const handler = createGetNeutralSessionSummaryHandler({
+    sessionStateStore: {
+      async getSessionStateBySessionId() {
+        return null;
+      },
+    },
+    sessionEventsStore: {
+      async listRuntimeEventsBySessionId() {
+        return [];
+      },
+    },
+  });
+
+  const { state, res } = createResCapture();
+
+  await handler({ params: { sessionId: "missing_session" } }, res);
+
+  assert.equal(state.statusCode, 404);
+  assert.deepEqual(state.payload, { error: "session_not_found" });
+});
+
+test("GET neutral session summary returns 400 when sessionId is missing", async () => {
+  const handler = createGetNeutralSessionSummaryHandler({
+    sessionStateStore: {
+      async getSessionStateBySessionId() {
+        return null;
+      },
+    },
+    sessionEventsStore: {
+      async listRuntimeEventsBySessionId() {
+        return [];
+      },
+    },
+  });
+
+  const { state, res } = createResCapture();
+
+  await handler({ params: {} }, res);
+
+  assert.equal(state.statusCode, 400);
+  assert.deepEqual(state.payload, { error: "missing_session_id" });
+});


### PR DESCRIPTION
## Summary
- add neutral single-session summary API contract
- add pinned factual read-model for UI/demo use
- add route handler and route tests
- fail semantic drift by exact-key contract coverage

## Proof
- npm run build:fast
- node --test test/session_summary_read_model.test.mjs test/sessions.summary.route.test.mjs