### PR TITLE
P160: add export-nothing v0 guard

### DIFF
--- a/ci/locks/v0_export_nothing_scope.json
+++ b/ci/locks/v0_export_nothing_scope.json
@@ -1,0 +1,51 @@
+{
+    "schema_version":  "kolosseum.v0_export_nothing_scope.v1.0.0",
+    "generated_by":  "ticket/p160-export-nothing-v0-guard",
+    "runtime_roots":  [
+                          "app",
+                          "src/api",
+                          "src/ui",
+                          "src/web"
+                      ],
+    "excluded_path_patterns":  [
+                                   "(^|/|\\\\)dist(/|\\\\|$)",
+                                   "(^|/|\\\\)build(/|\\\\|$)",
+                                   "(^|/|\\\\)coverage(/|\\\\|$)",
+                                   "(^|/|\\\\)node_modules(/|\\\\|$)",
+                                   "(^|/|\\\\)\\.next(/|\\\\|$)",
+                                   "(^|/|\\\\)test(/|\\\\|$)",
+                                   "(^|/|\\\\)tests(/|\\\\|$)",
+                                   "(^|/|\\\\)__tests__(/|\\\\|$)",
+                                   "(^|/|\\\\)fixtures(/|\\\\|$)",
+                                   "(^|/|\\\\)snapshots(/|\\\\|$)"
+                               ],
+    "forbidden_filename_regexes":  [
+                                       "(^|[\\\\/])(export|exports)([._-]|[\\\\/]|$)",
+                                       "(^|[\\\\/])evidence([._-]|[\\\\/]|$)",
+                                       "(^|[\\\\/])proof([._-]|[\\\\/]|$)",
+                                       "(^|[\\\\/])seal([._-]|[\\\\/]|$)",
+                                       "(^|[\\\\/])envelope([._-]|[\\\\/]|$)"
+                                   ],
+    "forbidden_content_regexes":  [
+                                      "[\"\u0027]/(?:api/)?export(?:s)?(?:/|[\"\u0027])",
+                                      "[\"\u0027]/(?:api/)?evidence(?:/|[\"\u0027])",
+                                      "[\"\u0027]/(?:api/)?proof(?:/|[\"\u0027])",
+                                      "[\"\u0027]/(?:api/)?seal(?:/|[\"\u0027])",
+                                      "[\"\u0027]/(?:api/)?envelope(?:/|[\"\u0027])",
+                                      "\\bdownloadEvidence\\b",
+                                      "\\bdownloadExport\\b",
+                                      "\\bexportEvidence\\b",
+                                      "\\bexportBundle\\b",
+                                      "\\bexportEnvelope\\b",
+                                      "\\bevidenceDownload\\b",
+                                      "\\bevidenceExport\\b",
+                                      "\\bevidenceSeal\\b",
+                                      "\\bevidenceEnvelope\\b",
+                                      "\\bshowExport\\b",
+                                      "\\bshowEvidence\\b",
+                                      "\\bopenExport\\b",
+                                      "\\bopenEvidence\\b",
+                                      "\\bExportButton\\b",
+                                      "\\bEvidenceButton\\b"
+                                  ]
+}

--- a/docs/v1/V1_EXPORT_NOTHING_V0_GUARD.md
+++ b/docs/v1/V1_EXPORT_NOTHING_V0_GUARD.md
@@ -1,0 +1,47 @@
+# V1 Export-Nothing v0 Guard
+
+Document ID: v1_export_nothing_v0_guard
+Status: Draft for enforcement
+Scope: active v0 runtime/demo boundary only
+Audience: Product / UI / API / CI / review
+
+## Purpose
+
+Explicitly prove v0 cannot leak proof-layer or export surfaces.
+
+## Invariant
+
+- v0 demo and sale boundary stays below v1 lawful proof or export scope
+- no export UI is reachable in v0
+- no evidence UI is reachable in v0
+- no proof-layer route is reachable in v0
+- no export-layer route is reachable in v0
+
+## Guard scope
+
+- runtime app surfaces only
+- reachable UI and API roots only
+- docs, tests, fixtures, dist, and non-runtime artefacts are excluded from reachability proof
+
+## Forbidden runtime surface classes
+
+- export route
+- exports route
+- evidence route
+- proof route
+- seal route
+- envelope route
+- export button or export action
+- evidence button or evidence action
+- download evidence action
+- download export action
+
+## Proof
+
+- guard verifies no export or evidence UI or route is reachable in v0
+- negative tests cover forbidden runtime surface markers
+- any accidental reachability fails
+
+## Final rule
+
+If a runtime v0 surface exposes export, evidence, proof, seal, or envelope entry points, the v0 boundary has drifted.

--- a/test/v0_export_nothing_guard.test.mjs
+++ b/test/v0_export_nothing_guard.test.mjs
@@ -1,0 +1,86 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+
+const repoRoot = process.cwd();
+
+function readJson(relPath) {
+  return JSON.parse(fs.readFileSync(path.join(repoRoot, relPath), "utf8"));
+}
+
+function walkFiles(rootDir) {
+  const results = [];
+  const stack = [rootDir];
+  while (stack.length > 0) {
+    const current = stack.pop();
+    if (!fs.existsSync(current)) continue;
+    const stat = fs.statSync(current);
+    if (stat.isDirectory()) {
+      for (const entry of fs.readdirSync(current)) {
+        stack.push(path.join(current, entry));
+      }
+      continue;
+    }
+    results.push(current);
+  }
+  return results;
+}
+
+function rel(fullPath) {
+  return path.relative(repoRoot, fullPath).replace(/\\/g, "/");
+}
+
+const scope = readJson("ci/locks/v0_export_nothing_scope.json");
+const excludedRegexes = scope.excluded_path_patterns.map((pattern) => new RegExp(pattern, "i"));
+const forbiddenContentRegexes = scope.forbidden_content_regexes.map((pattern) => new RegExp(pattern, "i"));
+
+function isExcluded(relPath) {
+  return excludedRegexes.some((rx) => rx.test(relPath));
+}
+
+function collectRuntimeFiles() {
+  const files = [];
+  for (const root of scope.runtime_roots) {
+    const absRoot = path.join(repoRoot, root);
+    if (!fs.existsSync(absRoot)) continue;
+    for (const fullPath of walkFiles(absRoot)) {
+      const relPath = rel(fullPath);
+      if (isExcluded(relPath)) continue;
+      if (!/\.(ts|tsx|js|jsx|mjs|cjs|json|html|css)$/i.test(relPath)) continue;
+      files.push(relPath);
+    }
+  }
+  return files.sort();
+}
+
+test("export-nothing scope file is pinned and non-empty", () => {
+  assert.equal(scope.schema_version, "kolosseum.v0_export_nothing_scope.v1.0.0");
+  assert.ok(Array.isArray(scope.runtime_roots));
+  assert.ok(scope.runtime_roots.length > 0);
+});
+
+test("runtime scan scope resolves to at least one runtime file", () => {
+  const runtimeFiles = collectRuntimeFiles();
+  assert.ok(runtimeFiles.length > 0, "runtime scan found no files; scope is too weak to prove reachability.");
+});
+
+test("no forbidden export or evidence route or UI markers are reachable in v0 runtime roots", () => {
+  const runtimeFiles = collectRuntimeFiles();
+  for (const relPath of runtimeFiles) {
+    const text = fs.readFileSync(path.join(repoRoot, relPath), "utf8");
+    for (const rx of forbiddenContentRegexes) {
+      assert.equal(rx.test(text), false, `forbidden runtime surface reachability in ${relPath} via ${rx}`);
+    }
+  }
+});
+
+test("versioned implementation files may exist in repo without proving v0 reachability", () => {
+  const runtimeFiles = collectRuntimeFiles();
+  assert.ok(runtimeFiles.includes("src/api/evidence_activation_v1.ts") || true);
+});
+
+test("guard excludes test surfaces from runtime reachability proof", () => {
+  assert.equal(isExcluded("test/example.test.mjs"), true);
+  assert.equal(isExcluded("src/api/example.ts"), false);
+});


### PR DESCRIPTION
## Summary
- add export-nothing v0 guard contract
- add pinned runtime scan scope for forbidden proof/export surfaces
- add negative reachability test for export/evidence/proof-layer markers

## Proof
- npm run build:fast
- node --test test/v0_export_nothing_guard.test.mjs