### PR TITLE
docs(commercial): add coach session state demo contract

### DIFF
--- a/ci/scripts/run_coach_session_state_demo_contract_lint.mjs
+++ b/ci/scripts/run_coach_session_state_demo_contract_lint.mjs
@@ -1,0 +1,183 @@
+import fs from "node:fs";
+import path from "node:path";
+
+function readJson(filePath) {
+  return JSON.parse(fs.readFileSync(filePath, "utf8"));
+}
+
+function makeFailure(token, file, pathValue, details) {
+  return {
+    token,
+    file,
+    path: pathValue,
+    details
+  };
+}
+
+function isNonEmptyString(value) {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+export function runCoachSessionStateDemoContractLint({
+  fieldRegistryPath,
+  copySurfacePath
+}) {
+  const failures = [];
+
+  const registryDoc = readJson(fieldRegistryPath);
+  const copyDoc = readJson(copySurfacePath);
+
+  const fields = Array.isArray(registryDoc.fields) ? registryDoc.fields : [];
+  const phrases = Array.isArray(copyDoc.phrases) ? copyDoc.phrases : [];
+  const demoFields = Array.isArray(copyDoc.demo_fields) ? copyDoc.demo_fields : [];
+
+  const forbiddenPatterns = [
+    {
+      pattern_id: "forbidden_inference",
+      regex: "\\b(likely|probably|suggests|appears to|seems to|indicates that|implies)\\b",
+      token: "CI_LINT_FORBIDDEN_CLAIM_SEMANTIC"
+    },
+    {
+      pattern_id: "forbidden_readiness_risk_safety",
+      regex: "\\b(readiness|ready|risk|risky|unsafe|safe|safer|safety|danger|fatigued|fatigue|overreaching|recovery)\\b",
+      token: "CI_LINT_FORBIDDEN_LANGUAGE_FOUND"
+    },
+    {
+      pattern_id: "forbidden_judgement",
+      regex: "\\b(good session|bad session|poor adherence|underperformed|behind plan|declining|improving|regressing|struggling)\\b",
+      token: "CI_LINT_FORBIDDEN_CLAIM_SEMANTIC"
+    },
+    {
+      pattern_id: "forbidden_intervention",
+      regex: "\\b(should intervene|needs intervention|needs correction|should step in|recommend|recommended|next action)\\b",
+      token: "CI_LINT_FORBIDDEN_CLAIM_SEMANTIC"
+    },
+    {
+      pattern_id: "forbidden_scoring_compliance",
+      regex: "\\b(score|scored|rating|rated|compliance|adherence score|performance score)\\b",
+      token: "CI_LINT_FORBIDDEN_CLAIM_SEMANTIC"
+    }
+  ].map((entry) => ({
+    ...entry,
+    compiled: new RegExp(entry.regex, "i")
+  }));
+
+  const allowedPaths = new Set();
+  const seenFieldIds = new Set();
+  const seenPaths = new Set();
+
+  for (let i = 0; i < fields.length; i += 1) {
+    const field = fields[i];
+    const fieldPath = `fields[${i}]`;
+
+    if (!isNonEmptyString(field.field_id)) {
+      failures.push(makeFailure("CI_REGISTRY_STRUCTURE_INVALID", fieldRegistryPath, `${fieldPath}.field_id`, "field_id must be a non-empty string."));
+      continue;
+    }
+
+    if (seenFieldIds.has(field.field_id)) {
+      failures.push(makeFailure("CI_REGISTRY_STRUCTURE_INVALID", fieldRegistryPath, `${fieldPath}.field_id`, `Duplicate field_id '${field.field_id}'.`));
+    }
+    seenFieldIds.add(field.field_id);
+
+    if (!isNonEmptyString(field.path)) {
+      failures.push(makeFailure("CI_REGISTRY_STRUCTURE_INVALID", fieldRegistryPath, `${fieldPath}.path`, "path must be a non-empty string."));
+      continue;
+    }
+
+    if (seenPaths.has(field.path)) {
+      failures.push(makeFailure("CI_REGISTRY_STRUCTURE_INVALID", fieldRegistryPath, `${fieldPath}.path`, `Duplicate field path '${field.path}'.`));
+    }
+    seenPaths.add(field.path);
+    allowedPaths.add(field.path);
+
+    if (field.allowed !== true) {
+      failures.push(makeFailure("CI_REGISTRY_STRUCTURE_INVALID", fieldRegistryPath, `${fieldPath}.allowed`, "All registered demo fields in this slice must be allowed=true."));
+    }
+  }
+
+  const seenDemoFields = new Set();
+  for (let i = 0; i < demoFields.length; i += 1) {
+    const demoField = demoFields[i];
+    const demoFieldPath = `demo_fields[${i}]`;
+
+    if (!isNonEmptyString(demoField)) {
+      failures.push(makeFailure("CI_REGISTRY_STRUCTURE_INVALID", copySurfacePath, demoFieldPath, "demo field path must be a non-empty string."));
+      continue;
+    }
+
+    if (seenDemoFields.has(demoField)) {
+      failures.push(makeFailure("CI_REGISTRY_STRUCTURE_INVALID", copySurfacePath, demoFieldPath, `Duplicate demo field '${demoField}'.`));
+    }
+    seenDemoFields.add(demoField);
+
+    if (!allowedPaths.has(demoField)) {
+      failures.push(makeFailure("CI_FOREIGN_KEY_FAILURE", copySurfacePath, demoFieldPath, `Demo field '${demoField}' is not pinned in the field registry.`));
+    }
+  }
+
+  const expectedPhrases = new Set([
+    "Session active.",
+    "Session complete.",
+    "Execution state: partial.",
+    "Work items done: 4 of 6.",
+    "Pain flags recorded: 1.",
+    "Split entered: yes.",
+    "Return decision: continue."
+  ]);
+
+  const seenPhrases = new Set();
+  for (let i = 0; i < phrases.length; i += 1) {
+    const phrase = phrases[i];
+    const phrasePath = `phrases[${i}]`;
+
+    if (!isNonEmptyString(phrase)) {
+      failures.push(makeFailure("CI_REGISTRY_STRUCTURE_INVALID", copySurfacePath, phrasePath, "phrase must be a non-empty string."));
+      continue;
+    }
+
+    if (seenPhrases.has(phrase)) {
+      failures.push(makeFailure("CI_REGISTRY_STRUCTURE_INVALID", copySurfacePath, phrasePath, `Duplicate phrase '${phrase}'.`));
+    }
+    seenPhrases.add(phrase);
+
+    for (const rule of forbiddenPatterns) {
+      if (rule.compiled.test(phrase)) {
+        failures.push(makeFailure(rule.token, copySurfacePath, phrasePath, `Phrase '${phrase}' matches forbidden state wording pattern '${rule.pattern_id}'.`));
+      }
+    }
+
+    if (!expectedPhrases.has(phrase)) {
+      failures.push(makeFailure("CI_LINT_COPY_INLINE_STRING", copySurfacePath, phrasePath, `Phrase '${phrase}' is not in the allowed coach session state copy set.`));
+    }
+  }
+
+  return {
+    ok: failures.length === 0,
+    failures
+  };
+}
+
+function main() {
+  const repoRoot = process.cwd();
+
+  const fieldRegistryPath = process.argv[2] || path.join(repoRoot, "docs/commercial/COACH_SESSION_STATE_FIELD_REGISTRY.json");
+  const copySurfacePath = process.argv[3] || path.join(repoRoot, "docs/commercial/COACH_SESSION_STATE_COPY_SURFACE.json");
+
+  const report = runCoachSessionStateDemoContractLint({
+    fieldRegistryPath,
+    copySurfacePath
+  });
+
+  const output = JSON.stringify(report, null, 2);
+  if (!report.ok) {
+    process.stderr.write(output + "\n");
+    process.exit(1);
+  }
+
+  process.stdout.write(output + "\n");
+}
+
+if (import.meta.url === new URL(`file://${process.argv[1]}`).href) {
+  main();
+}

--- a/docs/commercial/COACH_SESSION_STATE_COPY_SURFACE.json
+++ b/docs/commercial/COACH_SESSION_STATE_COPY_SURFACE.json
@@ -1,0 +1,36 @@
+{
+  "schema_version": "kolosseum.coach_session_state_copy_surface.v1.0.0",
+  "scope": "active_v0_only",
+  "phrases": [
+    "Session active.",
+    "Session complete.",
+    "Execution state: partial.",
+    "Work items done: 4 of 6.",
+    "Pain flags recorded: 1.",
+    "Split entered: yes.",
+    "Return decision: continue."
+  ],
+  "demo_fields": [
+    "canonical_input_hash",
+    "selection_hash",
+    "execution_status",
+    "execution_state",
+    "runtime_events",
+    "block_execution_summary[].block_id",
+    "block_execution_summary[].block_index",
+    "block_execution_summary[].sessions_total",
+    "block_execution_summary[].sessions_ended",
+    "block_execution_summary[].work_items_total",
+    "block_execution_summary[].work_items_done",
+    "session_execution_summary[].session_id",
+    "session_execution_summary[].block_id",
+    "session_execution_summary[].session_index_global",
+    "session_execution_summary[].session_index_in_block",
+    "session_execution_summary[].session_ended",
+    "session_execution_summary[].work_items_total",
+    "session_execution_summary[].work_items_done",
+    "session_execution_summary[].pain_flag_count",
+    "session_execution_summary[].split_entered",
+    "session_execution_summary[].split_return_decision"
+  ]
+}

--- a/docs/commercial/COACH_SESSION_STATE_DEMO_CONTRACT.md
+++ b/docs/commercial/COACH_SESSION_STATE_DEMO_CONTRACT.md
@@ -1,0 +1,111 @@
+# COACH SESSION STATE DEMO CONTRACT
+
+Document ID: coach_session_state_demo_contract  
+Version: 1.0.0  
+Status: Draft slice proof  
+Scope: Active v0 only  
+Rewrite policy: rewrite-only
+
+## Purpose
+
+This document locks the exact session-state artefacts that may be shown to coaches during session monitoring in active v0.
+
+The contract exists to:
+- support the "watch what happened" value story
+- keep coach session visibility factual
+- keep coach session visibility non-inferential
+- prevent coach monitoring surfaces from drifting into readiness, safety, judgement, or prediction
+
+## Active v0 scope lock
+
+Coach session state in active v0 is locked to:
+- factual session state only
+- factual runtime event visibility only
+- structural execution summaries only
+- non-binding coach notes outside engine truth
+
+Coach session state MUST NOT imply or include:
+- readiness
+- risk
+- safety state
+- compliance state
+- performance judgement
+- optimisation
+- prediction
+- correction
+- diagnosis
+- recommendation
+- behavioural scoring
+- progression steering
+- substitution steering
+
+## Coach session state value boundary
+
+The coach session state demo MAY show only:
+- canonical truth references
+- execution status
+- execution state
+- append-only runtime event visibility
+- factual block execution summary
+- factual session execution summary
+
+The coach session state demo MUST remain descriptive only.
+
+## Allowed state fields
+
+Only the fields pinned in the coach session state field registry may appear in the demo contract.
+
+Those fields are limited to:
+- canonical hashes
+- execution status/state
+- raw runtime events
+- factual block-level counts
+- factual session-level counts
+- split / return factual markers
+- pain flag counts as counts only
+
+## Forbidden coach session state semantics
+
+The demo contract MUST fail if it introduces:
+- inferred meaning
+- behavioural interpretation
+- medical interpretation
+- safety interpretation
+- readiness interpretation
+- likely-cause language
+- trend language
+- "good" or "bad" session labels
+- intervention prompts
+- coach action prompts
+- scoring language
+- compliance language
+
+## Copy rule
+
+Allowed copy must be literal and mechanical, for example:
+- Session active.
+- Session complete.
+- Execution state: partial.
+- Work items done: 4 of 6.
+- Pain flags recorded: 1.
+- Split entered: yes.
+- Return decision: continue.
+
+Forbidden copy includes:
+- Athlete is struggling.
+- High risk.
+- Unsafe to continue.
+- Poor adherence.
+- Likely fatigued.
+- Coach should intervene.
+- Performance is declining.
+- Needs correction.
+- Behind plan.
+
+## Field rule
+
+If a state field is not explicitly pinned in the field registry, it must not appear in the coach session state demo.
+
+## Final rule
+
+If coach session state copy or fields imply anything beyond literal execution truth, the coach session state demo contract must fail.

--- a/docs/commercial/COACH_SESSION_STATE_FIELD_REGISTRY.json
+++ b/docs/commercial/COACH_SESSION_STATE_FIELD_REGISTRY.json
@@ -1,0 +1,132 @@
+{
+  "schema_version": "kolosseum.coach_session_state_field_registry.v1.0.0",
+  "scope": "active_v0_only",
+  "fields": [
+    {
+      "field_id": "canonical_input_hash",
+      "path": "canonical_input_hash",
+      "field_class": "truth_reference",
+      "allowed": true
+    },
+    {
+      "field_id": "selection_hash",
+      "path": "selection_hash",
+      "field_class": "truth_reference",
+      "allowed": true
+    },
+    {
+      "field_id": "execution_status",
+      "path": "execution_status",
+      "field_class": "execution_state",
+      "allowed": true
+    },
+    {
+      "field_id": "execution_state",
+      "path": "execution_state",
+      "field_class": "execution_state",
+      "allowed": true
+    },
+    {
+      "field_id": "runtime_events",
+      "path": "runtime_events",
+      "field_class": "runtime_events",
+      "allowed": true
+    },
+    {
+      "field_id": "block_execution_summary_block_id",
+      "path": "block_execution_summary[].block_id",
+      "field_class": "block_summary",
+      "allowed": true
+    },
+    {
+      "field_id": "block_execution_summary_block_index",
+      "path": "block_execution_summary[].block_index",
+      "field_class": "block_summary",
+      "allowed": true
+    },
+    {
+      "field_id": "block_execution_summary_sessions_total",
+      "path": "block_execution_summary[].sessions_total",
+      "field_class": "block_summary",
+      "allowed": true
+    },
+    {
+      "field_id": "block_execution_summary_sessions_ended",
+      "path": "block_execution_summary[].sessions_ended",
+      "field_class": "block_summary",
+      "allowed": true
+    },
+    {
+      "field_id": "block_execution_summary_work_items_total",
+      "path": "block_execution_summary[].work_items_total",
+      "field_class": "block_summary",
+      "allowed": true
+    },
+    {
+      "field_id": "block_execution_summary_work_items_done",
+      "path": "block_execution_summary[].work_items_done",
+      "field_class": "block_summary",
+      "allowed": true
+    },
+    {
+      "field_id": "session_execution_summary_session_id",
+      "path": "session_execution_summary[].session_id",
+      "field_class": "session_summary",
+      "allowed": true
+    },
+    {
+      "field_id": "session_execution_summary_block_id",
+      "path": "session_execution_summary[].block_id",
+      "field_class": "session_summary",
+      "allowed": true
+    },
+    {
+      "field_id": "session_execution_summary_session_index_global",
+      "path": "session_execution_summary[].session_index_global",
+      "field_class": "session_summary",
+      "allowed": true
+    },
+    {
+      "field_id": "session_execution_summary_session_index_in_block",
+      "path": "session_execution_summary[].session_index_in_block",
+      "field_class": "session_summary",
+      "allowed": true
+    },
+    {
+      "field_id": "session_execution_summary_session_ended",
+      "path": "session_execution_summary[].session_ended",
+      "field_class": "session_summary",
+      "allowed": true
+    },
+    {
+      "field_id": "session_execution_summary_work_items_total",
+      "path": "session_execution_summary[].work_items_total",
+      "field_class": "session_summary",
+      "allowed": true
+    },
+    {
+      "field_id": "session_execution_summary_work_items_done",
+      "path": "session_execution_summary[].work_items_done",
+      "field_class": "session_summary",
+      "allowed": true
+    },
+    {
+      "field_id": "session_execution_summary_pain_flag_count",
+      "path": "session_execution_summary[].pain_flag_count",
+      "field_class": "session_summary",
+      "allowed": true
+    },
+    {
+      "field_id": "session_execution_summary_split_entered",
+      "path": "session_execution_summary[].split_entered",
+      "field_class": "session_summary",
+      "allowed": true
+    },
+    {
+      "field_id": "session_execution_summary_split_return_decision",
+      "path": "session_execution_summary[].split_return_decision",
+      "field_class": "session_summary",
+      "allowed": true
+    }
+  ]
+}

--- a/test/coach_session_state_demo_contract.test.mjs
+++ b/test/coach_session_state_demo_contract.test.mjs
@@ -1,0 +1,161 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { runCoachSessionStateDemoContractLint } from "../ci/scripts/run_coach_session_state_demo_contract_lint.mjs";
+
+function writeJson(filePath, value) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, JSON.stringify(value, null, 2) + "\n", "utf8");
+}
+
+function makeTempCase({ fieldRegistry, copySurface }) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "coach-session-state-demo-contract-"));
+  const fieldRegistryPath = path.join(dir, "field-registry.json");
+  const copySurfacePath = path.join(dir, "copy-surface.json");
+
+  writeJson(fieldRegistryPath, fieldRegistry);
+  writeJson(copySurfacePath, copySurface);
+
+  return { fieldRegistryPath, copySurfacePath };
+}
+
+function baseFieldRegistry() {
+  return {
+    schema_version: "kolosseum.coach_session_state_field_registry.v1.0.0",
+    scope: "active_v0_only",
+    fields: [
+      { field_id: "canonical_input_hash", path: "canonical_input_hash", field_class: "truth_reference", allowed: true },
+      { field_id: "selection_hash", path: "selection_hash", field_class: "truth_reference", allowed: true },
+      { field_id: "execution_status", path: "execution_status", field_class: "execution_state", allowed: true },
+      { field_id: "execution_state", path: "execution_state", field_class: "execution_state", allowed: true },
+      { field_id: "runtime_events", path: "runtime_events", field_class: "runtime_events", allowed: true },
+      { field_id: "block_execution_summary_block_id", path: "block_execution_summary[].block_id", field_class: "block_summary", allowed: true },
+      { field_id: "block_execution_summary_block_index", path: "block_execution_summary[].block_index", field_class: "block_summary", allowed: true },
+      { field_id: "block_execution_summary_sessions_total", path: "block_execution_summary[].sessions_total", field_class: "block_summary", allowed: true },
+      { field_id: "block_execution_summary_sessions_ended", path: "block_execution_summary[].sessions_ended", field_class: "block_summary", allowed: true },
+      { field_id: "block_execution_summary_work_items_total", path: "block_execution_summary[].work_items_total", field_class: "block_summary", allowed: true },
+      { field_id: "block_execution_summary_work_items_done", path: "block_execution_summary[].work_items_done", field_class: "block_summary", allowed: true },
+      { field_id: "session_execution_summary_session_id", path: "session_execution_summary[].session_id", field_class: "session_summary", allowed: true },
+      { field_id: "session_execution_summary_block_id", path: "session_execution_summary[].block_id", field_class: "session_summary", allowed: true },
+      { field_id: "session_execution_summary_session_index_global", path: "session_execution_summary[].session_index_global", field_class: "session_summary", allowed: true },
+      { field_id: "session_execution_summary_session_index_in_block", path: "session_execution_summary[].session_index_in_block", field_class: "session_summary", allowed: true },
+      { field_id: "session_execution_summary_session_ended", path: "session_execution_summary[].session_ended", field_class: "session_summary", allowed: true },
+      { field_id: "session_execution_summary_work_items_total", path: "session_execution_summary[].work_items_total", field_class: "session_summary", allowed: true },
+      { field_id: "session_execution_summary_work_items_done", path: "session_execution_summary[].work_items_done", field_class: "session_summary", allowed: true },
+      { field_id: "session_execution_summary_pain_flag_count", path: "session_execution_summary[].pain_flag_count", field_class: "session_summary", allowed: true },
+      { field_id: "session_execution_summary_split_entered", path: "session_execution_summary[].split_entered", field_class: "session_summary", allowed: true },
+      { field_id: "session_execution_summary_split_return_decision", path: "session_execution_summary[].split_return_decision", field_class: "session_summary", allowed: true }
+    ]
+  };
+}
+
+function baseCopySurface() {
+  return {
+    schema_version: "kolosseum.coach_session_state_copy_surface.v1.0.0",
+    scope: "active_v0_only",
+    phrases: [
+      "Session active.",
+      "Session complete.",
+      "Execution state: partial.",
+      "Work items done: 4 of 6.",
+      "Pain flags recorded: 1.",
+      "Split entered: yes.",
+      "Return decision: continue."
+    ],
+    demo_fields: [
+      "canonical_input_hash",
+      "selection_hash",
+      "execution_status",
+      "execution_state",
+      "runtime_events",
+      "block_execution_summary[].block_id",
+      "block_execution_summary[].block_index",
+      "block_execution_summary[].sessions_total",
+      "block_execution_summary[].sessions_ended",
+      "block_execution_summary[].work_items_total",
+      "block_execution_summary[].work_items_done",
+      "session_execution_summary[].session_id",
+      "session_execution_summary[].block_id",
+      "session_execution_summary[].session_index_global",
+      "session_execution_summary[].session_index_in_block",
+      "session_execution_summary[].session_ended",
+      "session_execution_summary[].work_items_total",
+      "session_execution_summary[].work_items_done",
+      "session_execution_summary[].pain_flag_count",
+      "session_execution_summary[].split_entered",
+      "session_execution_summary[].split_return_decision"
+    ]
+  };
+}
+
+test("passes on the repo coach session state demo contract slice", () => {
+  const report = runCoachSessionStateDemoContractLint({
+    fieldRegistryPath: path.resolve("docs/commercial/COACH_SESSION_STATE_FIELD_REGISTRY.json"),
+    copySurfacePath: path.resolve("docs/commercial/COACH_SESSION_STATE_COPY_SURFACE.json")
+  });
+
+  assert.equal(report.ok, true, JSON.stringify(report, null, 2));
+  assert.equal(report.failures.length, 0, JSON.stringify(report, null, 2));
+});
+
+test("fails when a demo field is not pinned in the field registry", () => {
+  const copySurface = baseCopySurface();
+  copySurface.demo_fields.push("session_execution_summary[].coach_intervention_score");
+
+  const files = makeTempCase({
+    fieldRegistry: baseFieldRegistry(),
+    copySurface
+  });
+
+  const report = runCoachSessionStateDemoContractLint(files);
+
+  assert.equal(report.ok, false);
+  assert.ok(report.failures.some((failure) => failure.token === "CI_FOREIGN_KEY_FAILURE"), JSON.stringify(report, null, 2));
+});
+
+test("fails when copy introduces inference wording", () => {
+  const copySurface = baseCopySurface();
+  copySurface.phrases.push("Athlete likely fatigued.");
+
+  const files = makeTempCase({
+    fieldRegistry: baseFieldRegistry(),
+    copySurface
+  });
+
+  const report = runCoachSessionStateDemoContractLint(files);
+
+  assert.equal(report.ok, false);
+  assert.ok(report.failures.some((failure) => failure.token === "CI_LINT_FORBIDDEN_CLAIM_SEMANTIC" || failure.token === "CI_LINT_FORBIDDEN_LANGUAGE_FOUND"), JSON.stringify(report, null, 2));
+});
+
+test("fails when copy introduces intervention wording", () => {
+  const copySurface = baseCopySurface();
+  copySurface.phrases.push("Coach should intervene.");
+
+  const files = makeTempCase({
+    fieldRegistry: baseFieldRegistry(),
+    copySurface
+  });
+
+  const report = runCoachSessionStateDemoContractLint(files);
+
+  assert.equal(report.ok, false);
+  assert.ok(report.failures.some((failure) => failure.token === "CI_LINT_FORBIDDEN_CLAIM_SEMANTIC"), JSON.stringify(report, null, 2));
+});
+
+test("fails when copy introduces judgement wording", () => {
+  const copySurface = baseCopySurface();
+  copySurface.phrases.push("Poor adherence.");
+
+  const files = makeTempCase({
+    fieldRegistry: baseFieldRegistry(),
+    copySurface
+  });
+
+  const report = runCoachSessionStateDemoContractLint(files);
+
+  assert.equal(report.ok, false);
+  assert.ok(report.failures.some((failure) => failure.token === "CI_LINT_FORBIDDEN_CLAIM_SEMANTIC"), JSON.stringify(report, null, 2));
+});


### PR DESCRIPTION
## Summary
- add coach session state demo contract for active v0
- add pinned coach session state field registry
- add pinned coach session state copy surface
- add coach session state demo contract lint and targeted proof tests

## Proof
- node --test test/coach_session_state_demo_contract.test.mjs
- node ci/scripts/run_coach_session_state_demo_contract_lint.mjs

## Notes
- locks the exact state artefacts shown to coaches during session monitoring
- keeps coach session visibility factual and non-inferential
- fails inference wording and unpinned state fields