### PR TITLE
P163: add coach demo artefact index lock

### DIFF
--- a/docs/commercial/V0_COACH_DEMO_ARTEFACT_INDEX.md
+++ b/docs/commercial/V0_COACH_DEMO_ARTEFACT_INDEX.md
@@ -1,0 +1,60 @@
+# V0 Coach Demo Artefact Index
+
+Document ID: v0_coach_demo_artefact_index
+Status: Draft for enforcement
+Scope: active v0 coach sale/demo path only
+Audience: Founder / Commercial / Demo operator / Review
+
+## Purpose
+
+Provide one pinned index for every artefact used in the coach sale/demo path.
+
+## Invariant
+
+- demo operator cannot rely on memory or hunting
+- every artefact used in the coach sale/demo path must be indexed once
+- every indexed artefact must exist in the repo
+- duplicate or missing artefact references are forbidden
+
+## Indexed artefacts
+
+### coach_value_pack
+
+- docs/commercial/V0_COACH_TIER_VALUE_PROOF_PACK.md
+- docs/commercial/V0_COACH_TIER_VALUE_CLAIM_REGISTRY.json
+
+### first_sale_demo_checklist
+
+- docs/commercial/V0_FIRST_SALE_DEMO_CHECKLIST.md
+- docs/commercial/V0_FIRST_SALE_DEMO_CHECKLIST_REGISTRY.json
+
+### founder_demo_boundary
+
+- docs/v1/V1_FOUNDER_DEMO_UI_COPY_LOCK.md
+- src/ui/copy/founder_demo_copy.ts
+- test/founder_demo_ui_copy_lock.test.mjs
+
+### declaration_error_boundary
+
+- docs/v1/V1_DECLARATION_ERROR_UX_CONTRACT.md
+- src/ui/copy/declaration_error_copy.ts
+- test/declaration_error_ux_contract.test.mjs
+
+### export_nothing_boundary
+
+- docs/v1/V1_EXPORT_NOTHING_V0_GUARD.md
+- ci/locks/v0_export_nothing_scope.json
+- test/v0_export_nothing_guard.test.mjs
+
+### coach_demo_execution_support
+
+- test/coach_tier_value_proof_pack.test.mjs
+- test/first_sale_demo_checklist.test.mjs
+
+## Operator rule
+
+If an artefact is needed for the coach sale/demo path and is not indexed here, the demo path is incomplete.
+
+## Final rule
+
+If any indexed artefact is missing, duplicated, or stale relative to the active v0 coach demo path, the coach demo artefact index has failed.

--- a/docs/commercial/V0_COACH_DEMO_ARTEFACT_INDEX_REGISTRY.json
+++ b/docs/commercial/V0_COACH_DEMO_ARTEFACT_INDEX_REGISTRY.json
@@ -1,0 +1,51 @@
+{
+    "schema_version":  "kolosseum.v0.coach_demo_artefact_index.v1.0.0",
+    "generated_by":  "ticket/p163-coach-demo-artefact-index-lock",
+    "artefact_groups":  [
+                            {
+                                "group_id":  "coach_value_pack",
+                                "artefacts":  [
+                                                  "docs/commercial/V0_COACH_TIER_VALUE_PROOF_PACK.md",
+                                                  "docs/commercial/V0_COACH_TIER_VALUE_CLAIM_REGISTRY.json"
+                                              ]
+                            },
+                            {
+                                "group_id":  "first_sale_demo_checklist",
+                                "artefacts":  [
+                                                  "docs/commercial/V0_FIRST_SALE_DEMO_CHECKLIST.md",
+                                                  "docs/commercial/V0_FIRST_SALE_DEMO_CHECKLIST_REGISTRY.json"
+                                              ]
+                            },
+                            {
+                                "group_id":  "founder_demo_boundary",
+                                "artefacts":  [
+                                                  "docs/v1/V1_FOUNDER_DEMO_UI_COPY_LOCK.md",
+                                                  "src/ui/copy/founder_demo_copy.ts",
+                                                  "test/founder_demo_ui_copy_lock.test.mjs"
+                                              ]
+                            },
+                            {
+                                "group_id":  "declaration_error_boundary",
+                                "artefacts":  [
+                                                  "docs/v1/V1_DECLARATION_ERROR_UX_CONTRACT.md",
+                                                  "src/ui/copy/declaration_error_copy.ts",
+                                                  "test/declaration_error_ux_contract.test.mjs"
+                                              ]
+                            },
+                            {
+                                "group_id":  "export_nothing_boundary",
+                                "artefacts":  [
+                                                  "docs/v1/V1_EXPORT_NOTHING_V0_GUARD.md",
+                                                  "ci/locks/v0_export_nothing_scope.json",
+                                                  "test/v0_export_nothing_guard.test.mjs"
+                                              ]
+                            },
+                            {
+                                "group_id":  "coach_demo_execution_support",
+                                "artefacts":  [
+                                                  "test/coach_tier_value_proof_pack.test.mjs",
+                                                  "test/first_sale_demo_checklist.test.mjs"
+                                              ]
+                            }
+                        ]
+}

--- a/test/coach_demo_artefact_index_lock.test.mjs
+++ b/test/coach_demo_artefact_index_lock.test.mjs
@@ -1,0 +1,83 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+
+const repoRoot = process.cwd();
+
+function readText(relPath) {
+  return fs.readFileSync(path.join(repoRoot, relPath), "utf8");
+}
+
+function readJson(relPath) {
+  return JSON.parse(readText(relPath));
+}
+
+const indexPath = "docs/commercial/V0_COACH_DEMO_ARTEFACT_INDEX.md";
+const registryPath = "docs/commercial/V0_COACH_DEMO_ARTEFACT_INDEX_REGISTRY.json";
+
+const EXPECTED_GROUP_IDS = [
+  "coach_demo_execution_support",
+  "coach_value_pack",
+  "declaration_error_boundary",
+  "export_nothing_boundary",
+  "first_sale_demo_checklist",
+  "founder_demo_boundary",
+].sort();
+
+const EXPECTED_ARTEFACTS = [
+  "ci/locks/v0_export_nothing_scope.json",
+  "docs/commercial/V0_COACH_TIER_VALUE_CLAIM_REGISTRY.json",
+  "docs/commercial/V0_COACH_TIER_VALUE_PROOF_PACK.md",
+  "docs/commercial/V0_FIRST_SALE_DEMO_CHECKLIST.md",
+  "docs/commercial/V0_FIRST_SALE_DEMO_CHECKLIST_REGISTRY.json",
+  "docs/v1/V1_DECLARATION_ERROR_UX_CONTRACT.md",
+  "docs/v1/V1_EXPORT_NOTHING_V0_GUARD.md",
+  "docs/v1/V1_FOUNDER_DEMO_UI_COPY_LOCK.md",
+  "src/ui/copy/declaration_error_copy.ts",
+  "src/ui/copy/founder_demo_copy.ts",
+  "test/coach_tier_value_proof_pack.test.mjs",
+  "test/declaration_error_ux_contract.test.mjs",
+  "test/first_sale_demo_checklist.test.mjs",
+  "test/founder_demo_ui_copy_lock.test.mjs",
+  "test/v0_export_nothing_guard.test.mjs",
+].sort();
+
+function flattenArtefacts(registry) {
+  return registry.artefact_groups.flatMap((group) => group.artefacts);
+}
+
+test("coach demo artefact index registry is pinned exactly", () => {
+  const registry = readJson(registryPath);
+  assert.equal(registry.schema_version, "kolosseum.v0.coach_demo_artefact_index.v1.0.0");
+  const groupIds = registry.artefact_groups.map((group) => group.group_id).sort();
+  assert.deepEqual(groupIds, EXPECTED_GROUP_IDS);
+});
+
+test("every indexed artefact exists", () => {
+  const registry = readJson(registryPath);
+  for (const relPath of flattenArtefacts(registry)) {
+    assert.equal(fs.existsSync(path.join(repoRoot, relPath)), true, `missing indexed artefact: ${relPath}`);
+  }
+});
+
+test("indexed artefacts are duplicate-free and pinned exactly", () => {
+  const registry = readJson(registryPath);
+  const artefacts = flattenArtefacts(registry);
+  const unique = [...new Set(artefacts)].sort();
+  assert.equal(unique.length, artefacts.length, "duplicate artefact reference detected in coach demo artefact index");
+  assert.deepEqual(unique, EXPECTED_ARTEFACTS);
+});
+
+test("artefact index markdown contains all required group headings", () => {
+  const text = readText(indexPath);
+  const headings = [...text.matchAll(/^###\s+([a-z_]+)$/gm)].map((match) => match[1]).sort();
+  assert.deepEqual(headings, EXPECTED_GROUP_IDS);
+});
+
+test("artefact index markdown references every pinned artefact path", () => {
+  const text = readText(indexPath);
+  for (const relPath of EXPECTED_ARTEFACTS) {
+    assert.equal(text.includes(relPath), true, `artefact path missing from markdown index: ${relPath}`);
+  }
+});


### PR DESCRIPTION
## Summary
- add coach demo artefact index doc
- add pinned coach demo artefact registry
- add proof test for existence, duplicates, and broken references

## Proof
- npm run build:fast
- node --test test/coach_demo_artefact_index_lock.test.mjs