### PR TITLE
P165: add founder demo script lock

### DIFF
--- a/docs/commercial/V0_FOUNDER_DEMO_SCRIPT_LOCK.md
+++ b/docs/commercial/V0_FOUNDER_DEMO_SCRIPT_LOCK.md
@@ -1,0 +1,68 @@
+# V0 Founder Demo Script Lock
+
+Document ID: v0_founder_demo_script_lock
+Status: Draft for enforcement
+Scope: active v0 first coach call only
+Audience: Founder / Commercial / Review
+
+## Purpose
+
+Pin the exact spoken demo script for the first coach call.
+
+## Invariant
+
+- founder demo wording must stay inside implemented truth
+- every spoken claim must map to a pinned claim registry entry
+- banned commercial drift is forbidden in spoken sections
+- the founder must not improvise capability language outside active v0
+
+## Spoken script
+
+### opening
+
+Today I will show only what is implemented in active v0 for a coach.
+I will stay inside assignment, factual execution view, non-binding notes boundary, and factual history counts.
+If you ask about anything outside that boundary, I will mark it as not part of the current v0 demo.
+
+### assignment
+
+Coach can assign work within the active v0 coach path.
+That is the claim I am making here, and nothing broader.
+
+### execution_view
+
+Coach can view factual execution artefacts and summaries only.
+This is a factual view surface, not a scoring or advisory layer.
+
+### notes_boundary
+
+Coach notes are non-binding and do not alter engine legality or execution authority.
+Notes can exist, but they do not override the engine boundary.
+
+### history_counts
+
+Coach can view factual history counts only where the v0 surface exposes counts.
+This is a factual count surface, not a trend or compliance layer.
+
+### close
+
+That is the implemented coach demo boundary in active v0.
+I am not claiming compliance monitoring, accountability enforcement, readiness scoring, export, replay, override authority, or automatic coaching decisions.
+
+## Banned commercial drift reference
+
+- compliance monitoring
+- athlete accountability enforcement
+- readiness scoring
+- performance improvement claims
+- evidence export
+- proof replay
+- override authority
+- legal or safety assurance
+- automatic coaching decisions
+- analytics dashboard
+- trend scoring
+
+## Final rule
+
+If the spoken founder demo script makes a claim that cannot be traced to the pinned coach claim registry, the script has failed.

--- a/docs/commercial/V0_FOUNDER_DEMO_SCRIPT_LOCK_REGISTRY.json
+++ b/docs/commercial/V0_FOUNDER_DEMO_SCRIPT_LOCK_REGISTRY.json
@@ -1,0 +1,81 @@
+{
+    "schema_version":  "kolosseum.v0.founder_demo_script_lock.v1.0.0",
+    "generated_by":  "ticket/p165-founder-demo-script-lock",
+    "source_claim_registry":  "docs/commercial/V0_COACH_DEMO_SURFACE_CLAIM_MATRIX_REGISTRY.json",
+    "spoken_sections":  [
+                            {
+                                "section_id":  "opening",
+                                "allowed_claim_ids":  [
+
+                                                      ],
+                                "script_lines":  [
+                                                     "Today I will show only what is implemented in active v0 for a coach.",
+                                                     "I will stay inside assignment, factual execution view, non-binding notes boundary, and factual history counts.",
+                                                     "If you ask about anything outside that boundary, I will mark it as not part of the current v0 demo."
+                                                 ]
+                            },
+                            {
+                                "section_id":  "assignment",
+                                "allowed_claim_ids":  [
+                                                          "assignment"
+                                                      ],
+                                "script_lines":  [
+                                                     "Coach can assign work within the active v0 coach path.",
+                                                     "That is the claim I am making here, and nothing broader."
+                                                 ]
+                            },
+                            {
+                                "section_id":  "execution_view",
+                                "allowed_claim_ids":  [
+                                                          "execution_view"
+                                                      ],
+                                "script_lines":  [
+                                                     "Coach can view factual execution artefacts and summaries only.",
+                                                     "This is a factual view surface, not a scoring or advisory layer."
+                                                 ]
+                            },
+                            {
+                                "section_id":  "notes_boundary",
+                                "allowed_claim_ids":  [
+                                                          "notes_boundary"
+                                                      ],
+                                "script_lines":  [
+                                                     "Coach notes are non-binding and do not alter engine legality or execution authority.",
+                                                     "Notes can exist, but they do not override the engine boundary."
+                                                 ]
+                            },
+                            {
+                                "section_id":  "history_counts",
+                                "allowed_claim_ids":  [
+                                                          "history_counts"
+                                                      ],
+                                "script_lines":  [
+                                                     "Coach can view factual history counts only where the v0 surface exposes counts.",
+                                                     "This is a factual count surface, not a trend or compliance layer."
+                                                 ]
+                            },
+                            {
+                                "section_id":  "close",
+                                "allowed_claim_ids":  [
+
+                                                      ],
+                                "script_lines":  [
+                                                     "That is the implemented coach demo boundary in active v0.",
+                                                     "I am not claiming compliance monitoring, accountability enforcement, readiness scoring, export, replay, override authority, or automatic coaching decisions."
+                                                 ]
+                            }
+                        ],
+    "banned_drift_terms":  [
+                               "compliance monitoring",
+                               "athlete accountability enforcement",
+                               "readiness scoring",
+                               "performance improvement claims",
+                               "evidence export",
+                               "proof replay",
+                               "override authority",
+                               "legal or safety assurance",
+                               "automatic coaching decisions",
+                               "analytics dashboard",
+                               "trend scoring"
+                           ]
+}

--- a/test/founder_demo_script_lock.test.mjs
+++ b/test/founder_demo_script_lock.test.mjs
@@ -1,0 +1,125 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+
+const repoRoot = process.cwd();
+
+function readText(relPath) {
+  return fs.readFileSync(path.join(repoRoot, relPath), "utf8");
+}
+
+function readJson(relPath) {
+  return JSON.parse(readText(relPath));
+}
+
+const scriptPath = "docs/commercial/V0_FOUNDER_DEMO_SCRIPT_LOCK.md";
+const registryPath = "docs/commercial/V0_FOUNDER_DEMO_SCRIPT_LOCK_REGISTRY.json";
+const claimRegistryPath = "docs/commercial/V0_COACH_DEMO_SURFACE_CLAIM_MATRIX_REGISTRY.json";
+
+const EXPECTED_SECTION_IDS = [
+  "assignment",
+  "close",
+  "execution_view",
+  "history_counts",
+  "notes_boundary",
+  "opening",
+].sort();
+
+const EXPECTED_CLAIM_IDS = [
+  "assignment",
+  "execution_view",
+  "history_counts",
+  "notes_boundary",
+].sort();
+
+const BANNED_TERM_REGEXES = [
+  /\bcompliance monitoring\b/i,
+  /\bathlete accountability enforcement\b/i,
+  /\breadiness scoring\b/i,
+  /\bperformance improvement claims\b/i,
+  /\bevidence export\b/i,
+  /\bproof replay\b/i,
+  /\boverride authority\b/i,
+  /\blegal or safety assurance\b/i,
+  /\bautomatic coaching decisions\b/i,
+  /\banalytics dashboard\b/i,
+  /\btrend scoring\b/i,
+];
+
+function extractSections(text) {
+  const sections = new Map();
+  const matches = [...text.matchAll(/^###\s+([a-z_]+)\n([\s\S]*?)(?=^###\s+|^##\s+|\Z)/gm)];
+  for (const match of matches) {
+    sections.set(match[1], match[2].trim());
+  }
+  return sections;
+}
+
+function assertNoBannedDrift(label, value) {
+  for (const rx of BANNED_TERM_REGEXES) {
+    assert.equal(rx.test(value), false, `banned commercial drift in ${label}: ${value}`);
+  }
+}
+
+test("founder demo script lock registry is pinned exactly", () => {
+  const registry = readJson(registryPath);
+  assert.equal(registry.schema_version, "kolosseum.v0.founder_demo_script_lock.v1.0.0");
+  assert.equal(registry.source_claim_registry, claimRegistryPath);
+  const sectionIds = registry.spoken_sections.map((section) => section.section_id).sort();
+  assert.deepEqual(sectionIds, EXPECTED_SECTION_IDS);
+});
+
+test("all claim-bearing script sections map only to pinned claim registry ids", () => {
+  const scriptRegistry = readJson(registryPath);
+  const claimRegistry = readJson(claimRegistryPath);
+  const claimIds = new Set(claimRegistry.claims.map((claim) => claim.claim_id));
+  assert.deepEqual([...claimIds].sort(), EXPECTED_CLAIM_IDS);
+  for (const section of scriptRegistry.spoken_sections) {
+    for (const claimId of section.allowed_claim_ids) {
+      assert.equal(claimIds.has(claimId), true, `orphan claim id in spoken section ${section.section_id}: ${claimId}`);
+    }
+  }
+});
+
+test("spoken claim sections contain only allowed claim text and no banned drift", () => {
+  const scriptRegistry = readJson(registryPath);
+  const claimRegistry = readJson(claimRegistryPath);
+  const claimMap = new Map(claimRegistry.claims.map((claim) => [claim.claim_id, claim.claim_text]));
+  for (const section of scriptRegistry.spoken_sections) {
+    const joined = section.script_lines.join(" ");
+    if (section.allowed_claim_ids.length > 0) {
+      for (const claimId of section.allowed_claim_ids) {
+        assert.equal(joined.includes(claimMap.get(claimId)), true, `missing mapped claim text ${claimId} in section ${section.section_id}`);
+      }
+      assertNoBannedDrift(section.section_id, joined);
+    }
+  }
+});
+
+test("script markdown contains exactly the pinned spoken sections", () => {
+  const text = readText(scriptPath);
+  const headings = [...text.matchAll(/^###\s+([a-z_]+)$/gm)].map((match) => match[1]).sort();
+  assert.deepEqual(headings, EXPECTED_SECTION_IDS);
+});
+
+test("registry script lines are rendered in markdown for every spoken section", () => {
+  const registry = readJson(registryPath);
+  const text = readText(scriptPath);
+  const sections = extractSections(text);
+  for (const spokenSection of registry.spoken_sections) {
+    const markdownSection = sections.get(spokenSection.section_id);
+    assert.ok(markdownSection, `missing markdown section for ${spokenSection.section_id}`);
+    for (const line of spokenSection.script_lines) {
+      assert.equal(markdownSection.includes(line), true, `missing script line in ${spokenSection.section_id}: ${line}`);
+    }
+  }
+});
+
+test("banned drift reference section exists in markdown without polluting spoken claim checks", () => {
+  const text = readText(scriptPath);
+  assert.equal(text.includes("## Banned commercial drift reference"), true);
+  for (const term of readJson(registryPath).banned_drift_terms) {
+    assert.equal(text.includes(term), true, `missing banned drift reference term: ${term}`);
+  }
+});


### PR DESCRIPTION
## Summary
- add pinned founder demo script for first coach call
- add registry mapping spoken sections to allowed claim ids
- add proof test for claim-registry alignment and banned drift failure

## Proof
- npm run build:fast
- node --test test/founder_demo_script_lock.test.mjs