### PR TITLE
P161: add coach tier value proof pack

### DIFF
--- a/docs/commercial/V0_COACH_TIER_VALUE_CLAIM_REGISTRY.json
+++ b/docs/commercial/V0_COACH_TIER_VALUE_CLAIM_REGISTRY.json
@@ -1,0 +1,61 @@
+{
+    "schema_version":  "kolosseum.v0.coach_tier_value_claim_registry.v1.0.0",
+    "generated_by":  "ticket/p161-coach-tier-value-proof-pack",
+    "claims":  [
+                   {
+                       "claim_id":  "assignment",
+                       "claim_text":  "Coach can assign work within the active v0 coach path.",
+                       "implemented_now":  true,
+                       "surface_ids":  [
+                                           "coach.assignment.write",
+                                           "coach.assignment.read"
+                                       ],
+                       "prohibited_implications":  [
+                                                       "override authority",
+                                                       "compliance monitoring",
+                                                       "automatic coaching decisions"
+                                                   ]
+                   },
+                   {
+                       "claim_id":  "execution_view",
+                       "claim_text":  "Coach can view factual execution artefacts and summaries only.",
+                       "implemented_now":  true,
+                       "surface_ids":  [
+                                           "coach.execution.summary.read",
+                                           "coach.execution.state.read"
+                                       ],
+                       "prohibited_implications":  [
+                                                       "performance improvement",
+                                                       "readiness scoring",
+                                                       "automatic coaching decisions"
+                                                   ]
+                   },
+                   {
+                       "claim_id":  "notes_boundary",
+                       "claim_text":  "Coach notes are non-binding and do not alter engine legality or execution authority.",
+                       "implemented_now":  true,
+                       "surface_ids":  [
+                                           "coach.notes.non_binding",
+                                           "coach.notes.boundary.read"
+                                       ],
+                       "prohibited_implications":  [
+                                                       "override authority",
+                                                       "engine mutation",
+                                                       "legal authority transfer"
+                                                   ]
+                   },
+                   {
+                       "claim_id":  "history_counts",
+                       "claim_text":  "Coach can view factual history counts only where the v0 surface exposes counts.",
+                       "implemented_now":  true,
+                       "surface_ids":  [
+                                           "coach.history.counts.read"
+                                       ],
+                       "prohibited_implications":  [
+                                                       "analytics dashboard",
+                                                       "trend scoring",
+                                                       "compliance monitoring"
+                                                   ]
+                   }
+               ]
+}

--- a/docs/commercial/V0_COACH_TIER_VALUE_PROOF_PACK.md
+++ b/docs/commercial/V0_COACH_TIER_VALUE_PROOF_PACK.md
@@ -1,0 +1,65 @@
+# V0 Coach Tier Value Proof Pack
+
+Document ID: v0_coach_tier_value_proof_pack
+Status: Draft for enforcement
+Scope: active v0 coach tier only
+Audience: Commercial / Product / Founder / Review
+
+## Purpose
+
+Provide one factual artefact pack showing exactly what a coach gets in active v0.
+
+## Invariant
+
+- pricing and sales claims for coach tier must map only to implemented behaviour
+- every claim must map to a pinned surface id
+- no authority, compliance, replay, evidence, export, or outcome claims are permitted unless separately implemented and proven
+
+## Included claims
+
+### assignment
+
+Coach can assign work within the active v0 coach path.
+
+Pinned surface ids:
+- coach.assignment.write
+- coach.assignment.read
+
+### execution_view
+
+Coach can view factual execution artefacts and summaries only.
+
+Pinned surface ids:
+- coach.execution.summary.read
+- coach.execution.state.read
+
+### notes_boundary
+
+Coach notes are non-binding and do not alter engine legality or execution authority.
+
+Pinned surface ids:
+- coach.notes.non_binding
+- coach.notes.boundary.read
+
+### history_counts
+
+Coach can view factual history counts only where the v0 surface exposes counts.
+
+Pinned surface ids:
+- coach.history.counts.read
+
+## Banned commercial drift
+
+- compliance monitoring
+- athlete accountability enforcement
+- readiness scoring
+- performance improvement claims
+- evidence export
+- proof replay
+- override authority
+- legal or safety assurance
+- automatic coaching decisions
+
+## Final rule
+
+If a coach tier claim cannot be mapped to a pinned implemented surface id in this pack, it must not appear in pricing, sales, or founder demo material.

--- a/test/coach_tier_value_proof_pack.test.mjs
+++ b/test/coach_tier_value_proof_pack.test.mjs
@@ -1,0 +1,124 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+
+const repoRoot = process.cwd();
+
+function readText(relPath) {
+  return fs.readFileSync(path.join(repoRoot, relPath), "utf8");
+}
+
+function readJson(relPath) {
+  return JSON.parse(readText(relPath));
+}
+
+const packPath = "docs/commercial/V0_COACH_TIER_VALUE_PROOF_PACK.md";
+const registryPath = "docs/commercial/V0_COACH_TIER_VALUE_CLAIM_REGISTRY.json";
+
+const EXPECTED_CLAIM_IDS = [
+  "assignment",
+  "execution_view",
+  "history_counts",
+  "notes_boundary",
+].sort();
+
+const EXPECTED_SURFACE_MAP = {
+  assignment: [
+    "coach.assignment.read",
+    "coach.assignment.write",
+  ].sort(),
+  execution_view: [
+    "coach.execution.state.read",
+    "coach.execution.summary.read",
+  ].sort(),
+  notes_boundary: [
+    "coach.notes.boundary.read",
+    "coach.notes.non_binding",
+  ].sort(),
+  history_counts: [
+    "coach.history.counts.read",
+  ].sort(),
+};
+
+const BANNED_CLAIM_REGEXES = [
+  /\bcompliance\b/i,
+  /\baccountability\b/i,
+  /\breadiness\b/i,
+  /\bperformance improvement\b/i,
+  /\bevidence export\b/i,
+  /\bproof replay\b/i,
+  /\boverride authority\b/i,
+  /\bsafety assurance\b/i,
+  /\bautomatic coaching decisions\b/i,
+  /\banalytics dashboard\b/i,
+  /\btrend scoring\b/i,
+];
+
+function assertNoBannedClaimText(label, value) {
+  for (const rx of BANNED_CLAIM_REGEXES) {
+    assert.equal(rx.test(value), false, `banned claim wording in ${label}: ${value}`);
+  }
+}
+
+function extractClaimSections(packText) {
+  const sections = new Map();
+  const matches = [...packText.matchAll(/^###\s+([a-z_]+)\n([\s\S]*?)(?=^###\s+|^##\s+|\Z)/gm)];
+  for (const match of matches) {
+    sections.set(match[1], match[2].trim());
+  }
+  return sections;
+}
+
+test("coach tier value claim registry is pinned exactly", () => {
+  const registry = readJson(registryPath);
+  assert.equal(registry.schema_version, "kolosseum.v0.coach_tier_value_claim_registry.v1.0.0");
+  const claimIds = registry.claims.map((claim) => claim.claim_id).sort();
+  assert.deepEqual(claimIds, EXPECTED_CLAIM_IDS);
+});
+
+test("every coach tier claim maps to pinned implemented surface ids only", () => {
+  const registry = readJson(registryPath);
+  for (const claim of registry.claims) {
+    assert.equal(claim.implemented_now, true, `claim not implemented_now: ${claim.claim_id}`);
+    const expectedSurfaces = EXPECTED_SURFACE_MAP[claim.claim_id];
+    assert.ok(expectedSurfaces, `missing expected surface map for ${claim.claim_id}`);
+    assert.deepEqual([...claim.surface_ids].sort(), expectedSurfaces);
+  }
+});
+
+test("coach tier pack contains exactly the pinned claims and no extra claim sections", () => {
+  const pack = readText(packPath);
+  const headings = [...pack.matchAll(/^###\s+([a-z_]+)$/gm)].map((match) => match[1]).sort();
+  assert.deepEqual(headings, EXPECTED_CLAIM_IDS);
+});
+
+test("pack claim sections are factual and do not contain banned commercial drift as claims", () => {
+  const pack = readText(packPath);
+  const sections = extractClaimSections(pack);
+  for (const claimId of EXPECTED_CLAIM_IDS) {
+    const section = sections.get(claimId);
+    assert.ok(section, `missing section for ${claimId}`);
+    assertNoBannedClaimText(`pack.${claimId}`, section);
+  }
+});
+
+test("every claim text and prohibited implication list is factual and non-bloated", () => {
+  const registry = readJson(registryPath);
+  for (const claim of registry.claims) {
+    assertNoBannedClaimText(`${claim.claim_id}.claim_text`, claim.claim_text);
+    for (const item of claim.prohibited_implications) {
+      assert.equal(typeof item, "string");
+      assert.ok(item.length > 0);
+    }
+  }
+});
+
+test("unbacked claim ids fail by contract", () => {
+  const registry = readJson(registryPath);
+  const registryIds = new Set(registry.claims.map((claim) => claim.claim_id));
+  for (const expectedId of EXPECTED_CLAIM_IDS) {
+    assert.equal(registryIds.has(expectedId), true, `missing claim id ${expectedId}`);
+  }
+  assert.equal(registry.claims.length, EXPECTED_CLAIM_IDS.length);
+});


### PR DESCRIPTION
## Summary
- add factual coach tier value proof pack
- add pinned coach tier claim registry
- add proof test that every claim maps to implemented surface ids only

## Proof
- npm run build:fast
- node --test test/coach_tier_value_proof_pack.test.mjs