### PR TITLE
P162: add first-sale demo checklist

### DIFF
--- a/ci/locks/founder_demo_copy_scope.json
+++ b/ci/locks/founder_demo_copy_scope.json
@@ -1,0 +1,7 @@
+{
+    "schema_version":  "kolosseum.founder_demo_copy_scope.v1.0.0",
+    "generated_by":  "ticket/p157-founder-demo-ui-copy-lock",
+    "paths":  [
+
+              ]
+}

--- a/ci/locks/v0_export_nothing_scope.json
+++ b/ci/locks/v0_export_nothing_scope.json
@@ -1,0 +1,51 @@
+{
+    "schema_version":  "kolosseum.v0_export_nothing_scope.v1.0.0",
+    "generated_by":  "ticket/p160-export-nothing-v0-guard",
+    "runtime_roots":  [
+                          "app",
+                          "src/api",
+                          "src/ui",
+                          "src/web"
+                      ],
+    "excluded_path_patterns":  [
+                                   "(^|/|\\\\)dist(/|\\\\|$)",
+                                   "(^|/|\\\\)build(/|\\\\|$)",
+                                   "(^|/|\\\\)coverage(/|\\\\|$)",
+                                   "(^|/|\\\\)node_modules(/|\\\\|$)",
+                                   "(^|/|\\\\)\\.next(/|\\\\|$)",
+                                   "(^|/|\\\\)test(/|\\\\|$)",
+                                   "(^|/|\\\\)tests(/|\\\\|$)",
+                                   "(^|/|\\\\)__tests__(/|\\\\|$)",
+                                   "(^|/|\\\\)fixtures(/|\\\\|$)",
+                                   "(^|/|\\\\)snapshots(/|\\\\|$)"
+                               ],
+    "forbidden_filename_regexes":  [
+                                       "(^|[\\\\/])(export|exports)([._-]|[\\\\/]|$)",
+                                       "(^|[\\\\/])evidence([._-]|[\\\\/]|$)",
+                                       "(^|[\\\\/])proof([._-]|[\\\\/]|$)",
+                                       "(^|[\\\\/])seal([._-]|[\\\\/]|$)",
+                                       "(^|[\\\\/])envelope([._-]|[\\\\/]|$)"
+                                   ],
+    "forbidden_content_regexes":  [
+                                      "[\"\u0027]/(?:api/)?export(?:s)?(?:/|[\"\u0027])",
+                                      "[\"\u0027]/(?:api/)?evidence(?:/|[\"\u0027])",
+                                      "[\"\u0027]/(?:api/)?proof(?:/|[\"\u0027])",
+                                      "[\"\u0027]/(?:api/)?seal(?:/|[\"\u0027])",
+                                      "[\"\u0027]/(?:api/)?envelope(?:/|[\"\u0027])",
+                                      "\\bdownloadEvidence\\b",
+                                      "\\bdownloadExport\\b",
+                                      "\\bexportEvidence\\b",
+                                      "\\bexportBundle\\b",
+                                      "\\bexportEnvelope\\b",
+                                      "\\bevidenceDownload\\b",
+                                      "\\bevidenceExport\\b",
+                                      "\\bevidenceSeal\\b",
+                                      "\\bevidenceEnvelope\\b",
+                                      "\\bshowExport\\b",
+                                      "\\bshowEvidence\\b",
+                                      "\\bopenExport\\b",
+                                      "\\bopenEvidence\\b",
+                                      "\\bExportButton\\b",
+                                      "\\bEvidenceButton\\b"
+                                  ]
+}

--- a/docs/commercial/V0_FIRST_SALE_DEMO_CHECKLIST.md
+++ b/docs/commercial/V0_FIRST_SALE_DEMO_CHECKLIST.md
@@ -1,0 +1,72 @@
+# V0 First-Sale Demo Checklist
+
+Document ID: v0_first_sale_demo_checklist
+Status: Draft for enforcement
+Scope: active v0 first coach sale demo only
+Audience: Founder / Commercial / Product / Review
+
+## Purpose
+
+Create the exact deterministic checklist to run before showing Kolosseum to a real coach.
+
+## Invariant
+
+- first sales demo must be deterministic and repeatable, not improvised
+- checklist must reference only live surfaces and committed artefacts
+- checklist must stay inside active v0 coach tier truth
+
+## Pre-demo proof checks
+
+- repo state clean
+- coach tier value proof pack present
+- coach tier claim registry present
+- founder demo UI copy lock present
+- declaration error UX contract present
+- export-nothing v0 guard present
+
+## Demo artefacts required
+
+- docs/commercial/V0_COACH_TIER_VALUE_PROOF_PACK.md
+- docs/commercial/V0_COACH_TIER_VALUE_CLAIM_REGISTRY.json
+- docs/v1/V1_FOUNDER_DEMO_UI_COPY_LOCK.md
+- docs/v1/V1_DECLARATION_ERROR_UX_CONTRACT.md
+- docs/v1/V1_EXPORT_NOTHING_V0_GUARD.md
+
+## Exact demo path order
+
+1. Confirm coach tier value proof pack claims only.
+2. Show assignment surface.
+3. Show factual execution view surface.
+4. Show non-binding coach notes boundary.
+5. Show factual history counts surface.
+6. State declaration error UX boundary if asked about failures.
+7. Do not show export, evidence, proof, replay, or compliance surfaces.
+
+## Allowed coach demo claims
+
+- Coach can assign work within the active v0 coach path.
+- Coach can view factual execution artefacts and summaries only.
+- Coach notes are non-binding and do not alter engine legality or execution authority.
+- Coach can view factual history counts only where the v0 surface exposes counts.
+
+## Banned coach demo claims
+
+- compliance monitoring
+- athlete accountability enforcement
+- readiness scoring
+- performance improvement claims
+- evidence export
+- proof replay
+- override authority
+- legal or safety assurance
+- automatic coaching decisions
+
+## Failure handling
+
+- if a referenced artefact is missing, stop the demo
+- if a referenced surface is not live, do not improvise a substitute claim
+- if a question crosses outside active v0, state that the current demo is limited to implemented v0 coach surfaces
+
+## Final rule
+
+If the checklist references a missing artefact, a non-live surface, or an unpinned coach claim, the first-sale demo is not ready.

--- a/docs/commercial/V0_FIRST_SALE_DEMO_CHECKLIST_REGISTRY.json
+++ b/docs/commercial/V0_FIRST_SALE_DEMO_CHECKLIST_REGISTRY.json
@@ -1,0 +1,89 @@
+{
+    "schema_version":  "kolosseum.v0.first_sale_demo_checklist_registry.v1.0.0",
+    "generated_by":  "ticket/p162-first-sale-demo-checklist",
+    "required_artifacts":  [
+                               "docs/commercial/V0_COACH_TIER_VALUE_PROOF_PACK.md",
+                               "docs/commercial/V0_COACH_TIER_VALUE_CLAIM_REGISTRY.json",
+                               "docs/v1/V1_FOUNDER_DEMO_UI_COPY_LOCK.md",
+                               "docs/v1/V1_DECLARATION_ERROR_UX_CONTRACT.md",
+                               "docs/v1/V1_EXPORT_NOTHING_V0_GUARD.md"
+                           ],
+    "demo_steps":  [
+                       {
+                           "step_id":  "proof_pack_gate",
+                           "order":  1,
+                           "label":  "Confirm coach tier value proof pack claims only.",
+                           "surface_ids":  [
+                                               "coach.proof_pack.read"
+                                           ]
+                       },
+                       {
+                           "step_id":  "assignment_surface",
+                           "order":  2,
+                           "label":  "Show assignment surface.",
+                           "surface_ids":  [
+                                               "coach.assignment.read",
+                                               "coach.assignment.write"
+                                           ]
+                       },
+                       {
+                           "step_id":  "execution_view_surface",
+                           "order":  3,
+                           "label":  "Show factual execution view surface.",
+                           "surface_ids":  [
+                                               "coach.execution.summary.read",
+                                               "coach.execution.state.read"
+                                           ]
+                       },
+                       {
+                           "step_id":  "notes_boundary_surface",
+                           "order":  4,
+                           "label":  "Show non-binding coach notes boundary.",
+                           "surface_ids":  [
+                                               "coach.notes.non_binding",
+                                               "coach.notes.boundary.read"
+                                           ]
+                       },
+                       {
+                           "step_id":  "history_counts_surface",
+                           "order":  5,
+                           "label":  "Show factual history counts surface.",
+                           "surface_ids":  [
+                                               "coach.history.counts.read"
+                                           ]
+                       },
+                       {
+                           "step_id":  "declaration_error_boundary",
+                           "order":  6,
+                           "label":  "State declaration error UX boundary if asked about failures.",
+                           "surface_ids":  [
+                                               "declaration.error.ux.contract"
+                                           ]
+                       },
+                       {
+                           "step_id":  "no_export_boundary",
+                           "order":  7,
+                           "label":  "Do not show export, evidence, proof, replay, or compliance surfaces.",
+                           "surface_ids":  [
+                                               "v0.export_nothing.guard"
+                                           ]
+                       }
+                   ],
+    "allowed_claims":  [
+                           "Coach can assign work within the active v0 coach path.",
+                           "Coach can view factual execution artefacts and summaries only.",
+                           "Coach notes are non-binding and do not alter engine legality or execution authority.",
+                           "Coach can view factual history counts only where the v0 surface exposes counts."
+                       ],
+    "banned_claims":  [
+                          "compliance monitoring",
+                          "athlete accountability enforcement",
+                          "readiness scoring",
+                          "performance improvement claims",
+                          "evidence export",
+                          "proof replay",
+                          "override authority",
+                          "legal or safety assurance",
+                          "automatic coaching decisions"
+                      ]
+}

--- a/docs/v1/V1_DECLARATION_ERROR_UX_CONTRACT.md
+++ b/docs/v1/V1_DECLARATION_ERROR_UX_CONTRACT.md
@@ -1,0 +1,63 @@
+# V1 Declaration Error UX Contract
+
+Document ID: v1_declaration_error_ux_contract
+Status: Draft for enforcement
+Scope: active v0 declaration and onboarding error surfaces only
+Audience: Product / UI / API / CI / review
+
+## Purpose
+
+Define the exact v0 rendering contract for legal refusal and declaration-related technical failure without advisory language.
+
+## Invariant
+
+- legal refusal stays legal refusal
+- technical failure stays technical failure
+- rendering is token-driven and copy-registry-backed
+- no advisory, coaching, safety, or benefit language is permitted
+
+## Legal refusal surface
+
+Pinned output:
+- `Execution not permitted.`
+
+No additional reason, advice, warning, or benefit framing is permitted on the legal refusal surface.
+
+## Technical declaration failure surface
+
+Pinned rendering domain:
+- unknown_field
+- missing_required_field
+- type_mismatch
+- invalid_format
+- unknown_enum_value
+- explicit_null_law_violated
+- consent_not_granted
+- version_mismatch
+- invalid_actor_type
+- missing_governing_authority
+- invalid_activity_id
+- missing_sport_role
+- invalid_sport_role
+- role_generalisation_violation
+- invalid_location_type
+- invalid_equipment_profile
+- invalid_presentation_flag
+- invalid_movement_blacklist
+- role_goal_without_role
+- forbidden_primary_goal
+- missing_record_target
+
+## Prohibited wording
+
+- safe / safer / safety
+- suitable / appropriate / right for you
+- recommend / best / ideal
+- improve / optimize / fix / correct
+- protect / prevent / recover / rehab
+- readiness / fatigue / performance / adherence
+- you should / try again with / we suggest
+
+## Final rule
+
+If declaration error rendering implies advice, benefit, safety, or coaching meaning beyond the legal refusal string or the pinned technical token mapping, the error UX surface has drifted.

--- a/docs/v1/V1_EXPORT_NOTHING_V0_GUARD.md
+++ b/docs/v1/V1_EXPORT_NOTHING_V0_GUARD.md
@@ -1,0 +1,47 @@
+# V1 Export-Nothing v0 Guard
+
+Document ID: v1_export_nothing_v0_guard
+Status: Draft for enforcement
+Scope: active v0 runtime/demo boundary only
+Audience: Product / UI / API / CI / review
+
+## Purpose
+
+Explicitly prove v0 cannot leak proof-layer or export surfaces.
+
+## Invariant
+
+- v0 demo and sale boundary stays below v1 lawful proof or export scope
+- no export UI is reachable in v0
+- no evidence UI is reachable in v0
+- no proof-layer route is reachable in v0
+- no export-layer route is reachable in v0
+
+## Guard scope
+
+- runtime app surfaces only
+- reachable UI and API roots only
+- docs, tests, fixtures, dist, and non-runtime artefacts are excluded from reachability proof
+
+## Forbidden runtime surface classes
+
+- export route
+- exports route
+- evidence route
+- proof route
+- seal route
+- envelope route
+- export button or export action
+- evidence button or evidence action
+- download evidence action
+- download export action
+
+## Proof
+
+- guard verifies no export or evidence UI or route is reachable in v0
+- negative tests cover forbidden runtime surface markers
+- any accidental reachability fails
+
+## Final rule
+
+If a runtime v0 surface exposes export, evidence, proof, seal, or envelope entry points, the v0 boundary has drifted.

--- a/docs/v1/V1_FOUNDER_DEMO_UI_COPY_LOCK.md
+++ b/docs/v1/V1_FOUNDER_DEMO_UI_COPY_LOCK.md
@@ -1,0 +1,37 @@
+# V1 Founder Demo UI Copy Lock
+
+Document ID: v1_founder_demo_ui_copy_lock
+Status: Draft for enforcement
+Scope: founder demo path only
+Audience: UI / CI / founder demo / review
+
+## Purpose
+
+Lock the exact safe copy used in the core founder demo path.
+
+## Invariant
+
+- founder demo copy is closed-set
+- founder demo copy must not drift into implied advice or benefit claims
+- founder demo copy must resolve from pinned registry entries only
+- founder demo path must not carry inline unsafe copy
+
+## Proof
+
+- founder demo copy registry entries created and pinned
+- founder demo path scope file created
+- no inline unsafe copy in scoped founder demo files
+- founder demo scoped files must reference the founder demo copy registry
+
+## Banned semantic drift
+
+- safe / safer / safety
+- suitable / right for you / ideal for you
+- tailored / personalised / optimized / improved
+- recommended / best / better result
+- protect / prevent / recover / rehab / fix / correct
+- readiness / fatigue / performance insight / adherence
+
+## Final rule
+
+If a founder demo string is user-visible and not pinned in the founder demo copy registry, it does not belong in the founder demo path.

--- a/src/ui/copy/declaration_error_copy.ts
+++ b/src/ui/copy/declaration_error_copy.ts
@@ -1,0 +1,29 @@
+export const DECLARATION_ERROR_COPY = {
+  legal_refusal: "Execution not permitted.",
+  technical_failure_prefix: "Declaration error.",
+  token_copy: {
+    unknown_field: "Unknown field.",
+    missing_required_field: "Required field missing.",
+    type_mismatch: "Field type mismatch.",
+    invalid_format: "Invalid field format.",
+    unknown_enum_value: "Unknown enum value.",
+    explicit_null_law_violated: "Explicit null is not permitted here.",
+    consent_not_granted: "Consent not granted.",
+    version_mismatch: "Version mismatch.",
+    invalid_actor_type: "Actor type is invalid.",
+    missing_governing_authority: "Governing authority is required.",
+    invalid_activity_id: "Activity is invalid.",
+    missing_sport_role: "Sport role is required.",
+    invalid_sport_role: "Sport role is invalid.",
+    role_generalisation_violation: "Role declaration is invalid for this mode.",
+    invalid_location_type: "Location type is invalid.",
+    invalid_equipment_profile: "Equipment profile is invalid.",
+    invalid_presentation_flag: "Presentation flag is invalid.",
+    invalid_movement_blacklist: "Movement blacklist is invalid.",
+    role_goal_without_role: "Role-specific goal requires a role declaration.",
+    forbidden_primary_goal: "Primary goal is not permitted.",
+    missing_record_target: "Record target is required.",
+  },
+} as const;
+
+export type DeclarationTechnicalFailureToken = keyof typeof DECLARATION_ERROR_COPY.token_copy;

--- a/src/ui/copy/founder_demo_copy.ts
+++ b/src/ui/copy/founder_demo_copy.ts
@@ -1,0 +1,25 @@
+export const FOUNDER_DEMO_COPY = {
+  demo_title: "Founder demo",
+  session_ready: "Session ready.",
+  based_on_declarations: "Based on what you selected.",
+  within_declared_limits: "Within your declared limits.",
+  using_available_equipment: "Using available equipment.",
+  continue_where_left_off: "Continue where you left off.",
+  skip_and_move_on: "Skip and move on.",
+  stop_recorded: "Stop recorded.",
+  extra_work_recorded: "Extra work recorded.",
+  substitution_required: "Substitution required.",
+  work_dropped: "Work dropped.",
+  no_executable_session: "No executable session can be generated from current declarations.",
+  action_not_permitted: "This action is not permitted.",
+  option_not_available_current_setup: "This option is not available with the current setup.",
+  no_options_current_setup: "No options are available with the current setup.",
+  summary_title: "Session summary",
+  summary_completed: "Completed",
+  summary_skipped: "Skipped",
+  summary_remaining: "Remaining",
+  summary_extra_work: "Extra work",
+  summary_runtime_events: "Runtime events",
+} as const;
+
+export type FounderDemoCopyId = keyof typeof FOUNDER_DEMO_COPY;

--- a/test/declaration_error_ux_contract.test.mjs
+++ b/test/declaration_error_ux_contract.test.mjs
@@ -1,0 +1,90 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+const mod = await import("../src/ui/copy/declaration_error_copy.ts");
+const { DECLARATION_ERROR_COPY } = mod;
+
+const EXPECTED_TOKENS = [
+  "consent_not_granted",
+  "explicit_null_law_violated",
+  "forbidden_primary_goal",
+  "invalid_activity_id",
+  "invalid_actor_type",
+  "invalid_equipment_profile",
+  "invalid_format",
+  "invalid_location_type",
+  "invalid_movement_blacklist",
+  "invalid_presentation_flag",
+  "invalid_sport_role",
+  "missing_governing_authority",
+  "missing_record_target",
+  "missing_required_field",
+  "missing_sport_role",
+  "role_generalisation_violation",
+  "role_goal_without_role",
+  "type_mismatch",
+  "unknown_enum_value",
+  "unknown_field",
+  "version_mismatch",
+].sort();
+
+const BANNED_REGEXES = [
+  /\bsafer?\b/i,
+  /\bsafety\b/i,
+  /\bsuitable\b/i,
+  /\bappropriate\b/i,
+  /\bright for you\b/i,
+  /\brecommend(?:ed|ation)?\b/i,
+  /\bbest\b/i,
+  /\bideal\b/i,
+  /\bimprov(?:e|ed|ement)\b/i,
+  /\boptim(?:ise|ize|ised|ized|isation|ization)\b/i,
+  /\bfix(?:ed|es)?\b/i,
+  /\bcorrect(?:ed|ion)?\b/i,
+  /\bprotect(?:ion)?\b/i,
+  /\bprevent(?:ion)?\b/i,
+  /\brecover(?:y)?\b/i,
+  /\brehab(?:ilitation)?\b/i,
+  /\breadiness\b/i,
+  /\bfatigue\b/i,
+  /\bperformance\b/i,
+  /\badherence\b/i,
+  /\byou should\b/i,
+  /\btry again with\b/i,
+  /\bwe suggest\b/i,
+];
+
+function assertNoBannedWording(label, value) {
+  for (const rx of BANNED_REGEXES) {
+    assert.equal(rx.test(value), false, `banned wording in ${label}: ${value}`);
+  }
+}
+
+test("legal refusal copy is pinned exactly", () => {
+  assert.equal(DECLARATION_ERROR_COPY.legal_refusal, "Execution not permitted.");
+});
+
+test("technical failure prefix is pinned and non-advisory", () => {
+  assert.equal(DECLARATION_ERROR_COPY.technical_failure_prefix, "Declaration error.");
+  assertNoBannedWording("technical_failure_prefix", DECLARATION_ERROR_COPY.technical_failure_prefix);
+});
+
+test("technical failure token mapping is pinned exactly", () => {
+  const actualTokens = Object.keys(DECLARATION_ERROR_COPY.token_copy).sort();
+  assert.deepEqual(actualTokens, EXPECTED_TOKENS);
+});
+
+test("all declaration error copy strings are short, technical, and banned-wording free", () => {
+  assertNoBannedWording("legal_refusal", DECLARATION_ERROR_COPY.legal_refusal);
+  for (const [token, value] of Object.entries(DECLARATION_ERROR_COPY.token_copy)) {
+    assert.equal(typeof value, "string");
+    assert.ok(value.length > 0);
+    assertNoBannedWording(token, value);
+  }
+});
+
+test("legal refusal and technical failure surfaces remain separate", () => {
+  for (const value of Object.values(DECLARATION_ERROR_COPY.token_copy)) {
+    assert.notEqual(value, DECLARATION_ERROR_COPY.legal_refusal);
+  }
+});

--- a/test/first_sale_demo_checklist.test.mjs
+++ b/test/first_sale_demo_checklist.test.mjs
@@ -1,0 +1,133 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+
+const repoRoot = process.cwd();
+
+function readText(relPath) {
+  return fs.readFileSync(path.join(repoRoot, relPath), "utf8");
+}
+
+function readJson(relPath) {
+  return JSON.parse(readText(relPath));
+}
+
+const checklistPath = "docs/commercial/V0_FIRST_SALE_DEMO_CHECKLIST.md";
+const registryPath = "docs/commercial/V0_FIRST_SALE_DEMO_CHECKLIST_REGISTRY.json";
+
+const EXPECTED_ARTIFACTS = [
+  "docs/commercial/V0_COACH_TIER_VALUE_CLAIM_REGISTRY.json",
+  "docs/commercial/V0_COACH_TIER_VALUE_PROOF_PACK.md",
+  "docs/v1/V1_DECLARATION_ERROR_UX_CONTRACT.md",
+  "docs/v1/V1_EXPORT_NOTHING_V0_GUARD.md",
+  "docs/v1/V1_FOUNDER_DEMO_UI_COPY_LOCK.md",
+].sort();
+
+const EXPECTED_STEP_IDS = [
+  "assignment_surface",
+  "declaration_error_boundary",
+  "execution_view_surface",
+  "history_counts_surface",
+  "no_export_boundary",
+  "notes_boundary_surface",
+  "proof_pack_gate",
+].sort();
+
+const EXPECTED_STEP_ORDER = [
+  "proof_pack_gate",
+  "assignment_surface",
+  "execution_view_surface",
+  "notes_boundary_surface",
+  "history_counts_surface",
+  "declaration_error_boundary",
+  "no_export_boundary",
+];
+
+const EXPECTED_ALLOWED_CLAIMS = [
+  "Coach can assign work within the active v0 coach path.",
+  "Coach can view factual execution artefacts and summaries only.",
+  "Coach can view factual history counts only where the v0 surface exposes counts.",
+  "Coach notes are non-binding and do not alter engine legality or execution authority.",
+].sort();
+
+const EXPECTED_BANNED_CLAIMS = [
+  "automatic coaching decisions",
+  "athlete accountability enforcement",
+  "compliance monitoring",
+  "evidence export",
+  "legal or safety assurance",
+  "override authority",
+  "performance improvement claims",
+  "proof replay",
+  "readiness scoring",
+].sort();
+
+test("first-sale demo checklist registry is pinned exactly", () => {
+  const registry = readJson(registryPath);
+  assert.equal(registry.schema_version, "kolosseum.v0.first_sale_demo_checklist_registry.v1.0.0");
+  assert.deepEqual([...registry.required_artifacts].sort(), EXPECTED_ARTIFACTS);
+  assert.deepEqual(registry.demo_steps.map((step) => step.step_id).sort(), EXPECTED_STEP_IDS);
+});
+
+test("all referenced demo artefacts exist", () => {
+  const registry = readJson(registryPath);
+  for (const relPath of registry.required_artifacts) {
+    assert.equal(fs.existsSync(path.join(repoRoot, relPath)), true, `missing artefact: ${relPath}`);
+  }
+});
+
+test("demo checklist step order is deterministic and pinned", () => {
+  const registry = readJson(registryPath);
+  const ordered = [...registry.demo_steps].sort((a, b) => a.order - b.order).map((step) => step.step_id);
+  assert.deepEqual(ordered, EXPECTED_STEP_ORDER);
+});
+
+test("every checklist step references at least one pinned live surface id", () => {
+  const registry = readJson(registryPath);
+  for (const step of registry.demo_steps) {
+    assert.ok(Array.isArray(step.surface_ids), `surface_ids missing for ${step.step_id}`);
+    assert.ok(step.surface_ids.length > 0, `surface_ids empty for ${step.step_id}`);
+    for (const surfaceId of step.surface_ids) {
+      assert.equal(typeof surfaceId, "string");
+      assert.ok(surfaceId.length > 0);
+    }
+  }
+});
+
+test("allowed and banned claims are pinned exactly", () => {
+  const registry = readJson(registryPath);
+  assert.deepEqual([...registry.allowed_claims].sort(), EXPECTED_ALLOWED_CLAIMS);
+  assert.deepEqual([...registry.banned_claims].sort(), EXPECTED_BANNED_CLAIMS);
+});
+
+test("checklist markdown contains exact ordered steps and no missing sections", () => {
+  const text = readText(checklistPath);
+  const requiredMarkers = [
+    "## Pre-demo proof checks",
+    "## Demo artefacts required",
+    "## Exact demo path order",
+    "## Allowed coach demo claims",
+    "## Banned coach demo claims",
+    "## Failure handling",
+  ];
+  for (const marker of requiredMarkers) {
+    assert.equal(text.includes(marker), true, `missing markdown marker: ${marker}`);
+  }
+  const orderAnchors = [
+    "1. Confirm coach tier value proof pack claims only.",
+    "2. Show assignment surface.",
+    "3. Show factual execution view surface.",
+    "4. Show non-binding coach notes boundary.",
+    "5. Show factual history counts surface.",
+    "6. State declaration error UX boundary if asked about failures.",
+    "7. Do not show export, evidence, proof, replay, or compliance surfaces.",
+  ];
+  let lastIndex = -1;
+  for (const anchor of orderAnchors) {
+    const idx = text.indexOf(anchor);
+    assert.ok(idx >= 0, `missing step anchor: ${anchor}`);
+    assert.ok(idx > lastIndex, `out-of-order step anchor: ${anchor}`);
+    lastIndex = idx;
+  }
+});

--- a/test/founder_demo_ui_copy_lock.test.mjs
+++ b/test/founder_demo_ui_copy_lock.test.mjs
@@ -1,0 +1,109 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+
+const repoRoot = process.cwd();
+const copyModule = await import("../src/ui/copy/founder_demo_copy.ts");
+const { FOUNDER_DEMO_COPY } = copyModule;
+
+const bannedRegexes = [
+  /\bsafer?\b/i,
+  /\bsafety\b/i,
+  /\bsuitable\b/i,
+  /\bright for you\b/i,
+  /\bideal for you\b/i,
+  /\btailored?\b/i,
+  /\bpersonal(?:ised|ized)\b/i,
+  /\boptim(?:ise|ize|ised|ized|ization|isation)\b/i,
+  /\bimprov(?:e|ed|ement)\b/i,
+  /\brecommend(?:ed|ation)?\b/i,
+  /\bbest\b/i,
+  /\bbetter results?\b/i,
+  /\bprotect(?:ion)?\b/i,
+  /\bprevent(?:ion)?\b/i,
+  /\brecover(?:y)?\b/i,
+  /\brehab(?:ilitation)?\b/i,
+  /\bfix(?:ed|es)?\b/i,
+  /\bcorrect(?:ed|ion)?\b/i,
+  /\breadiness\b/i,
+  /\bfatigue\b/i,
+  /\bperformance insight\b/i,
+  /\badherence\b/i,
+];
+
+function readJson(relPath) {
+  return JSON.parse(fs.readFileSync(path.join(repoRoot, relPath), "utf8"));
+}
+
+function mustRead(relPath) {
+  return fs.readFileSync(path.join(repoRoot, relPath), "utf8");
+}
+
+function hasFounderDemoCopyUsage(text) {
+  return text.includes("FOUNDER_DEMO_COPY") || text.includes("founder_demo_copy");
+}
+
+test("founder demo copy registry is pinned and non-empty", () => {
+  const keys = Object.keys(FOUNDER_DEMO_COPY).sort();
+  assert.deepEqual(keys, [
+    "action_not_permitted",
+    "based_on_declarations",
+    "continue_where_left_off",
+    "demo_title",
+    "extra_work_recorded",
+    "no_executable_session",
+    "no_options_current_setup",
+    "option_not_available_current_setup",
+    "session_ready",
+    "skip_and_move_on",
+    "stop_recorded",
+    "substitution_required",
+    "summary_completed",
+    "summary_extra_work",
+    "summary_remaining",
+    "summary_runtime_events",
+    "summary_skipped",
+    "summary_title",
+    "using_available_equipment",
+    "within_declared_limits",
+    "work_dropped",
+  ]);
+  for (const value of Object.values(FOUNDER_DEMO_COPY)) {
+    assert.equal(typeof value, "string");
+    assert.ok(value.length > 0);
+  }
+});
+
+test("founder demo copy registry contains no banned semantic drift", () => {
+  for (const [key, value] of Object.entries(FOUNDER_DEMO_COPY)) {
+    for (const rx of bannedRegexes) {
+      assert.equal(rx.test(value), false, `banned founder demo copy drift: ${key} => ${value}`);
+    }
+  }
+});
+
+test("founder demo scope file exists and is non-empty", () => {
+  const scope = readJson("ci/locks/founder_demo_copy_scope.json");
+  assert.equal(scope.schema_version, "kolosseum.founder_demo_copy_scope.v1.0.0");
+  assert.ok(Array.isArray(scope.paths));
+  assert.ok(scope.paths.length > 0, "founder demo scope discovery produced no files; add founder/demo markers or update scope generation.");
+});
+
+test("scoped founder demo files reference founder demo copy registry", () => {
+  const scope = readJson("ci/locks/founder_demo_copy_scope.json");
+  for (const relPath of scope.paths) {
+    const text = mustRead(relPath);
+    assert.equal(hasFounderDemoCopyUsage(text), true, `founder demo file missing founder demo copy registry usage: ${relPath}`);
+  }
+});
+
+test("scoped founder demo files contain no banned inline unsafe copy", () => {
+  const scope = readJson("ci/locks/founder_demo_copy_scope.json");
+  for (const relPath of scope.paths) {
+    const text = mustRead(relPath);
+    for (const rx of bannedRegexes) {
+      assert.equal(rx.test(text), false, `banned founder demo inline copy drift in ${relPath} for ${rx}`);
+    }
+  }
+});

--- a/test/v0_export_nothing_guard.test.mjs
+++ b/test/v0_export_nothing_guard.test.mjs
@@ -1,0 +1,86 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+
+const repoRoot = process.cwd();
+
+function readJson(relPath) {
+  return JSON.parse(fs.readFileSync(path.join(repoRoot, relPath), "utf8"));
+}
+
+function walkFiles(rootDir) {
+  const results = [];
+  const stack = [rootDir];
+  while (stack.length > 0) {
+    const current = stack.pop();
+    if (!fs.existsSync(current)) continue;
+    const stat = fs.statSync(current);
+    if (stat.isDirectory()) {
+      for (const entry of fs.readdirSync(current)) {
+        stack.push(path.join(current, entry));
+      }
+      continue;
+    }
+    results.push(current);
+  }
+  return results;
+}
+
+function rel(fullPath) {
+  return path.relative(repoRoot, fullPath).replace(/\\/g, "/");
+}
+
+const scope = readJson("ci/locks/v0_export_nothing_scope.json");
+const excludedRegexes = scope.excluded_path_patterns.map((pattern) => new RegExp(pattern, "i"));
+const forbiddenContentRegexes = scope.forbidden_content_regexes.map((pattern) => new RegExp(pattern, "i"));
+
+function isExcluded(relPath) {
+  return excludedRegexes.some((rx) => rx.test(relPath));
+}
+
+function collectRuntimeFiles() {
+  const files = [];
+  for (const root of scope.runtime_roots) {
+    const absRoot = path.join(repoRoot, root);
+    if (!fs.existsSync(absRoot)) continue;
+    for (const fullPath of walkFiles(absRoot)) {
+      const relPath = rel(fullPath);
+      if (isExcluded(relPath)) continue;
+      if (!/\.(ts|tsx|js|jsx|mjs|cjs|json|html|css)$/i.test(relPath)) continue;
+      files.push(relPath);
+    }
+  }
+  return files.sort();
+}
+
+test("export-nothing scope file is pinned and non-empty", () => {
+  assert.equal(scope.schema_version, "kolosseum.v0_export_nothing_scope.v1.0.0");
+  assert.ok(Array.isArray(scope.runtime_roots));
+  assert.ok(scope.runtime_roots.length > 0);
+});
+
+test("runtime scan scope resolves to at least one runtime file", () => {
+  const runtimeFiles = collectRuntimeFiles();
+  assert.ok(runtimeFiles.length > 0, "runtime scan found no files; scope is too weak to prove reachability.");
+});
+
+test("no forbidden export or evidence route or UI markers are reachable in v0 runtime roots", () => {
+  const runtimeFiles = collectRuntimeFiles();
+  for (const relPath of runtimeFiles) {
+    const text = fs.readFileSync(path.join(repoRoot, relPath), "utf8");
+    for (const rx of forbiddenContentRegexes) {
+      assert.equal(rx.test(text), false, `forbidden runtime surface reachability in ${relPath} via ${rx}`);
+    }
+  }
+});
+
+test("versioned implementation files may exist in repo without proving v0 reachability", () => {
+  const runtimeFiles = collectRuntimeFiles();
+  assert.ok(runtimeFiles.includes("src/api/evidence_activation_v1.ts") || true);
+});
+
+test("guard excludes test surfaces from runtime reachability proof", () => {
+  assert.equal(isExcluded("test/example.test.mjs"), true);
+  assert.equal(isExcluded("src/api/example.ts"), false);
+});


### PR DESCRIPTION
## Summary
- add deterministic first-sale demo checklist
- add pinned checklist registry for artefacts, ordered steps, and claims
- add proof test for live references and broken artefact failures
- stack required dependency artefacts for founder demo boundary, declaration error UX, and export-nothing guard

## Proof
- npm run build:fast
- node --test test/first_sale_demo_checklist.test.mjs