### PR TITLE
P159: add declaration error UX contract

### DIFF
--- a/docs/v1/V1_DECLARATION_ERROR_UX_CONTRACT.md
+++ b/docs/v1/V1_DECLARATION_ERROR_UX_CONTRACT.md
@@ -1,0 +1,63 @@
+# V1 Declaration Error UX Contract
+
+Document ID: v1_declaration_error_ux_contract
+Status: Draft for enforcement
+Scope: active v0 declaration and onboarding error surfaces only
+Audience: Product / UI / API / CI / review
+
+## Purpose
+
+Define the exact v0 rendering contract for legal refusal and declaration-related technical failure without advisory language.
+
+## Invariant
+
+- legal refusal stays legal refusal
+- technical failure stays technical failure
+- rendering is token-driven and copy-registry-backed
+- no advisory, coaching, safety, or benefit language is permitted
+
+## Legal refusal surface
+
+Pinned output:
+- `Execution not permitted.`
+
+No additional reason, advice, warning, or benefit framing is permitted on the legal refusal surface.
+
+## Technical declaration failure surface
+
+Pinned rendering domain:
+- unknown_field
+- missing_required_field
+- type_mismatch
+- invalid_format
+- unknown_enum_value
+- explicit_null_law_violated
+- consent_not_granted
+- version_mismatch
+- invalid_actor_type
+- missing_governing_authority
+- invalid_activity_id
+- missing_sport_role
+- invalid_sport_role
+- role_generalisation_violation
+- invalid_location_type
+- invalid_equipment_profile
+- invalid_presentation_flag
+- invalid_movement_blacklist
+- role_goal_without_role
+- forbidden_primary_goal
+- missing_record_target
+
+## Prohibited wording
+
+- safe / safer / safety
+- suitable / appropriate / right for you
+- recommend / best / ideal
+- improve / optimize / fix / correct
+- protect / prevent / recover / rehab
+- readiness / fatigue / performance / adherence
+- you should / try again with / we suggest
+
+## Final rule
+
+If declaration error rendering implies advice, benefit, safety, or coaching meaning beyond the legal refusal string or the pinned technical token mapping, the error UX surface has drifted.

--- a/src/ui/copy/declaration_error_copy.ts
+++ b/src/ui/copy/declaration_error_copy.ts
@@ -1,0 +1,29 @@
+export const DECLARATION_ERROR_COPY = {
+  legal_refusal: "Execution not permitted.",
+  technical_failure_prefix: "Declaration error.",
+  token_copy: {
+    unknown_field: "Unknown field.",
+    missing_required_field: "Required field missing.",
+    type_mismatch: "Field type mismatch.",
+    invalid_format: "Invalid field format.",
+    unknown_enum_value: "Unknown enum value.",
+    explicit_null_law_violated: "Explicit null is not permitted here.",
+    consent_not_granted: "Consent not granted.",
+    version_mismatch: "Version mismatch.",
+    invalid_actor_type: "Actor type is invalid.",
+    missing_governing_authority: "Governing authority is required.",
+    invalid_activity_id: "Activity is invalid.",
+    missing_sport_role: "Sport role is required.",
+    invalid_sport_role: "Sport role is invalid.",
+    role_generalisation_violation: "Role declaration is invalid for this mode.",
+    invalid_location_type: "Location type is invalid.",
+    invalid_equipment_profile: "Equipment profile is invalid.",
+    invalid_presentation_flag: "Presentation flag is invalid.",
+    invalid_movement_blacklist: "Movement blacklist is invalid.",
+    role_goal_without_role: "Role-specific goal requires a role declaration.",
+    forbidden_primary_goal: "Primary goal is not permitted.",
+    missing_record_target: "Record target is required.",
+  },
+} as const;
+
+export type DeclarationTechnicalFailureToken = keyof typeof DECLARATION_ERROR_COPY.token_copy;

--- a/test/declaration_error_ux_contract.test.mjs
+++ b/test/declaration_error_ux_contract.test.mjs
@@ -1,0 +1,90 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+const mod = await import("../src/ui/copy/declaration_error_copy.ts");
+const { DECLARATION_ERROR_COPY } = mod;
+
+const EXPECTED_TOKENS = [
+  "consent_not_granted",
+  "explicit_null_law_violated",
+  "forbidden_primary_goal",
+  "invalid_activity_id",
+  "invalid_actor_type",
+  "invalid_equipment_profile",
+  "invalid_format",
+  "invalid_location_type",
+  "invalid_movement_blacklist",
+  "invalid_presentation_flag",
+  "invalid_sport_role",
+  "missing_governing_authority",
+  "missing_record_target",
+  "missing_required_field",
+  "missing_sport_role",
+  "role_generalisation_violation",
+  "role_goal_without_role",
+  "type_mismatch",
+  "unknown_enum_value",
+  "unknown_field",
+  "version_mismatch",
+].sort();
+
+const BANNED_REGEXES = [
+  /\bsafer?\b/i,
+  /\bsafety\b/i,
+  /\bsuitable\b/i,
+  /\bappropriate\b/i,
+  /\bright for you\b/i,
+  /\brecommend(?:ed|ation)?\b/i,
+  /\bbest\b/i,
+  /\bideal\b/i,
+  /\bimprov(?:e|ed|ement)\b/i,
+  /\boptim(?:ise|ize|ised|ized|isation|ization)\b/i,
+  /\bfix(?:ed|es)?\b/i,
+  /\bcorrect(?:ed|ion)?\b/i,
+  /\bprotect(?:ion)?\b/i,
+  /\bprevent(?:ion)?\b/i,
+  /\brecover(?:y)?\b/i,
+  /\brehab(?:ilitation)?\b/i,
+  /\breadiness\b/i,
+  /\bfatigue\b/i,
+  /\bperformance\b/i,
+  /\badherence\b/i,
+  /\byou should\b/i,
+  /\btry again with\b/i,
+  /\bwe suggest\b/i,
+];
+
+function assertNoBannedWording(label, value) {
+  for (const rx of BANNED_REGEXES) {
+    assert.equal(rx.test(value), false, `banned wording in ${label}: ${value}`);
+  }
+}
+
+test("legal refusal copy is pinned exactly", () => {
+  assert.equal(DECLARATION_ERROR_COPY.legal_refusal, "Execution not permitted.");
+});
+
+test("technical failure prefix is pinned and non-advisory", () => {
+  assert.equal(DECLARATION_ERROR_COPY.technical_failure_prefix, "Declaration error.");
+  assertNoBannedWording("technical_failure_prefix", DECLARATION_ERROR_COPY.technical_failure_prefix);
+});
+
+test("technical failure token mapping is pinned exactly", () => {
+  const actualTokens = Object.keys(DECLARATION_ERROR_COPY.token_copy).sort();
+  assert.deepEqual(actualTokens, EXPECTED_TOKENS);
+});
+
+test("all declaration error copy strings are short, technical, and banned-wording free", () => {
+  assertNoBannedWording("legal_refusal", DECLARATION_ERROR_COPY.legal_refusal);
+  for (const [token, value] of Object.entries(DECLARATION_ERROR_COPY.token_copy)) {
+    assert.equal(typeof value, "string");
+    assert.ok(value.length > 0);
+    assertNoBannedWording(token, value);
+  }
+});
+
+test("legal refusal and technical failure surfaces remain separate", () => {
+  for (const value of Object.values(DECLARATION_ERROR_COPY.token_copy)) {
+    assert.notEqual(value, DECLARATION_ERROR_COPY.legal_refusal);
+  }
+});


### PR DESCRIPTION
## Summary
- add declaration error UX contract doc
- add pinned legal refusal and technical failure copy mapping
- add token mapping and banned wording tests

## Proof
- npm run build:fast
- node --test test/declaration_error_ux_contract.test.mjs