### PR TITLE
docs(commercial): lock coach tier pricing boundary

### DIFF
--- a/ci/scripts/run_coach_tier_pricing_boundary_lint.mjs
+++ b/ci/scripts/run_coach_tier_pricing_boundary_lint.mjs
@@ -1,0 +1,197 @@
+import fs from "node:fs";
+import path from "node:path";
+
+function readJson(filePath) {
+  return JSON.parse(fs.readFileSync(filePath, "utf8"));
+}
+
+function makeFailure(token, file, pathValue, details) {
+  return {
+    token,
+    file,
+    path: pathValue,
+    details
+  };
+}
+
+function isNonEmptyString(value) {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+export function runCoachTierPricingBoundaryLint({
+  claimsPath,
+  proofPath,
+  surfacePath
+}) {
+  const failures = [];
+
+  const claimsDoc = readJson(claimsPath);
+  const proofDoc = readJson(proofPath);
+  const surfaceDoc = readJson(surfacePath);
+
+  const claims = Array.isArray(claimsDoc.claims) ? claimsDoc.claims : [];
+  const proofs = Array.isArray(proofDoc.proofs) ? proofDoc.proofs : [];
+  const phrases = Array.isArray(surfaceDoc.phrases) ? surfaceDoc.phrases : [];
+
+  const claimIds = new Set();
+  const proofIds = new Set();
+
+  for (let i = 0; i < claims.length; i += 1) {
+    const claim = claims[i];
+    const claimPath = `claims[${i}]`;
+
+    if (!isNonEmptyString(claim.claim_id)) {
+      failures.push(makeFailure("CI_REGISTRY_STRUCTURE_INVALID", claimsPath, `${claimPath}.claim_id`, "claim_id must be a non-empty string."));
+      continue;
+    }
+
+    if (claimIds.has(claim.claim_id)) {
+      failures.push(makeFailure("CI_REGISTRY_STRUCTURE_INVALID", claimsPath, `${claimPath}.claim_id`, `Duplicate claim_id '${claim.claim_id}'.`));
+    }
+    claimIds.add(claim.claim_id);
+
+    if (claim.status !== "allowed") {
+      failures.push(makeFailure("CI_REGISTRY_STRUCTURE_INVALID", claimsPath, `${claimPath}.status`, `Only 'allowed' claims are supported by this slice. Found '${claim.status}'.`));
+    }
+
+    if (claim.tier_id !== "coach_16") {
+      failures.push(makeFailure("CI_TIER_VIOLATION", claimsPath, `${claimPath}.tier_id`, `Coach pricing boundary is locked to coach_16. Found '${claim.tier_id}'.`));
+    }
+
+    if (claim.v0_scope_only !== true) {
+      failures.push(makeFailure("CI_SCOPE_VIOLATION", claimsPath, `${claimPath}.v0_scope_only`, "All coach pricing claims must be v0-scope-only."));
+    }
+
+    if (!Array.isArray(claim.proof_ids) || claim.proof_ids.length === 0) {
+      failures.push(makeFailure("CI_CONSTRAINT_UNUSED", claimsPath, `${claimPath}.proof_ids`, `Claim '${claim.claim_id}' has no proof linkage.`));
+    }
+
+    if (!isNonEmptyString(claim.claim_text)) {
+      failures.push(makeFailure("CI_REGISTRY_STRUCTURE_INVALID", claimsPath, `${claimPath}.claim_text`, "claim_text must be a non-empty string."));
+    }
+  }
+
+  const forbiddenPatterns = Array.isArray(claimsDoc.forbidden_semantic_patterns)
+    ? claimsDoc.forbidden_semantic_patterns.map((rule) => ({
+        ...rule,
+        compiled: new RegExp(rule.regex, "i")
+      }))
+    : [];
+
+  const proofById = new Map();
+  for (let i = 0; i < proofs.length; i += 1) {
+    const proof = proofs[i];
+    const proofPathValue = `proofs[${i}]`;
+
+    if (!isNonEmptyString(proof.proof_id)) {
+      failures.push(makeFailure("CI_REGISTRY_STRUCTURE_INVALID", proofPath, `${proofPathValue}.proof_id`, "proof_id must be a non-empty string."));
+      continue;
+    }
+
+    if (proofIds.has(proof.proof_id)) {
+      failures.push(makeFailure("CI_REGISTRY_STRUCTURE_INVALID", proofPath, `${proofPathValue}.proof_id`, `Duplicate proof_id '${proof.proof_id}'.`));
+    }
+    proofIds.add(proof.proof_id);
+    proofById.set(proof.proof_id, proof);
+
+    if (!Array.isArray(proof.supported_claim_ids) || proof.supported_claim_ids.length === 0) {
+      failures.push(makeFailure("CI_CONSTRAINT_UNUSED", proofPath, `${proofPathValue}.supported_claim_ids`, `Proof '${proof.proof_id}' does not support any claims.`));
+    }
+
+    for (let j = 0; j < (proof.supported_claim_ids || []).length; j += 1) {
+      const claimId = proof.supported_claim_ids[j];
+      if (!claimIds.has(claimId)) {
+        failures.push(makeFailure("CI_FOREIGN_KEY_FAILURE", proofPath, `${proofPathValue}.supported_claim_ids[${j}]`, `Proof '${proof.proof_id}' references missing claim '${claimId}'.`));
+      }
+    }
+  }
+
+  const claimTextToId = new Map();
+
+  for (let i = 0; i < claims.length; i += 1) {
+    const claim = claims[i];
+    if (!isNonEmptyString(claim.claim_text)) {
+      continue;
+    }
+
+    if (claimTextToId.has(claim.claim_text)) {
+      failures.push(makeFailure("CI_REGISTRY_STRUCTURE_INVALID", claimsPath, `claims[${i}].claim_text`, `Duplicate claim_text '${claim.claim_text}'.`));
+    }
+    claimTextToId.set(claim.claim_text, claim.claim_id);
+
+    for (const rule of forbiddenPatterns) {
+      if (rule.compiled.test(claim.claim_text)) {
+        failures.push(makeFailure(rule.token || "CI_LINT_FORBIDDEN_CLAIM_SEMANTIC", claimsPath, `claims[${i}].claim_text`, `Claim text '${claim.claim_text}' matches forbidden pricing pattern '${rule.pattern_id}'.`));
+      }
+    }
+
+    for (const proofId of claim.proof_ids || []) {
+      if (!proofById.has(proofId)) {
+        failures.push(makeFailure("CI_CONSTRAINT_UNUSED", claimsPath, `claims[${i}].proof_ids`, `Claim '${claim.claim_id}' references missing proof '${proofId}'.`));
+        continue;
+      }
+
+      const proof = proofById.get(proofId);
+      if (!Array.isArray(proof.supported_claim_ids) || !proof.supported_claim_ids.includes(claim.claim_id)) {
+        failures.push(makeFailure("CI_CONSTRAINT_UNUSED", claimsPath, `claims[${i}].proof_ids`, `Proof '${proofId}' does not reciprocally support claim '${claim.claim_id}'.`));
+      }
+    }
+  }
+
+  const phraseSeen = new Set();
+  for (let i = 0; i < phrases.length; i += 1) {
+    const phrase = phrases[i];
+    const phrasePath = `phrases[${i}]`;
+
+    if (!isNonEmptyString(phrase)) {
+      failures.push(makeFailure("CI_REGISTRY_STRUCTURE_INVALID", surfacePath, phrasePath, "Pricing phrase must be a non-empty string."));
+      continue;
+    }
+
+    if (phraseSeen.has(phrase)) {
+      failures.push(makeFailure("CI_REGISTRY_STRUCTURE_INVALID", surfacePath, phrasePath, `Duplicate surfaced phrase '${phrase}'.`));
+    }
+    phraseSeen.add(phrase);
+
+    for (const rule of forbiddenPatterns) {
+      if (rule.compiled.test(phrase)) {
+        failures.push(makeFailure(rule.token || "CI_LINT_FORBIDDEN_CLAIM_SEMANTIC", surfacePath, phrasePath, `Surfaced phrase '${phrase}' matches forbidden pricing pattern '${rule.pattern_id}'.`));
+      }
+    }
+
+    if (!claimTextToId.has(phrase)) {
+      failures.push(makeFailure("CI_LINT_COPY_INLINE_STRING", surfacePath, phrasePath, `Surfaced phrase '${phrase}' is not backed by the coach-tier claim registry.`));
+    }
+  }
+
+  return {
+    ok: failures.length === 0,
+    failures
+  };
+}
+
+function main() {
+  const repoRoot = process.cwd();
+
+  const claimsPath = process.argv[2] || path.join(repoRoot, "docs/commercial/COACH_TIER_PRICING_CLAIM_REGISTRY.json");
+  const proofPath = process.argv[3] || path.join(repoRoot, "docs/commercial/COACH_TIER_VALUE_PROOF_PACK.json");
+  const surfacePath = process.argv[4] || path.join(repoRoot, "docs/commercial/COACH_TIER_PRICING_COPY_SURFACE.json");
+
+  const report = runCoachTierPricingBoundaryLint({
+    claimsPath,
+    proofPath,
+    surfacePath
+  });
+
+  const output = JSON.stringify(report, null, 2);
+  if (!report.ok) {
+    process.stderr.write(output + "\n");
+    process.exit(1);
+  }
+
+  process.stdout.write(output + "\n");
+}
+
+if (import.meta.url === new URL(`file://${process.argv[1]}`).href) {
+  main();
+}

--- a/docs/commercial/COACH_TIER_PRICING_BOUNDARY_LOCK.md
+++ b/docs/commercial/COACH_TIER_PRICING_BOUNDARY_LOCK.md
@@ -1,0 +1,123 @@
+# COACH TIER PRICING BOUNDARY LOCK
+
+Document ID: coach_tier_pricing_boundary_lock  
+Version: 1.0.0  
+Status: Draft slice proof  
+Scope: Active v0 only  
+Rewrite policy: rewrite-only
+
+## Purpose
+
+This document defines the only lawful claims that may appear in coach-tier pricing context for the active v0 coach surface.
+
+This boundary exists to stop pricing copy from outrunning:
+- the active v0 coach capability boundary
+- the active coach authority boundary
+- the available value proof pack
+
+## Active v0 scope lock
+
+Coach-tier pricing for the current v0 build is locked to `coach_16` only.
+
+Pricing copy MUST remain within the active v0 build fence:
+- individual_user and coach only
+- individual and coach_managed execution only
+- powerlifting, rugby_union, and general_strength only
+- Phase 1 through Phase 6 only
+- coach assign/view/note surface only
+- no replay access
+- no evidence access
+- no legality override
+- no substitution authority
+- no progression authority
+- no registry authority
+- no Phase-1 edit authority
+
+## Allowed pricing claim classes
+
+Only the following claim classes may appear in coach-tier pricing context:
+
+- `price_fact`
+- `seat_cap_fact`
+- `access_fact`
+- `visibility_fact`
+- `authority_limit`
+- `proof_scoped_value`
+
+## Allowed coach-tier value boundary
+
+Coach-tier pricing copy MAY say only that coach tier allows the coach to:
+
+- assign programs within system limits
+- view athlete execution artefacts
+- write non-binding coach notes
+- manage athlete lists up to the tier cap
+- request session planning within system limits
+- operate with observational-only authority
+
+Coach-tier pricing copy MAY say only that coach tier does NOT allow the coach to:
+
+- override engine decisions
+- change constraints
+- trigger substitutions
+- edit registries
+- edit Phase-1 declarations
+- see unmanaged athletes
+- see aggregate organisation data
+- access replay
+- access evidence
+
+## Forbidden pricing categories
+
+Coach-tier pricing copy MUST NOT include any claim that implies or states:
+
+- outcome improvement
+- optimisation
+- safety
+- injury reduction
+- medical or rehab semantics
+- suitability
+- readiness
+- compliance enforcement
+- correction
+- recommendation
+- hidden engine authority
+- replay-backed coach authority
+- evidence-backed coach authority
+- program validity changes caused by payment
+- substitutions controlled by coach tier
+- progression controlled by coach tier
+- legality controlled by coach tier
+
+## Proof rule
+
+Every allowed pricing claim MUST map to at least one proof item in the coach-tier value proof pack.
+
+If a surfaced pricing phrase has no matching registered claim with valid proof support, it is unlawful and must fail.
+
+## Lint rule
+
+The pricing boundary lint MUST fail closed.
+
+It MUST fail when:
+- a surfaced pricing phrase does not exactly match a registered allowed claim
+- a surfaced pricing phrase matches a forbidden semantic pattern
+- an allowed claim has no valid proof linkage
+- a proof item references a missing claim
+- a proof-backed claim exceeds active v0 coach scope
+- duplicate claim IDs or duplicate proof IDs exist
+
+## Canonical coach-tier summary for active v0
+
+Use only this value frame for active v0 pricing context:
+
+- assign programs within system limits
+- view athlete execution artefacts
+- write non-binding coach notes
+- manage up to 16 athletes
+- observational only
+- coaches may comment, never decide
+
+## Final rule
+
+If coach-tier pricing copy says more than the active coach proof pack can prove, it must fail.

--- a/docs/commercial/COACH_TIER_PRICING_CLAIM_REGISTRY.json
+++ b/docs/commercial/COACH_TIER_PRICING_CLAIM_REGISTRY.json
@@ -1,0 +1,159 @@
+{
+  "schema_version": "kolosseum.coach_tier_pricing_claim_registry.v1.0.0",
+  "scope": "active_v0_only",
+  "tier_id": "coach_16",
+  "claims": [
+    {
+      "claim_id": "coach_16_price_month",
+      "tier_id": "coach_16",
+      "claim_text": "£59.99 per month.",
+      "claim_class": "price_fact",
+      "proof_ids": [
+        "proof_pricing_row_coach_16"
+      ],
+      "v0_scope_only": true,
+      "status": "allowed"
+    },
+    {
+      "claim_id": "coach_16_capacity",
+      "tier_id": "coach_16",
+      "claim_text": "Manage up to 16 athletes.",
+      "claim_class": "seat_cap_fact",
+      "proof_ids": [
+        "proof_pricing_row_coach_16"
+      ],
+      "v0_scope_only": true,
+      "status": "allowed"
+    },
+    {
+      "claim_id": "coach_assign_within_system_limits",
+      "tier_id": "coach_16",
+      "claim_text": "Assign programs within system limits.",
+      "claim_class": "access_fact",
+      "proof_ids": [
+        "proof_coach_gets_assign_within_system_limits"
+      ],
+      "v0_scope_only": true,
+      "status": "allowed"
+    },
+    {
+      "claim_id": "coach_view_execution_artefacts",
+      "tier_id": "coach_16",
+      "claim_text": "View athlete execution artefacts.",
+      "claim_class": "visibility_fact",
+      "proof_ids": [
+        "proof_coach_gets_view_execution_artefacts"
+      ],
+      "v0_scope_only": true,
+      "status": "allowed"
+    },
+    {
+      "claim_id": "coach_write_non_binding_notes",
+      "tier_id": "coach_16",
+      "claim_text": "Write non-binding coach notes.",
+      "claim_class": "proof_scoped_value",
+      "proof_ids": [
+        "proof_coach_gets_non_binding_notes",
+        "proof_coach_notes_non_authoritative"
+      ],
+      "v0_scope_only": true,
+      "status": "allowed"
+    },
+    {
+      "claim_id": "coach_observational_only",
+      "tier_id": "coach_16",
+      "claim_text": "Observational only.",
+      "claim_class": "authority_limit",
+      "proof_ids": [
+        "proof_coach_authority_observational_only"
+      ],
+      "v0_scope_only": true,
+      "status": "allowed"
+    },
+    {
+      "claim_id": "coach_comment_never_decide",
+      "tier_id": "coach_16",
+      "claim_text": "Coaches may comment, never decide.",
+      "claim_class": "authority_limit",
+      "proof_ids": [
+        "proof_coach_core_rule_comment_never_decide"
+      ],
+      "v0_scope_only": true,
+      "status": "allowed"
+    },
+    {
+      "claim_id": "coach_cannot_override_engine",
+      "tier_id": "coach_16",
+      "claim_text": "Does not allow overriding engine decisions.",
+      "claim_class": "authority_limit",
+      "proof_ids": [
+        "proof_coach_does_not_get_override_engine_decisions",
+        "proof_coach_must_not_override_engine_decisions"
+      ],
+      "v0_scope_only": true,
+      "status": "allowed"
+    },
+    {
+      "claim_id": "coach_cannot_change_constraints",
+      "tier_id": "coach_16",
+      "claim_text": "Does not allow changing constraints.",
+      "claim_class": "authority_limit",
+      "proof_ids": [
+        "proof_coach_does_not_get_change_constraints"
+      ],
+      "v0_scope_only": true,
+      "status": "allowed"
+    },
+    {
+      "claim_id": "coach_cannot_trigger_substitutions",
+      "tier_id": "coach_16",
+      "claim_text": "Does not allow triggering substitutions.",
+      "claim_class": "authority_limit",
+      "proof_ids": [
+        "proof_coach_does_not_get_trigger_substitutions",
+        "proof_coach_must_not_trigger_substitutions"
+      ],
+      "v0_scope_only": true,
+      "status": "allowed"
+    },
+    {
+      "claim_id": "coach_cannot_access_replay_or_evidence",
+      "tier_id": "coach_16",
+      "claim_text": "Does not include replay or evidence access.",
+      "claim_class": "authority_limit",
+      "proof_ids": [
+        "proof_coach_does_not_get_replay_access",
+        "proof_coach_does_not_get_evidence_access"
+      ],
+      "v0_scope_only": true,
+      "status": "allowed"
+    }
+  ],
+  "forbidden_semantic_patterns": [
+    {
+      "pattern_id": "forbidden_outcome_improvement",
+      "regex": "\\b(better outcomes?|improve(?:d|ment|s)?|performance gains?|results?)\\b",
+      "token": "CI_LINT_FORBIDDEN_CLAIM_SEMANTIC"
+    },
+    {
+      "pattern_id": "forbidden_optimisation",
+      "regex": "\\b(optimi[sz](?:e|ed|es|ing|ation)|maximi[sz](?:e|ed|es|ing|ation)|best|faster|proven)\\b",
+      "token": "CI_LINT_FORBIDDEN_CLAIM_SEMANTIC"
+    },
+    {
+      "pattern_id": "forbidden_safety_medical",
+      "regex": "\\b(safe|safer|safety|injur(?:y|ies)|rehab(?:ilit(?:ation)?)?|medical|clinical|therapy|treatment|protect(?:ion)?|prevent(?:ion)?)\\b",
+      "token": "CI_LINT_FORBIDDEN_CLAIM_SEMANTIC"
+    },
+    {
+      "pattern_id": "forbidden_suitability_readiness",
+      "regex": "\\b(suitable|suitability|appropriate|readiness|ready|right for you|ideal for you)\\b",
+      "token": "CI_LINT_FORBIDDEN_CLAIM_SEMANTIC"
+    },
+    {
+      "pattern_id": "forbidden_hidden_authority",
+      "regex": "\\b(override|control legality|change legality|trigger substitutions?|edit registr(?:y|ies)|edit phase[- ]?1|proof[- ]backed authority|evidence[- ]backed authority|replay[- ]backed authority)\\b",
+      "token": "CI_LINT_FORBIDDEN_CLAIM_SEMANTIC"
+    }
+  ]
+}

--- a/docs/commercial/COACH_TIER_PRICING_COPY_SURFACE.json
+++ b/docs/commercial/COACH_TIER_PRICING_COPY_SURFACE.json
@@ -1,0 +1,17 @@
+{
+  "schema_version": "kolosseum.coach_tier_pricing_copy_surface.v1.0.0",
+  "tier_id": "coach_16",
+  "phrases": [
+    "£59.99 per month.",
+    "Manage up to 16 athletes.",
+    "Assign programs within system limits.",
+    "View athlete execution artefacts.",
+    "Write non-binding coach notes.",
+    "Observational only.",
+    "Coaches may comment, never decide.",
+    "Does not allow overriding engine decisions.",
+    "Does not allow changing constraints.",
+    "Does not allow triggering substitutions.",
+    "Does not include replay or evidence access."
+  ]
+}

--- a/docs/commercial/COACH_TIER_VALUE_PROOF_PACK.json
+++ b/docs/commercial/COACH_TIER_VALUE_PROOF_PACK.json
@@ -1,0 +1,133 @@
+{
+  "schema_version": "kolosseum.coach_tier_value_proof_pack.v1.0.0",
+  "scope": "active_v0_only",
+  "proofs": [
+    {
+      "proof_id": "proof_pricing_row_coach_16",
+      "source_doc": "_commercial_pricing - v0 fenced.docx",
+      "source_anchor": "Coach Pricing Table / Coach 16",
+      "summary": "Coach 16 is priced at £59.99 per month and covers 7-16 athletes.",
+      "supported_claim_ids": [
+        "coach_16_price_month",
+        "coach_16_capacity"
+      ]
+    },
+    {
+      "proof_id": "proof_coach_gets_assign_within_system_limits",
+      "source_doc": "_commercial_pricing - v0 fenced.docx",
+      "source_anchor": "Coach / Gets / Assign programs within system limits",
+      "summary": "Coach tier includes assigning programs within system limits.",
+      "supported_claim_ids": [
+        "coach_assign_within_system_limits"
+      ]
+    },
+    {
+      "proof_id": "proof_coach_gets_view_execution_artefacts",
+      "source_doc": "_commercial_pricing - v0 fenced.docx",
+      "source_anchor": "Coach / Gets / View athlete execution artefacts",
+      "summary": "Coach tier includes viewing athlete execution artefacts.",
+      "supported_claim_ids": [
+        "coach_view_execution_artefacts"
+      ]
+    },
+    {
+      "proof_id": "proof_coach_gets_non_binding_notes",
+      "source_doc": "_commercial_pricing - v0 fenced.docx",
+      "source_anchor": "Coach / Gets / Write coach notes (non-binding)",
+      "summary": "Coach tier includes non-binding coach notes.",
+      "supported_claim_ids": [
+        "coach_write_non_binding_notes"
+      ]
+    },
+    {
+      "proof_id": "proof_coach_authority_observational_only",
+      "source_doc": "_commercial_pricing - v0 fenced.docx",
+      "source_anchor": "Coach / Authority: Observational only (per law)",
+      "summary": "Coach tier authority is observational only.",
+      "supported_claim_ids": [
+        "coach_observational_only"
+      ]
+    },
+    {
+      "proof_id": "proof_coach_core_rule_comment_never_decide",
+      "source_doc": "_commercial_pricing - v0 fenced.docx",
+      "source_anchor": "Coach / Core rule",
+      "summary": "The coach core rule states that coaches may comment, never decide.",
+      "supported_claim_ids": [
+        "coach_comment_never_decide"
+      ]
+    },
+    {
+      "proof_id": "proof_coach_does_not_get_override_engine_decisions",
+      "source_doc": "_commercial_pricing - v0 fenced.docx",
+      "source_anchor": "Coach / Does NOT get / Override engine decisions",
+      "summary": "Coach tier does not allow overriding engine decisions.",
+      "supported_claim_ids": [
+        "coach_cannot_override_engine"
+      ]
+    },
+    {
+      "proof_id": "proof_coach_does_not_get_change_constraints",
+      "source_doc": "_commercial_pricing - v0 fenced.docx",
+      "source_anchor": "Coach / Does NOT get / Change constraints",
+      "summary": "Coach tier does not allow changing constraints.",
+      "supported_claim_ids": [
+        "coach_cannot_change_constraints"
+      ]
+    },
+    {
+      "proof_id": "proof_coach_does_not_get_trigger_substitutions",
+      "source_doc": "_commercial_pricing - v0 fenced.docx",
+      "source_anchor": "Coach / Does NOT get / Trigger substitutions",
+      "summary": "Coach tier does not allow triggering substitutions.",
+      "supported_claim_ids": [
+        "coach_cannot_trigger_substitutions"
+      ]
+    },
+    {
+      "proof_id": "proof_coach_does_not_get_replay_access",
+      "source_doc": "_commercial_pricing - v0 fenced.docx",
+      "source_anchor": "Coach / Does NOT get / Evidence / replay access",
+      "summary": "Coach tier does not include replay access.",
+      "supported_claim_ids": [
+        "coach_cannot_access_replay_or_evidence"
+      ]
+    },
+    {
+      "proof_id": "proof_coach_does_not_get_evidence_access",
+      "source_doc": "_commercial_pricing - v0 fenced.docx",
+      "source_anchor": "Coach / Does NOT get / Evidence / replay access",
+      "summary": "Coach tier does not include evidence access.",
+      "supported_claim_ids": [
+        "coach_cannot_access_replay_or_evidence"
+      ]
+    },
+    {
+      "proof_id": "proof_coach_notes_non_authoritative",
+      "source_doc": "coach_relationship_authority_law",
+      "source_anchor": "Section 3.1 Coach Notes",
+      "summary": "Coach notes are non-binding, non-authoritative, non-executable, and must not influence execution or evidence.",
+      "supported_claim_ids": [
+        "coach_write_non_binding_notes"
+      ]
+    },
+    {
+      "proof_id": "proof_coach_must_not_override_engine_decisions",
+      "source_doc": "coach_relationship_authority_law",
+      "source_anchor": "Section 2.2 What a Coach MUST NOT Do",
+      "summary": "Coach authority excludes overriding engine decisions.",
+      "supported_claim_ids": [
+        "coach_cannot_override_engine"
+      ]
+    },
+    {
+      "proof_id": "proof_coach_must_not_trigger_substitutions",
+      "source_doc": "coach_relationship_authority_law",
+      "source_anchor": "Section 2.2 What a Coach MUST NOT Do",
+      "summary": "Coach authority excludes triggering substitutions.",
+      "supported_claim_ids": [
+        "coach_cannot_trigger_substitutions"
+      ]
+    }
+  ]
+}

--- a/test/coach_tier_pricing_boundary_lint.test.mjs
+++ b/test/coach_tier_pricing_boundary_lint.test.mjs
@@ -1,0 +1,143 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { runCoachTierPricingBoundaryLint } from "../ci/scripts/run_coach_tier_pricing_boundary_lint.mjs";
+
+function writeJson(filePath, value) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, JSON.stringify(value, null, 2) + "\n", "utf8");
+}
+
+function makeTempCase({ claims, proofs, surface }) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "coach-tier-pricing-boundary-"));
+  const claimsPath = path.join(dir, "claims.json");
+  const proofPath = path.join(dir, "proofs.json");
+  const surfacePath = path.join(dir, "surface.json");
+
+  writeJson(claimsPath, claims);
+  writeJson(proofPath, proofs);
+  writeJson(surfacePath, surface);
+
+  return { claimsPath, proofPath, surfacePath };
+}
+
+function baseClaims() {
+  return {
+    schema_version: "kolosseum.coach_tier_pricing_claim_registry.v1.0.0",
+    scope: "active_v0_only",
+    tier_id: "coach_16",
+    claims: [
+      {
+        claim_id: "coach_16_price_month",
+        tier_id: "coach_16",
+        claim_text: "£59.99 per month.",
+        claim_class: "price_fact",
+        proof_ids: ["proof_pricing_row_coach_16"],
+        v0_scope_only: true,
+        status: "allowed"
+      },
+      {
+        claim_id: "coach_assign_within_system_limits",
+        tier_id: "coach_16",
+        claim_text: "Assign programs within system limits.",
+        claim_class: "access_fact",
+        proof_ids: ["proof_assign"],
+        v0_scope_only: true,
+        status: "allowed"
+      }
+    ],
+    forbidden_semantic_patterns: [
+      {
+        pattern_id: "forbidden_optimisation",
+        regex: "\\b(optimi[sz](?:e|ed|es|ing|ation)|better outcomes?)\\b",
+        token: "CI_LINT_FORBIDDEN_CLAIM_SEMANTIC"
+      }
+    ]
+  };
+}
+
+function baseProofs() {
+  return {
+    schema_version: "kolosseum.coach_tier_value_proof_pack.v1.0.0",
+    scope: "active_v0_only",
+    proofs: [
+      {
+        proof_id: "proof_pricing_row_coach_16",
+        source_doc: "_commercial_pricing - v0 fenced.docx",
+        source_anchor: "Coach Pricing Table / Coach 16",
+        summary: "Coach 16 price proof.",
+        supported_claim_ids: ["coach_16_price_month"]
+      },
+      {
+        proof_id: "proof_assign",
+        source_doc: "_commercial_pricing - v0 fenced.docx",
+        source_anchor: "Coach / Gets / Assign programs within system limits",
+        summary: "Assign within system limits proof.",
+        supported_claim_ids: ["coach_assign_within_system_limits"]
+      }
+    ]
+  };
+}
+
+function baseSurface() {
+  return {
+    schema_version: "kolosseum.coach_tier_pricing_copy_surface.v1.0.0",
+    tier_id: "coach_16",
+    phrases: [
+      "£59.99 per month.",
+      "Assign programs within system limits."
+    ]
+  };
+}
+
+test("passes on the repo coach-tier pricing proof slice", () => {
+  const report = runCoachTierPricingBoundaryLint({
+    claimsPath: path.resolve("docs/commercial/COACH_TIER_PRICING_CLAIM_REGISTRY.json"),
+    proofPath: path.resolve("docs/commercial/COACH_TIER_VALUE_PROOF_PACK.json"),
+    surfacePath: path.resolve("docs/commercial/COACH_TIER_PRICING_COPY_SURFACE.json")
+  });
+
+  assert.equal(report.ok, true, JSON.stringify(report, null, 2));
+  assert.equal(report.failures.length, 0, JSON.stringify(report, null, 2));
+});
+
+test("fails when surfaced pricing copy uses forbidden optimisation language", () => {
+  const claims = baseClaims();
+  const proofs = baseProofs();
+  const surface = baseSurface();
+  surface.phrases.push("Optimised coaching decisions.");
+
+  const files = makeTempCase({ claims, proofs, surface });
+  const report = runCoachTierPricingBoundaryLint(files);
+
+  assert.equal(report.ok, false);
+  assert.ok(report.failures.some((failure) => failure.token === "CI_LINT_FORBIDDEN_CLAIM_SEMANTIC"), JSON.stringify(report, null, 2));
+});
+
+test("fails when a surfaced pricing phrase is not registered", () => {
+  const claims = baseClaims();
+  const proofs = baseProofs();
+  const surface = baseSurface();
+  surface.phrases.push("Centralise coach workflow.");
+
+  const files = makeTempCase({ claims, proofs, surface });
+  const report = runCoachTierPricingBoundaryLint(files);
+
+  assert.equal(report.ok, false);
+  assert.ok(report.failures.some((failure) => failure.token === "CI_LINT_COPY_INLINE_STRING"), JSON.stringify(report, null, 2));
+});
+
+test("fails when an allowed claim has no proof linkage", () => {
+  const claims = baseClaims();
+  claims.claims[1].proof_ids = [];
+  const proofs = baseProofs();
+  const surface = baseSurface();
+
+  const files = makeTempCase({ claims, proofs, surface });
+  const report = runCoachTierPricingBoundaryLint(files);
+
+  assert.equal(report.ok, false);
+  assert.ok(report.failures.some((failure) => failure.token === "CI_CONSTRAINT_UNUSED"), JSON.stringify(report, null, 2));
+});


### PR DESCRIPTION
## Summary
- add coach tier pricing boundary lock for active v0
- add coach tier pricing claim registry and value proof pack
- add surfaced coach pricing copy file
- add coach tier pricing boundary lint and targeted proof tests

## Proof
- node --test test/coach_tier_pricing_boundary_lint.test.mjs
- node ci/scripts/run_coach_tier_pricing_boundary_lint.mjs

## Notes
- locks pricing copy to the stricter active v0 coach boundary
- prevents pricing claims from outrunning proof-backed coach capabilities