### PR TITLE
docs(commercial): add minimal coach onboarding pack

### DIFF
--- a/ci/scripts/run_minimal_coach_onboarding_pack_lint.mjs
+++ b/ci/scripts/run_minimal_coach_onboarding_pack_lint.mjs
@@ -1,0 +1,248 @@
+import fs from "node:fs";
+import path from "node:path";
+
+function readJson(filePath) {
+  return JSON.parse(fs.readFileSync(filePath, "utf8"));
+}
+
+function makeFailure(token, file, pathValue, details) {
+  return {
+    token,
+    file,
+    path: pathValue,
+    details
+  };
+}
+
+function isNonEmptyString(value) {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+export function runMinimalCoachOnboardingPackLint({
+  registryPath,
+  surfaceMapPath,
+  copySurfacePath
+}) {
+  const failures = [];
+
+  const registryDoc = readJson(registryPath);
+  const surfaceMapDoc = readJson(surfaceMapPath);
+  const copySurfaceDoc = readJson(copySurfacePath);
+
+  const steps = Array.isArray(registryDoc.steps) ? registryDoc.steps : [];
+  const forbiddenPatterns = Array.isArray(registryDoc.forbidden_prompt_patterns)
+    ? registryDoc.forbidden_prompt_patterns.map((rule) => ({
+        ...rule,
+        compiled: new RegExp(rule.regex, "i")
+      }))
+    : [];
+
+  const allowedLive = new Set(
+    (surfaceMapDoc.allowed_live_surfaces || []).map((entry) => entry.surface_id)
+  );
+  const allowedManual = new Set(
+    (surfaceMapDoc.allowed_manual_operator_steps || []).map((entry) => entry.surface_id)
+  );
+
+  const stepToSurface = new Map();
+  for (let i = 0; i < (surfaceMapDoc.step_to_surface_map || []).length; i += 1) {
+    const entry = surfaceMapDoc.step_to_surface_map[i];
+    const mapPath = `step_to_surface_map[${i}]`;
+
+    if (!isNonEmptyString(entry.step_id)) {
+      failures.push(makeFailure("CI_REGISTRY_STRUCTURE_INVALID", surfaceMapPath, `${mapPath}.step_id`, "step_id must be a non-empty string."));
+      continue;
+    }
+
+    if (stepToSurface.has(entry.step_id)) {
+      failures.push(makeFailure("CI_REGISTRY_STRUCTURE_INVALID", surfaceMapPath, `${mapPath}.step_id`, `Duplicate step_to_surface_map entry for '${entry.step_id}'.`));
+    }
+    stepToSurface.set(entry.step_id, entry);
+
+    if (entry.surface_type === "live_surface") {
+      if (!allowedLive.has(entry.surface_id)) {
+        failures.push(makeFailure("CI_FOREIGN_KEY_FAILURE", surfaceMapPath, `${mapPath}.surface_id`, `Unknown live surface '${entry.surface_id}'.`));
+      }
+    } else if (entry.surface_type === "manual_operator_step") {
+      if (!allowedManual.has(entry.surface_id)) {
+        failures.push(makeFailure("CI_FOREIGN_KEY_FAILURE", surfaceMapPath, `${mapPath}.surface_id`, `Unknown manual operator step '${entry.surface_id}'.`));
+      }
+    } else {
+      failures.push(makeFailure("CI_REGISTRY_STRUCTURE_INVALID", surfaceMapPath, `${mapPath}.surface_type`, `surface_type must be 'live_surface' or 'manual_operator_step'.`));
+    }
+  }
+
+  const expectedStepIds = [
+    "accept_platform_legal_gate",
+    "create_coach_platform_identity",
+    "apply_coach_role",
+    "apply_coach_16_entitlement",
+    "create_explicit_coach_athlete_link",
+    "confirm_live_coach_surface",
+    "enter_first_lawful_coach_managed_run"
+  ];
+
+  if (steps.length !== expectedStepIds.length) {
+    failures.push(makeFailure("CI_CONSTRAINT_UNUSED", registryPath, "steps", `Expected exactly ${expectedStepIds.length} onboarding steps. Found ${steps.length}.`));
+  }
+
+  const seenIds = new Set();
+  const seenOrders = new Set();
+  let totalLivePrompts = 0;
+
+  for (let i = 0; i < steps.length; i += 1) {
+    const step = steps[i];
+    const stepPath = `steps[${i}]`;
+
+    if (!isNonEmptyString(step.step_id)) {
+      failures.push(makeFailure("CI_REGISTRY_STRUCTURE_INVALID", registryPath, `${stepPath}.step_id`, "step_id must be a non-empty string."));
+      continue;
+    }
+
+    if (seenIds.has(step.step_id)) {
+      failures.push(makeFailure("CI_REGISTRY_STRUCTURE_INVALID", registryPath, `${stepPath}.step_id`, `Duplicate step_id '${step.step_id}'.`));
+    }
+    seenIds.add(step.step_id);
+
+    if (expectedStepIds[i] !== step.step_id) {
+      failures.push(makeFailure("CI_CONSTRAINT_UNUSED", registryPath, `${stepPath}.step_id`, `Unexpected step order. Expected '${expectedStepIds[i]}', found '${step.step_id}'.`));
+    }
+
+    if (step.step_order !== i + 1) {
+      failures.push(makeFailure("CI_REGISTRY_STRUCTURE_INVALID", registryPath, `${stepPath}.step_order`, `step_order must be ${i + 1}.`));
+    }
+
+    if (seenOrders.has(step.step_order)) {
+      failures.push(makeFailure("CI_REGISTRY_STRUCTURE_INVALID", registryPath, `${stepPath}.step_order`, `Duplicate step_order '${step.step_order}'.`));
+    }
+    seenOrders.add(step.step_order);
+
+    if (step.status !== "allowed") {
+      failures.push(makeFailure("CI_REGISTRY_STRUCTURE_INVALID", registryPath, `${stepPath}.status`, `Only 'allowed' steps are supported by this slice. Found '${step.status}'.`));
+    }
+
+    if (step.step_type !== "live_surface" && step.step_type !== "manual_operator_step") {
+      failures.push(makeFailure("CI_REGISTRY_STRUCTURE_INVALID", registryPath, `${stepPath}.step_type`, `step_type must be 'live_surface' or 'manual_operator_step'.`));
+    }
+
+    if (!stepToSurface.has(step.step_id)) {
+      failures.push(makeFailure("CI_FOREIGN_KEY_FAILURE", registryPath, `${stepPath}.step_id`, `Step '${step.step_id}' has no mapped surface.`));
+    } else {
+      const mapped = stepToSurface.get(step.step_id);
+      if (mapped.surface_id !== step.surface_id) {
+        failures.push(makeFailure("CI_FOREIGN_KEY_FAILURE", registryPath, `${stepPath}.surface_id`, `Step '${step.step_id}' surface_id '${step.surface_id}' does not match mapped surface '${mapped.surface_id}'.`));
+      }
+      if (mapped.surface_type !== step.step_type) {
+        failures.push(makeFailure("CI_FOREIGN_KEY_FAILURE", registryPath, `${stepPath}.step_type`, `Step '${step.step_id}' step_type '${step.step_type}' does not match mapped surface type '${mapped.surface_type}'.`));
+      }
+    }
+
+    if (!Array.isArray(step.required_fields) || step.required_fields.length === 0) {
+      failures.push(makeFailure("CI_REGISTRY_STRUCTURE_INVALID", registryPath, `${stepPath}.required_fields`, `Step '${step.step_id}' must declare non-empty required_fields.`));
+    }
+
+    if (!Array.isArray(step.prompts)) {
+      failures.push(makeFailure("CI_REGISTRY_STRUCTURE_INVALID", registryPath, `${stepPath}.prompts`, `Step '${step.step_id}' prompts must be an array.`));
+      continue;
+    }
+
+    if (step.step_type === "live_surface") {
+      totalLivePrompts += step.prompts.length;
+      if (step.prompts.length > 3) {
+        failures.push(makeFailure("CI_CONSTRAINT_UNUSED", registryPath, `${stepPath}.prompts`, `Live step '${step.step_id}' exceeds three prompts.`));
+      }
+    } else if (step.prompts.length !== 0) {
+      failures.push(makeFailure("CI_CONSTRAINT_UNUSED", registryPath, `${stepPath}.prompts`, `Manual operator step '${step.step_id}' must not define prompts.`));
+    }
+
+    for (let j = 0; j < step.prompts.length; j += 1) {
+      const prompt = step.prompts[j];
+      const promptPath = `${stepPath}.prompts[${j}]`;
+
+      if (!isNonEmptyString(prompt)) {
+        failures.push(makeFailure("CI_REGISTRY_STRUCTURE_INVALID", registryPath, promptPath, "Prompt must be a non-empty string."));
+        continue;
+      }
+
+      for (const rule of forbiddenPatterns) {
+        if (rule.compiled.test(prompt)) {
+          failures.push(makeFailure(rule.token || "CI_LINT_FORBIDDEN_LANGUAGE_FOUND", registryPath, promptPath, `Prompt '${prompt}' matches forbidden onboarding pattern '${rule.pattern_id}'.`));
+        }
+      }
+    }
+  }
+
+  if (totalLivePrompts > 8) {
+    failures.push(makeFailure("CI_CONSTRAINT_UNUSED", registryPath, "steps", `Total live prompts must be <= 8. Found ${totalLivePrompts}.`));
+  }
+
+  const copyPhrases = Array.isArray(copySurfaceDoc.phrases) ? copySurfaceDoc.phrases : [];
+  const allowedCopyPhrases = new Set([
+    "Create coach access.",
+    "Assign coach role.",
+    "Apply coach_16 access.",
+    "Link coach to athlete explicitly.",
+    "Confirm current coach surfaces.",
+    "Start first lawful coach-managed run.",
+    "Assign within system limits.",
+    "View factual execution artefacts.",
+    "Write non-binding coach notes."
+  ]);
+
+  const copySeen = new Set();
+  for (let i = 0; i < copyPhrases.length; i += 1) {
+    const phrase = copyPhrases[i];
+    const phrasePath = `phrases[${i}]`;
+
+    if (!isNonEmptyString(phrase)) {
+      failures.push(makeFailure("CI_REGISTRY_STRUCTURE_INVALID", copySurfacePath, phrasePath, "Copy phrase must be a non-empty string."));
+      continue;
+    }
+
+    if (copySeen.has(phrase)) {
+      failures.push(makeFailure("CI_REGISTRY_STRUCTURE_INVALID", copySurfacePath, phrasePath, `Duplicate copy phrase '${phrase}'.`));
+    }
+    copySeen.add(phrase);
+
+    for (const rule of forbiddenPatterns) {
+      if (rule.compiled.test(phrase)) {
+        failures.push(makeFailure(rule.token || "CI_LINT_FORBIDDEN_LANGUAGE_FOUND", copySurfacePath, phrasePath, `Copy phrase '${phrase}' matches forbidden onboarding pattern '${rule.pattern_id}'.`));
+      }
+    }
+
+    if (!allowedCopyPhrases.has(phrase)) {
+      failures.push(makeFailure("CI_LINT_COPY_INLINE_STRING", copySurfacePath, phrasePath, `Copy phrase '${phrase}' is not in the allowed onboarding copy set.`));
+    }
+  }
+
+  return {
+    ok: failures.length === 0,
+    failures
+  };
+}
+
+function main() {
+  const repoRoot = process.cwd();
+
+  const registryPath = process.argv[2] || path.join(repoRoot, "docs/commercial/MINIMAL_COACH_ONBOARDING_STEP_REGISTRY.json");
+  const surfaceMapPath = process.argv[3] || path.join(repoRoot, "docs/commercial/MINIMAL_COACH_ONBOARDING_SURFACE_MAP.json");
+  const copySurfacePath = process.argv[4] || path.join(repoRoot, "docs/commercial/MINIMAL_COACH_ONBOARDING_COPY_SURFACE.json");
+
+  const report = runMinimalCoachOnboardingPackLint({
+    registryPath,
+    surfaceMapPath,
+    copySurfacePath
+  });
+
+  const output = JSON.stringify(report, null, 2);
+  if (!report.ok) {
+    process.stderr.write(output + "\n");
+    process.exit(1);
+  }
+
+  process.stdout.write(output + "\n");
+}
+
+if (import.meta.url === new URL(`file://${process.argv[1]}`).href) {
+  main();
+}

--- a/docs/commercial/MINIMAL_COACH_ONBOARDING_COPY_SURFACE.json
+++ b/docs/commercial/MINIMAL_COACH_ONBOARDING_COPY_SURFACE.json
@@ -1,0 +1,15 @@
+{
+  "schema_version": "kolosseum.minimal_coach_onboarding_copy_surface.v1.0.0",
+  "scope": "active_v0_only",
+  "phrases": [
+    "Create coach access.",
+    "Assign coach role.",
+    "Apply coach_16 access.",
+    "Link coach to athlete explicitly.",
+    "Confirm current coach surfaces.",
+    "Start first lawful coach-managed run.",
+    "Assign within system limits.",
+    "View factual execution artefacts.",
+    "Write non-binding coach notes."
+  ]
+}

--- a/docs/commercial/MINIMAL_COACH_ONBOARDING_PACK.md
+++ b/docs/commercial/MINIMAL_COACH_ONBOARDING_PACK.md
@@ -1,0 +1,162 @@
+# MINIMAL COACH ONBOARDING PACK
+
+Document ID: minimal_coach_onboarding_pack  
+Version: 1.0.0  
+Status: Draft slice proof  
+Scope: Active v0 only  
+Rewrite policy: rewrite-only
+
+## Purpose
+
+This document defines the minimum truthful onboarding pack for a coach account or operator entering the active v0 product.
+
+The pack exists to:
+- onboard a coach truthfully
+- stay commercially usable
+- avoid bloated prompts
+- map every onboarding step to a current live surface or a current manual operator step
+
+## Active v0 scope lock
+
+Minimal coach onboarding in active v0 is locked to:
+- actor_type `coach`
+- execution_scope `coach_managed`
+- product tier `coach_16`
+- assign within system limits
+- view factual execution artefacts
+- write non-binding coach notes
+
+Minimal coach onboarding MUST NOT imply or require:
+- replay access
+- evidence access
+- registry access
+- legality override
+- substitution authority
+- progression authority
+- Phase-1 edit authority
+- organisation runtime setup
+- team runtime setup
+- dashboards
+- messaging
+- analytics
+- readiness scoring
+- medical or safety intake
+
+## Binding onboarding sequence
+
+The onboarding pack contains exactly seven steps.
+
+### Step 1 — accept platform legal gate
+Type: manual_operator_step or current live auth gate
+
+Purpose:
+- confirm access begins behind an explicit legal/terms boundary
+
+### Step 2 — create coach platform identity
+Type: live_surface
+
+Purpose:
+- create the coach operator account
+- capture only identity/contact fields required for account creation
+
+### Step 3 — apply coach role
+Type: manual_operator_step
+
+Purpose:
+- assign the `coach` role explicitly
+- role must not be inferred
+
+### Step 4 — apply coach product entitlement
+Type: manual_operator_step
+
+Purpose:
+- apply tier `coach_16`
+- entitlement controls access only
+- entitlement does not grant engine authority
+
+### Step 5 — establish explicit coach-athlete link
+Type: manual_operator_step or live_surface
+
+Purpose:
+- create an explicit coach-to-athlete relationship
+- no implied or inferred relationships are permitted
+
+### Step 6 — confirm active coach surfaces
+Type: live_surface
+
+Purpose:
+- confirm the coach can access only:
+  - assign within system limits
+  - view factual execution artefacts
+  - write non-binding coach notes
+
+### Step 7 — first lawful coach-managed run entry
+Type: live_surface
+
+Purpose:
+- enter the first lawful coach-managed path using current v0 surfaces only
+- this step must remain a minimal route into current truth capture, not a broad profile interview
+
+## Minimal data rule
+
+Coach onboarding must stay minimal.
+
+Allowed onboarding prompts are limited to:
+- account identity fields required to create access
+- role and entitlement assignment fields handled manually where needed
+- explicit coach-athlete link identifiers
+- first-run fields already required by current v0 declaration flow
+
+Coach onboarding MUST NOT collect:
+- injury history
+- diagnoses
+- treatment history
+- rehab history
+- safety preferences
+- readiness questionnaires
+- suitability questions
+- optimisation goals
+- broad coaching philosophy fields
+- biography fields for engine use
+- outcome promises
+- organisation structure data beyond the current manual operator need
+
+## No-bloat rule
+
+The onboarding pack must stay commercially usable.
+
+The pack fails if:
+- any extra onboarding step is added
+- any onboarding step has no mapped live surface or manual operator step
+- any live onboarding step exceeds three prompts
+- total live onboarding prompts exceed eight
+- any prompt introduces future-scope product surfaces
+- any prompt introduces medical, safety, readiness, suitability, optimisation, or compliance semantics
+
+## Required current live surfaces and manual operator steps
+
+Allowed live surfaces:
+- `coach_account_create`
+- `coach_surface_confirmation`
+- `phase1_onboarding_form`
+
+Allowed manual operator steps:
+- `legal_gate_acceptance_recorded`
+- `coach_role_assignment`
+- `coach_16_entitlement_assignment`
+- `coach_athlete_link_create`
+
+## Canonical minimal commercial summary
+
+Use only this value frame:
+
+- create coach access
+- assign coach role
+- apply coach_16 access
+- link coach to athlete explicitly
+- confirm current coach surfaces
+- start first lawful coach-managed run
+
+## Final rule
+
+If coach onboarding asks for more than active v0 requires to create access, link coach to athlete, confirm the live coach surface, and enter the first lawful coach-managed run path, it must fail.

--- a/docs/commercial/MINIMAL_COACH_ONBOARDING_STEP_REGISTRY.json
+++ b/docs/commercial/MINIMAL_COACH_ONBOARDING_STEP_REGISTRY.json
@@ -1,0 +1,150 @@
+{
+  "schema_version": "kolosseum.minimal_coach_onboarding_step_registry.v1.0.0",
+  "scope": "active_v0_only",
+  "tier_id": "coach_16",
+  "steps": [
+    {
+      "step_id": "accept_platform_legal_gate",
+      "step_order": 1,
+      "step_title": "Accept platform legal gate.",
+      "step_type": "manual_operator_step",
+      "surface_id": "legal_gate_acceptance_recorded",
+      "goal": "Record that the coach entered through the platform legal gate.",
+      "prompts": [],
+      "required_fields": [
+        "coach_id",
+        "accepted_at"
+      ],
+      "forbidden_semantics": [],
+      "status": "allowed"
+    },
+    {
+      "step_id": "create_coach_platform_identity",
+      "step_order": 2,
+      "step_title": "Create coach platform identity.",
+      "step_type": "live_surface",
+      "surface_id": "coach_account_create",
+      "goal": "Create the coach operator account with minimal access identity data.",
+      "prompts": [
+        "First name.",
+        "Last name.",
+        "Email address."
+      ],
+      "required_fields": [
+        "first_name",
+        "last_name",
+        "email"
+      ],
+      "forbidden_semantics": [],
+      "status": "allowed"
+    },
+    {
+      "step_id": "apply_coach_role",
+      "step_order": 3,
+      "step_title": "Apply coach role.",
+      "step_type": "manual_operator_step",
+      "surface_id": "coach_role_assignment",
+      "goal": "Assign the explicit coach role.",
+      "prompts": [],
+      "required_fields": [
+        "coach_id",
+        "role_id"
+      ],
+      "forbidden_semantics": [],
+      "status": "allowed"
+    },
+    {
+      "step_id": "apply_coach_16_entitlement",
+      "step_order": 4,
+      "step_title": "Apply coach_16 entitlement.",
+      "step_type": "manual_operator_step",
+      "surface_id": "coach_16_entitlement_assignment",
+      "goal": "Apply the active v0 coach entitlement without adding authority beyond access.",
+      "prompts": [],
+      "required_fields": [
+        "coach_id",
+        "tier_id"
+      ],
+      "forbidden_semantics": [],
+      "status": "allowed"
+    },
+    {
+      "step_id": "create_explicit_coach_athlete_link",
+      "step_order": 5,
+      "step_title": "Create explicit coach-athlete link.",
+      "step_type": "manual_operator_step",
+      "surface_id": "coach_athlete_link_create",
+      "goal": "Create the explicit coach-to-athlete relationship.",
+      "prompts": [],
+      "required_fields": [
+        "coach_id",
+        "athlete_id",
+        "link_state"
+      ],
+      "forbidden_semantics": [],
+      "status": "allowed"
+    },
+    {
+      "step_id": "confirm_live_coach_surface",
+      "step_order": 6,
+      "step_title": "Confirm live coach surface.",
+      "step_type": "live_surface",
+      "surface_id": "coach_surface_confirmation",
+      "goal": "Confirm the coach sees only the active v0 coach surface.",
+      "prompts": [
+        "Assign within system limits.",
+        "View factual execution artefacts."
+      ],
+      "required_fields": [
+        "coach_id"
+      ],
+      "forbidden_semantics": [],
+      "status": "allowed"
+    },
+    {
+      "step_id": "enter_first_lawful_coach_managed_run",
+      "step_order": 7,
+      "step_title": "Enter first lawful coach-managed run.",
+      "step_type": "live_surface",
+      "surface_id": "phase1_onboarding_form",
+      "goal": "Enter the first lawful coach-managed run path using current v0 declarations only.",
+      "prompts": [
+        "Select athlete.",
+        "Select activity.",
+        "Select location type."
+      ],
+      "required_fields": [
+        "actor_type",
+        "execution_scope",
+        "governing_authority_id",
+        "subject_id",
+        "activity_id",
+        "location_type"
+      ],
+      "forbidden_semantics": [],
+      "status": "allowed"
+    }
+  ],
+  "forbidden_prompt_patterns": [
+    {
+      "pattern_id": "forbidden_medical_safety",
+      "regex": "\\b(injur(?:y|ies)|diagnos(?:is|es)|treat(?:ment)?|therapy|rehab(?:ilit(?:ation)?)?|medical|clinical|safe|safer|safety|risk|prevent(?:ion)?|protect(?:ion)?)\\b",
+      "token": "CI_LINT_FORBIDDEN_LANGUAGE_FOUND"
+    },
+    {
+      "pattern_id": "forbidden_readiness_suitability",
+      "regex": "\\b(readiness|ready|suitable|suitability|appropriate|ideal for you|right for you)\\b",
+      "token": "CI_LINT_FORBIDDEN_CLAIM_SEMANTIC"
+    },
+    {
+      "pattern_id": "forbidden_optimisation",
+      "regex": "\\b(optimi[sz](?:e|ed|es|ing|ation)|maximi[sz](?:e|ed|es|ing|ation)|best|better outcomes?|improve(?:d|ment|s)?)\\b",
+      "token": "CI_LINT_FORBIDDEN_CLAIM_SEMANTIC"
+    },
+    {
+      "pattern_id": "forbidden_future_scope",
+      "regex": "\\b(replay|evidence|audit export|dashboard|analytics|messaging|organisation|team setup|unit setup|registry access|substitution authority|progression authority)\\b",
+      "token": "CI_PRODUCT_BEHAVIOUR_LEAK"
+    }
+  ]
+}

--- a/docs/commercial/MINIMAL_COACH_ONBOARDING_SURFACE_MAP.json
+++ b/docs/commercial/MINIMAL_COACH_ONBOARDING_SURFACE_MAP.json
@@ -1,0 +1,80 @@
+{
+  "schema_version": "kolosseum.minimal_coach_onboarding_surface_map.v1.0.0",
+  "scope": "active_v0_only",
+  "allowed_live_surfaces": [
+    {
+      "surface_id": "coach_account_create",
+      "surface_type": "live_surface",
+      "summary": "Creates coach platform identity with minimal account fields."
+    },
+    {
+      "surface_id": "coach_surface_confirmation",
+      "surface_type": "live_surface",
+      "summary": "Shows the active v0 coach surface only."
+    },
+    {
+      "surface_id": "phase1_onboarding_form",
+      "surface_type": "live_surface",
+      "summary": "Current declaration path for the first lawful coach-managed run."
+    }
+  ],
+  "allowed_manual_operator_steps": [
+    {
+      "surface_id": "legal_gate_acceptance_recorded",
+      "surface_type": "manual_operator_step",
+      "summary": "Manual operator record of legal gate acceptance."
+    },
+    {
+      "surface_id": "coach_role_assignment",
+      "surface_type": "manual_operator_step",
+      "summary": "Manual role assignment of coach."
+    },
+    {
+      "surface_id": "coach_16_entitlement_assignment",
+      "surface_type": "manual_operator_step",
+      "summary": "Manual coach_16 entitlement assignment."
+    },
+    {
+      "surface_id": "coach_athlete_link_create",
+      "surface_type": "manual_operator_step",
+      "summary": "Manual explicit coach-athlete relationship creation."
+    }
+  ],
+  "step_to_surface_map": [
+    {
+      "step_id": "accept_platform_legal_gate",
+      "surface_id": "legal_gate_acceptance_recorded",
+      "surface_type": "manual_operator_step"
+    },
+    {
+      "step_id": "create_coach_platform_identity",
+      "surface_id": "coach_account_create",
+      "surface_type": "live_surface"
+    },
+    {
+      "step_id": "apply_coach_role",
+      "surface_id": "coach_role_assignment",
+      "surface_type": "manual_operator_step"
+    },
+    {
+      "step_id": "apply_coach_16_entitlement",
+      "surface_id": "coach_16_entitlement_assignment",
+      "surface_type": "manual_operator_step"
+    },
+    {
+      "step_id": "create_explicit_coach_athlete_link",
+      "surface_id": "coach_athlete_link_create",
+      "surface_type": "manual_operator_step"
+    },
+    {
+      "step_id": "confirm_live_coach_surface",
+      "surface_id": "coach_surface_confirmation",
+      "surface_type": "live_surface"
+    },
+    {
+      "step_id": "enter_first_lawful_coach_managed_run",
+      "surface_id": "phase1_onboarding_form",
+      "surface_type": "live_surface"
+    }
+  ]
+}

--- a/test/minimal_coach_onboarding_pack.test.mjs
+++ b/test/minimal_coach_onboarding_pack.test.mjs
@@ -1,0 +1,250 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { runMinimalCoachOnboardingPackLint } from "../ci/scripts/run_minimal_coach_onboarding_pack_lint.mjs";
+
+function writeJson(filePath, value) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, JSON.stringify(value, null, 2) + "\n", "utf8");
+}
+
+function makeTempCase({ registry, surfaceMap, copySurface }) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "minimal-coach-onboarding-pack-"));
+  const registryPath = path.join(dir, "registry.json");
+  const surfaceMapPath = path.join(dir, "surface-map.json");
+  const copySurfacePath = path.join(dir, "copy-surface.json");
+
+  writeJson(registryPath, registry);
+  writeJson(surfaceMapPath, surfaceMap);
+  writeJson(copySurfacePath, copySurface);
+
+  return { registryPath, surfaceMapPath, copySurfacePath };
+}
+
+function baseRegistry() {
+  return {
+    schema_version: "kolosseum.minimal_coach_onboarding_step_registry.v1.0.0",
+    scope: "active_v0_only",
+    tier_id: "coach_16",
+    steps: [
+      {
+        step_id: "accept_platform_legal_gate",
+        step_order: 1,
+        step_title: "Accept platform legal gate.",
+        step_type: "manual_operator_step",
+        surface_id: "legal_gate_acceptance_recorded",
+        goal: "Record legal gate acceptance.",
+        prompts: [],
+        required_fields: ["coach_id", "accepted_at"],
+        forbidden_semantics: [],
+        status: "allowed"
+      },
+      {
+        step_id: "create_coach_platform_identity",
+        step_order: 2,
+        step_title: "Create coach platform identity.",
+        step_type: "live_surface",
+        surface_id: "coach_account_create",
+        goal: "Create coach account.",
+        prompts: ["First name.", "Last name.", "Email address."],
+        required_fields: ["first_name", "last_name", "email"],
+        forbidden_semantics: [],
+        status: "allowed"
+      },
+      {
+        step_id: "apply_coach_role",
+        step_order: 3,
+        step_title: "Apply coach role.",
+        step_type: "manual_operator_step",
+        surface_id: "coach_role_assignment",
+        goal: "Assign coach role.",
+        prompts: [],
+        required_fields: ["coach_id", "role_id"],
+        forbidden_semantics: [],
+        status: "allowed"
+      },
+      {
+        step_id: "apply_coach_16_entitlement",
+        step_order: 4,
+        step_title: "Apply coach_16 entitlement.",
+        step_type: "manual_operator_step",
+        surface_id: "coach_16_entitlement_assignment",
+        goal: "Assign coach_16.",
+        prompts: [],
+        required_fields: ["coach_id", "tier_id"],
+        forbidden_semantics: [],
+        status: "allowed"
+      },
+      {
+        step_id: "create_explicit_coach_athlete_link",
+        step_order: 5,
+        step_title: "Create explicit coach-athlete link.",
+        step_type: "manual_operator_step",
+        surface_id: "coach_athlete_link_create",
+        goal: "Create link.",
+        prompts: [],
+        required_fields: ["coach_id", "athlete_id", "link_state"],
+        forbidden_semantics: [],
+        status: "allowed"
+      },
+      {
+        step_id: "confirm_live_coach_surface",
+        step_order: 6,
+        step_title: "Confirm live coach surface.",
+        step_type: "live_surface",
+        surface_id: "coach_surface_confirmation",
+        goal: "Confirm coach surface.",
+        prompts: ["Assign within system limits.", "View factual execution artefacts."],
+        required_fields: ["coach_id"],
+        forbidden_semantics: [],
+        status: "allowed"
+      },
+      {
+        step_id: "enter_first_lawful_coach_managed_run",
+        step_order: 7,
+        step_title: "Enter first lawful coach-managed run.",
+        step_type: "live_surface",
+        surface_id: "phase1_onboarding_form",
+        goal: "Enter first run.",
+        prompts: ["Select athlete.", "Select activity.", "Select location type."],
+        required_fields: ["actor_type", "execution_scope", "governing_authority_id", "subject_id", "activity_id", "location_type"],
+        forbidden_semantics: [],
+        status: "allowed"
+      }
+    ],
+    forbidden_prompt_patterns: [
+      {
+        pattern_id: "forbidden_medical_safety",
+        regex: "\\b(injur(?:y|ies)|diagnos(?:is|es)|treat(?:ment)?|therapy|rehab(?:ilit(?:ation)?)?|medical|clinical|safe|safer|safety|risk|prevent(?:ion)?|protect(?:ion)?)\\b",
+        token: "CI_LINT_FORBIDDEN_LANGUAGE_FOUND"
+      },
+      {
+        pattern_id: "forbidden_future_scope",
+        regex: "\\b(replay|evidence|analytics|dashboard|messaging|organisation|team setup|unit setup)\\b",
+        token: "CI_PRODUCT_BEHAVIOUR_LEAK"
+      }
+    ]
+  };
+}
+
+function baseSurfaceMap() {
+  return {
+    schema_version: "kolosseum.minimal_coach_onboarding_surface_map.v1.0.0",
+    scope: "active_v0_only",
+    allowed_live_surfaces: [
+      { surface_id: "coach_account_create", surface_type: "live_surface", summary: "Create coach account." },
+      { surface_id: "coach_surface_confirmation", surface_type: "live_surface", summary: "Confirm coach surface." },
+      { surface_id: "phase1_onboarding_form", surface_type: "live_surface", summary: "Phase 1 onboarding form." }
+    ],
+    allowed_manual_operator_steps: [
+      { surface_id: "legal_gate_acceptance_recorded", surface_type: "manual_operator_step", summary: "Legal gate recorded." },
+      { surface_id: "coach_role_assignment", surface_type: "manual_operator_step", summary: "Role assignment." },
+      { surface_id: "coach_16_entitlement_assignment", surface_type: "manual_operator_step", summary: "Entitlement assignment." },
+      { surface_id: "coach_athlete_link_create", surface_type: "manual_operator_step", summary: "Coach-athlete link create." }
+    ],
+    step_to_surface_map: [
+      { step_id: "accept_platform_legal_gate", surface_id: "legal_gate_acceptance_recorded", surface_type: "manual_operator_step" },
+      { step_id: "create_coach_platform_identity", surface_id: "coach_account_create", surface_type: "live_surface" },
+      { step_id: "apply_coach_role", surface_id: "coach_role_assignment", surface_type: "manual_operator_step" },
+      { step_id: "apply_coach_16_entitlement", surface_id: "coach_16_entitlement_assignment", surface_type: "manual_operator_step" },
+      { step_id: "create_explicit_coach_athlete_link", surface_id: "coach_athlete_link_create", surface_type: "manual_operator_step" },
+      { step_id: "confirm_live_coach_surface", surface_id: "coach_surface_confirmation", surface_type: "live_surface" },
+      { step_id: "enter_first_lawful_coach_managed_run", surface_id: "phase1_onboarding_form", surface_type: "live_surface" }
+    ]
+  };
+}
+
+function baseCopySurface() {
+  return {
+    schema_version: "kolosseum.minimal_coach_onboarding_copy_surface.v1.0.0",
+    scope: "active_v0_only",
+    phrases: [
+      "Create coach access.",
+      "Assign coach role.",
+      "Apply coach_16 access.",
+      "Link coach to athlete explicitly.",
+      "Confirm current coach surfaces.",
+      "Start first lawful coach-managed run.",
+      "Assign within system limits.",
+      "View factual execution artefacts.",
+      "Write non-binding coach notes."
+    ]
+  };
+}
+
+test("passes on the repo minimal coach onboarding pack slice", () => {
+  const report = runMinimalCoachOnboardingPackLint({
+    registryPath: path.resolve("docs/commercial/MINIMAL_COACH_ONBOARDING_STEP_REGISTRY.json"),
+    surfaceMapPath: path.resolve("docs/commercial/MINIMAL_COACH_ONBOARDING_SURFACE_MAP.json"),
+    copySurfacePath: path.resolve("docs/commercial/MINIMAL_COACH_ONBOARDING_COPY_SURFACE.json")
+  });
+
+  assert.equal(report.ok, true, JSON.stringify(report, null, 2));
+  assert.equal(report.failures.length, 0, JSON.stringify(report, null, 2));
+});
+
+test("fails when a live onboarding step is bloated with too many prompts", () => {
+  const registry = baseRegistry();
+  registry.steps[1].prompts.push("Phone number.");
+
+  const files = makeTempCase({
+    registry,
+    surfaceMap: baseSurfaceMap(),
+    copySurface: baseCopySurface()
+  });
+
+  const report = runMinimalCoachOnboardingPackLint(files);
+
+  assert.equal(report.ok, false);
+  assert.ok(report.failures.some((failure) => failure.token === "CI_CONSTRAINT_UNUSED"), JSON.stringify(report, null, 2));
+});
+
+test("fails when a prompt introduces medical language", () => {
+  const registry = baseRegistry();
+  registry.steps[6].prompts[0] = "Describe injury history.";
+
+  const files = makeTempCase({
+    registry,
+    surfaceMap: baseSurfaceMap(),
+    copySurface: baseCopySurface()
+  });
+
+  const report = runMinimalCoachOnboardingPackLint(files);
+
+  assert.equal(report.ok, false);
+  assert.ok(report.failures.some((failure) => failure.token === "CI_LINT_FORBIDDEN_LANGUAGE_FOUND"), JSON.stringify(report, null, 2));
+});
+
+test("fails when a step has no mapped current surface", () => {
+  const registry = baseRegistry();
+  registry.steps[4].surface_id = "coach_athlete_link_live_magic";
+
+  const files = makeTempCase({
+    registry,
+    surfaceMap: baseSurfaceMap(),
+    copySurface: baseCopySurface()
+  });
+
+  const report = runMinimalCoachOnboardingPackLint(files);
+
+  assert.equal(report.ok, false);
+  assert.ok(report.failures.some((failure) => failure.token === "CI_FOREIGN_KEY_FAILURE"), JSON.stringify(report, null, 2));
+});
+
+test("fails when copy surface introduces future-scope language", () => {
+  const copySurface = baseCopySurface();
+  copySurface.phrases.push("Open replay evidence dashboard.");
+
+  const files = makeTempCase({
+    registry: baseRegistry(),
+    surfaceMap: baseSurfaceMap(),
+    copySurface
+  });
+
+  const report = runMinimalCoachOnboardingPackLint(files);
+
+  assert.equal(report.ok, false);
+  assert.ok(report.failures.some((failure) => failure.token === "CI_PRODUCT_BEHAVIOUR_LEAK"), JSON.stringify(report, null, 2));
+});


### PR DESCRIPTION
## Summary
- add minimal coach onboarding pack for active v0
- add onboarding step registry and live/manual surface map
- add onboarding copy surface
- add minimal coach onboarding lint and targeted proof tests

## Proof
- node --test test/minimal_coach_onboarding_pack.test.mjs
- node ci/scripts/run_minimal_coach_onboarding_pack_lint.mjs

## Notes
- keeps coach onboarding minimal and commercially usable
- pins every onboarding step to a live surface or current manual operator step
- blocks bloated prompts and future-scope onboarding drift