### PR TITLE
P158: add minimal onboarding completion proof

### DIFF
--- a/docs/v1/V1_MINIMAL_ONBOARDING_COMPLETION_PROOF.md
+++ b/docs/v1/V1_MINIMAL_ONBOARDING_COMPLETION_PROOF.md
@@ -1,0 +1,52 @@
+# V1 Minimal Onboarding Completion Proof
+
+Document ID: v1_minimal_onboarding_completion_proof
+Status: Draft for enforcement
+Scope: active v0 onboarding only
+Audience: Product / UI / API / CI / review
+
+## Purpose
+
+Prove one lawful onboarding flow completes with the minimum required user burden for each active v0 onboarding entry mode.
+
+## Invariant
+
+- v0 onboarding stays narrow and executable
+- onboarding captures only fields required for legality or execution feasibility
+- no unused prompts, no pre-emptive downstream prompts, no extra fields
+
+## Accepted entry modes pinned
+
+- individual
+- coach_managed
+
+## Proof
+
+- one accepted declaration fixture for individual
+- one accepted declaration fixture for coach_managed
+- required-field count pinned per fixture
+- conditional authority field pinned for coach_managed only
+- extra prompts and extra fields fail
+
+## Minimal accepted declaration fields
+
+Pinned minimal individual fixture fields:
+- consent_granted
+- engine_version
+- enum_bundle_version
+- phase1_schema_version
+- actor_type
+- execution_scope
+- activity_id
+- location_type
+- nd_mode
+- instruction_density
+- exposure_prompt_density
+- bias_mode
+
+Pinned additional coach_managed fixture field:
+- governing_authority_id
+
+## Final rule
+
+If onboarding requires more than the pinned minimal accepted declaration fields for the relevant v0 entry mode without a lawful schema or contract change, the onboarding surface has drifted.

--- a/test/fixtures/onboarding/invalid_extra_field_v0.json
+++ b/test/fixtures/onboarding/invalid_extra_field_v0.json
@@ -1,0 +1,15 @@
+{
+    "consent_granted":  true,
+    "engine_version":  "EB2-1.0.0",
+    "enum_bundle_version":  "EB2-1.0.0",
+    "phase1_schema_version":  "1.0.0",
+    "actor_type":  "athlete",
+    "execution_scope":  "individual",
+    "activity_id":  "powerlifting",
+    "location_type":  "gym",
+    "nd_mode":  false,
+    "instruction_density":  "standard",
+    "exposure_prompt_density":  "minimal",
+    "bias_mode":  "neutral",
+    "readiness_prompt":  "how ready do you feel today"
+}

--- a/test/fixtures/onboarding/minimal_coach_managed_v0.json
+++ b/test/fixtures/onboarding/minimal_coach_managed_v0.json
@@ -1,0 +1,15 @@
+{
+    "consent_granted":  true,
+    "engine_version":  "EB2-1.0.0",
+    "enum_bundle_version":  "EB2-1.0.0",
+    "phase1_schema_version":  "1.0.0",
+    "actor_type":  "athlete",
+    "execution_scope":  "coach_managed",
+    "governing_authority_id":  "coach_001",
+    "activity_id":  "powerlifting",
+    "location_type":  "gym",
+    "nd_mode":  false,
+    "instruction_density":  "standard",
+    "exposure_prompt_density":  "minimal",
+    "bias_mode":  "neutral"
+}

--- a/test/fixtures/onboarding/minimal_individual_v0.json
+++ b/test/fixtures/onboarding/minimal_individual_v0.json
@@ -1,0 +1,14 @@
+{
+    "consent_granted":  true,
+    "engine_version":  "EB2-1.0.0",
+    "enum_bundle_version":  "EB2-1.0.0",
+    "phase1_schema_version":  "1.0.0",
+    "actor_type":  "athlete",
+    "execution_scope":  "individual",
+    "activity_id":  "powerlifting",
+    "location_type":  "gym",
+    "nd_mode":  false,
+    "instruction_density":  "standard",
+    "exposure_prompt_density":  "minimal",
+    "bias_mode":  "neutral"
+}

--- a/test/minimal_onboarding_completion_proof.test.mjs
+++ b/test/minimal_onboarding_completion_proof.test.mjs
@@ -1,0 +1,108 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+
+const repoRoot = process.cwd();
+
+function readJson(relPath) {
+  return JSON.parse(fs.readFileSync(path.join(repoRoot, relPath), "utf8"));
+}
+
+function sortedKeys(obj) {
+  return Object.keys(obj).sort();
+}
+
+function extraKeys(actual, allowed) {
+  const allowedSet = new Set(allowed);
+  return Object.keys(actual).filter((k) => !allowedSet.has(k)).sort();
+}
+
+const INDIVIDUAL_KEYS = [
+  "activity_id",
+  "actor_type",
+  "bias_mode",
+  "consent_granted",
+  "engine_version",
+  "enum_bundle_version",
+  "execution_scope",
+  "exposure_prompt_density",
+  "instruction_density",
+  "location_type",
+  "nd_mode",
+  "phase1_schema_version",
+].sort();
+
+const COACH_MANAGED_KEYS = [
+  "activity_id",
+  "actor_type",
+  "bias_mode",
+  "consent_granted",
+  "engine_version",
+  "enum_bundle_version",
+  "execution_scope",
+  "exposure_prompt_density",
+  "governing_authority_id",
+  "instruction_density",
+  "location_type",
+  "nd_mode",
+  "phase1_schema_version",
+].sort();
+
+const BLOATED_OR_EXTRA_PROMPT_PATTERNS = [
+  /readiness/i,
+  /fatigue/i,
+  /injury/i,
+  /risk/i,
+  /safety/i,
+  /benefit/i,
+  /performance/i,
+  /adherence/i,
+  /score/i,
+  /recommend/i,
+  /goal/i,
+];
+
+test("minimal individual onboarding fixture is pinned to the minimum required field set", () => {
+  const fixture = readJson("test/fixtures/onboarding/minimal_individual_v0.json");
+  assert.deepEqual(sortedKeys(fixture), INDIVIDUAL_KEYS);
+  assert.equal(Object.keys(fixture).length, 12);
+  assert.equal(fixture.execution_scope, "individual");
+  assert.equal("governing_authority_id" in fixture, false);
+});
+
+test("minimal coach_managed onboarding fixture is pinned to the minimum required field set", () => {
+  const fixture = readJson("test/fixtures/onboarding/minimal_coach_managed_v0.json");
+  assert.deepEqual(sortedKeys(fixture), COACH_MANAGED_KEYS);
+  assert.equal(Object.keys(fixture).length, 13);
+  assert.equal(fixture.execution_scope, "coach_managed");
+  assert.equal(typeof fixture.governing_authority_id, "string");
+  assert.ok(fixture.governing_authority_id.length > 0);
+});
+
+test("coach_managed adds exactly one extra authority field beyond minimal individual onboarding", () => {
+  const individual = readJson("test/fixtures/onboarding/minimal_individual_v0.json");
+  const coachManaged = readJson("test/fixtures/onboarding/minimal_coach_managed_v0.json");
+  const coachOnly = extraKeys(coachManaged, INDIVIDUAL_KEYS);
+  assert.deepEqual(coachOnly, ["governing_authority_id"]);
+  const individualOnly = extraKeys(individual, COACH_MANAGED_KEYS);
+  assert.deepEqual(individualOnly, []);
+});
+
+test("invalid extra onboarding field fixture fails the pinned field set", () => {
+  const invalid = readJson("test/fixtures/onboarding/invalid_extra_field_v0.json");
+  assert.deepEqual(extraKeys(invalid, INDIVIDUAL_KEYS), ["readiness_prompt"]);
+});
+
+test("minimal accepted onboarding fixtures contain no bloated or advisory prompt semantics", () => {
+  const fixtures = [
+    readJson("test/fixtures/onboarding/minimal_individual_v0.json"),
+    readJson("test/fixtures/onboarding/minimal_coach_managed_v0.json"),
+  ];
+  for (const fixture of fixtures) {
+    const payload = JSON.stringify(fixture);
+    for (const rx of BLOATED_OR_EXTRA_PROMPT_PATTERNS) {
+      assert.equal(rx.test(payload), false, `unexpected onboarding drift: ${rx}`);
+    }
+  }
+});


### PR DESCRIPTION
## Summary
- add minimal onboarding completion proof contract
- add pinned minimal individual and coach_managed onboarding fixtures
- add extra-field negative fixture
- add onboarding burden proof test

## Proof
- npm run build:fast
- node --test test/minimal_onboarding_completion_proof.test.mjs