### PR TITLE
docs(commercial): reinforce coach summary export ban

### DIFF
--- a/ci/scripts/run_coach_summary_export_ban_lint.mjs
+++ b/ci/scripts/run_coach_summary_export_ban_lint.mjs
@@ -1,0 +1,154 @@
+import fs from "node:fs";
+import path from "node:path";
+
+function readJson(filePath) {
+  return JSON.parse(fs.readFileSync(filePath, "utf8"));
+}
+
+function makeFailure(token, file, pathValue, details) {
+  return {
+    token,
+    file,
+    path: pathValue,
+    details
+  };
+}
+
+function isNonEmptyString(value) {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+export function runCoachSummaryExportBanLint({
+  copySurfacePath,
+  fieldBoundaryPath
+}) {
+  const failures = [];
+
+  const copyDoc = readJson(copySurfacePath);
+  const fieldDoc = readJson(fieldBoundaryPath);
+
+  const phrases = Array.isArray(copyDoc.phrases) ? copyDoc.phrases : [];
+  const allowedFields = Array.isArray(fieldDoc.allowed_fields) ? fieldDoc.allowed_fields : [];
+  const forbiddenFields = Array.isArray(fieldDoc.forbidden_fields) ? fieldDoc.forbidden_fields : [];
+
+  const forbiddenPatterns = [
+    {
+      pattern_id: "forbidden_export_download",
+      regex: "\\b(export|download|print|printable|share(?:able)?|pdf|file|report)\\b",
+      token: "CI_LINT_FORBIDDEN_LANGUAGE_FOUND"
+    },
+    {
+      pattern_id: "forbidden_proof_evidence",
+      regex: "\\b(proof|evidence|seal(?:ed)?|audit(?:-ready)?|artifact|artefact|package|packaging)\\b",
+      token: "CI_LINT_FORBIDDEN_CLAIM_SEMANTIC"
+    },
+    {
+      pattern_id: "forbidden_generation",
+      regex: "\\b(generate|generated|generator|formal report|coach report)\\b",
+      token: "CI_LINT_FORBIDDEN_CLAIM_SEMANTIC"
+    }
+  ].map((entry) => ({
+    ...entry,
+    compiled: new RegExp(entry.regex, "i")
+  }));
+
+  const expectedPhrases = new Set([
+    "View summary.",
+    "Session summary.",
+    "Execution summary.",
+    "Block summary.",
+    "Read-only summary.",
+    "View factual session state."
+  ]);
+
+  const seenPhrases = new Set();
+  for (let i = 0; i < phrases.length; i += 1) {
+    const phrase = phrases[i];
+    const phrasePath = `phrases[${i}]`;
+
+    if (!isNonEmptyString(phrase)) {
+      failures.push(makeFailure("CI_REGISTRY_STRUCTURE_INVALID", copySurfacePath, phrasePath, "phrase must be a non-empty string."));
+      continue;
+    }
+
+    if (seenPhrases.has(phrase)) {
+      failures.push(makeFailure("CI_REGISTRY_STRUCTURE_INVALID", copySurfacePath, phrasePath, `Duplicate phrase '${phrase}'.`));
+    }
+    seenPhrases.add(phrase);
+
+    for (const rule of forbiddenPatterns) {
+      if (rule.compiled.test(phrase)) {
+        failures.push(makeFailure(rule.token, copySurfacePath, phrasePath, `Phrase '${phrase}' matches forbidden summary wording pattern '${rule.pattern_id}'.`));
+      }
+    }
+
+    if (!expectedPhrases.has(phrase)) {
+      failures.push(makeFailure("CI_LINT_COPY_INLINE_STRING", copySurfacePath, phrasePath, `Phrase '${phrase}' is not in the allowed coach summary copy set.`));
+    }
+  }
+
+  const seenAllowed = new Set();
+  for (let i = 0; i < allowedFields.length; i += 1) {
+    const field = allowedFields[i];
+    const fieldPath = `allowed_fields[${i}]`;
+
+    if (!isNonEmptyString(field)) {
+      failures.push(makeFailure("CI_REGISTRY_STRUCTURE_INVALID", fieldBoundaryPath, fieldPath, "allowed field must be a non-empty string."));
+      continue;
+    }
+
+    if (seenAllowed.has(field)) {
+      failures.push(makeFailure("CI_REGISTRY_STRUCTURE_INVALID", fieldBoundaryPath, fieldPath, `Duplicate allowed field '${field}'.`));
+    }
+    seenAllowed.add(field);
+
+    if (forbiddenFields.includes(field)) {
+      failures.push(makeFailure("CI_FOREIGN_KEY_FAILURE", fieldBoundaryPath, fieldPath, `Field '${field}' is listed as both allowed and forbidden.`));
+    }
+  }
+
+  const seenForbidden = new Set();
+  for (let i = 0; i < forbiddenFields.length; i += 1) {
+    const field = forbiddenFields[i];
+    const fieldPath = `forbidden_fields[${i}]`;
+
+    if (!isNonEmptyString(field)) {
+      failures.push(makeFailure("CI_REGISTRY_STRUCTURE_INVALID", fieldBoundaryPath, fieldPath, "forbidden field must be a non-empty string."));
+      continue;
+    }
+
+    if (seenForbidden.has(field)) {
+      failures.push(makeFailure("CI_REGISTRY_STRUCTURE_INVALID", fieldBoundaryPath, fieldPath, `Duplicate forbidden field '${field}'.`));
+    }
+    seenForbidden.add(field);
+  }
+
+  return {
+    ok: failures.length === 0,
+    failures
+  };
+}
+
+function main() {
+  const repoRoot = process.cwd();
+
+  const copySurfacePath = process.argv[2] || path.join(repoRoot, "docs/commercial/COACH_SUMMARY_COPY_SURFACE.json");
+  const fieldBoundaryPath = process.argv[3] || path.join(repoRoot, "docs/commercial/COACH_SUMMARY_FIELD_BOUNDARY.json");
+
+  const report = runCoachSummaryExportBanLint({
+    copySurfacePath,
+    fieldBoundaryPath
+  });
+
+  const output = JSON.stringify(report, null, 2);
+  if (!report.ok) {
+    process.stderr.write(output + "\n");
+    process.exit(1);
+  }
+
+  process.stdout.write(output + "\n");
+}
+
+if (import.meta.url === new URL(`file://${process.argv[1]}`).href) {
+  main();
+}

--- a/docs/commercial/COACH_SUMMARY_COPY_SURFACE.json
+++ b/docs/commercial/COACH_SUMMARY_COPY_SURFACE.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": "kolosseum.coach_summary_copy_surface.v1.0.0",
+  "scope": "active_v0_only",
+  "phrases": [
+    "View summary.",
+    "Session summary.",
+    "Execution summary.",
+    "Block summary.",
+    "Read-only summary.",
+    "View factual session state."
+  ]
+}

--- a/docs/commercial/COACH_SUMMARY_EXPORT_BAN_REINFORCEMENT.md
+++ b/docs/commercial/COACH_SUMMARY_EXPORT_BAN_REINFORCEMENT.md
@@ -1,0 +1,110 @@
+# COACH SUMMARY EXPORT BAN REINFORCEMENT
+
+Document ID: coach_summary_export_ban_reinforcement  
+Version: 1.0.0  
+Status: Draft slice proof  
+Scope: Active v0 only  
+Rewrite policy: rewrite-only
+
+## Purpose
+
+This document explicitly proves that the coach-facing summary path in active v0 cannot be read as an export, reporting, proof, or packaging product.
+
+The contract exists to:
+- protect the view-only boundary
+- stop summary wording from drifting into export/report/proof semantics
+- keep coach summary surfaces commercially useful without implying packaging or evidence output
+- reinforce that v0 summary is observation only
+
+## Active v0 scope lock
+
+Coach-facing summary in active v0 is locked to:
+- view-only summary
+- factual descriptive summary
+- on-screen read-only session/block state
+- non-binding coach observation surface
+
+Coach-facing summary MUST NOT imply or include:
+- export
+- download
+- report generation
+- proof packaging
+- evidence packaging
+- print output
+- shareable package
+- formal reporting
+- audit output
+- replay-backed document
+- downloadable file product
+
+## Allowed summary meaning
+
+Coach summary MAY mean only:
+- current view
+- current summary
+- factual descriptive summary
+- read-only session state summary
+- read-only block state summary
+
+Coach summary MUST remain:
+- non-exportable
+- non-proof
+- non-packaged
+- non-downloadable
+- non-printable
+
+## Allowed summary copy
+
+Allowed summary copy is limited to literal, on-screen wording such as:
+- View summary.
+- Session summary.
+- Execution summary.
+- Block summary.
+- Read-only summary.
+- View factual session state.
+
+## Forbidden summary copy
+
+The summary path MUST fail if it includes wording such as:
+- Export summary.
+- Download report.
+- Generate PDF.
+- Coach report.
+- Evidence summary.
+- Proof-backed summary.
+- Print summary.
+- Share summary pack.
+- Audit-ready summary.
+- Formal report.
+
+## Allowed summary field boundary
+
+Coach summary may show only:
+- execution status/state
+- work item counts
+- pain flag counts
+- split entered markers
+- split return decision markers
+- session identifiers
+- block identifiers
+- structural factual summaries already lawful in the coach session state surface
+
+## Forbidden summary field boundary
+
+Coach summary MUST NOT include packaging or export-like fields such as:
+- export_id
+- report_id
+- report_url
+- download_url
+- file_name
+- mime_type
+- evidence_envelope
+- seal_id
+- artifact_hash
+- pdf_path
+- printable_summary
+- share_token
+
+## Final rule
+
+If coach-facing summary copy or fields imply export, download, report, proof, evidence, or package semantics, the summary surface must fail.

--- a/docs/commercial/COACH_SUMMARY_FIELD_BOUNDARY.json
+++ b/docs/commercial/COACH_SUMMARY_FIELD_BOUNDARY.json
@@ -1,0 +1,38 @@
+{
+  "schema_version": "kolosseum.coach_summary_field_boundary.v1.0.0",
+  "scope": "active_v0_only",
+  "allowed_fields": [
+    "execution_status",
+    "execution_state",
+    "block_execution_summary[].block_id",
+    "block_execution_summary[].block_index",
+    "block_execution_summary[].sessions_total",
+    "block_execution_summary[].sessions_ended",
+    "block_execution_summary[].work_items_total",
+    "block_execution_summary[].work_items_done",
+    "session_execution_summary[].session_id",
+    "session_execution_summary[].block_id",
+    "session_execution_summary[].session_index_global",
+    "session_execution_summary[].session_index_in_block",
+    "session_execution_summary[].session_ended",
+    "session_execution_summary[].work_items_total",
+    "session_execution_summary[].work_items_done",
+    "session_execution_summary[].pain_flag_count",
+    "session_execution_summary[].split_entered",
+    "session_execution_summary[].split_return_decision"
+  ],
+  "forbidden_fields": [
+    "export_id",
+    "report_id",
+    "report_url",
+    "download_url",
+    "file_name",
+    "mime_type",
+    "evidence_envelope",
+    "seal_id",
+    "artifact_hash",
+    "pdf_path",
+    "printable_summary",
+    "share_token"
+  ]
+}

--- a/test/coach_summary_export_ban.test.mjs
+++ b/test/coach_summary_export_ban.test.mjs
@@ -1,0 +1,163 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { runCoachSummaryExportBanLint } from "../ci/scripts/run_coach_summary_export_ban_lint.mjs";
+
+function writeJson(filePath, value) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, JSON.stringify(value, null, 2) + "\n", "utf8");
+}
+
+function makeTempCase({ copySurface, fieldBoundary }) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "coach-summary-export-ban-"));
+  const copySurfacePath = path.join(dir, "copy-surface.json");
+  const fieldBoundaryPath = path.join(dir, "field-boundary.json");
+
+  writeJson(copySurfacePath, copySurface);
+  writeJson(fieldBoundaryPath, fieldBoundary);
+
+  return { copySurfacePath, fieldBoundaryPath };
+}
+
+function baseCopySurface() {
+  return {
+    schema_version: "kolosseum.coach_summary_copy_surface.v1.0.0",
+    scope: "active_v0_only",
+    phrases: [
+      "View summary.",
+      "Session summary.",
+      "Execution summary.",
+      "Block summary.",
+      "Read-only summary.",
+      "View factual session state."
+    ]
+  };
+}
+
+function baseFieldBoundary() {
+  return {
+    schema_version: "kolosseum.coach_summary_field_boundary.v1.0.0",
+    scope: "active_v0_only",
+    allowed_fields: [
+      "execution_status",
+      "execution_state",
+      "block_execution_summary[].block_id",
+      "block_execution_summary[].block_index",
+      "block_execution_summary[].sessions_total",
+      "block_execution_summary[].sessions_ended",
+      "block_execution_summary[].work_items_total",
+      "block_execution_summary[].work_items_done",
+      "session_execution_summary[].session_id",
+      "session_execution_summary[].block_id",
+      "session_execution_summary[].session_index_global",
+      "session_execution_summary[].session_index_in_block",
+      "session_execution_summary[].session_ended",
+      "session_execution_summary[].work_items_total",
+      "session_execution_summary[].work_items_done",
+      "session_execution_summary[].pain_flag_count",
+      "session_execution_summary[].split_entered",
+      "session_execution_summary[].split_return_decision"
+    ],
+    forbidden_fields: [
+      "export_id",
+      "report_id",
+      "report_url",
+      "download_url",
+      "file_name",
+      "mime_type",
+      "evidence_envelope",
+      "seal_id",
+      "artifact_hash",
+      "pdf_path",
+      "printable_summary",
+      "share_token"
+    ]
+  };
+}
+
+test("passes on the repo coach summary export ban slice", () => {
+  const report = runCoachSummaryExportBanLint({
+    copySurfacePath: path.resolve("docs/commercial/COACH_SUMMARY_COPY_SURFACE.json"),
+    fieldBoundaryPath: path.resolve("docs/commercial/COACH_SUMMARY_FIELD_BOUNDARY.json")
+  });
+
+  assert.equal(report.ok, true, JSON.stringify(report, null, 2));
+  assert.equal(report.failures.length, 0, JSON.stringify(report, null, 2));
+});
+
+test("fails when copy says export summary", () => {
+  const copySurface = baseCopySurface();
+  copySurface.phrases.push("Export summary.");
+
+  const files = makeTempCase({
+    copySurface,
+    fieldBoundary: baseFieldBoundary()
+  });
+
+  const report = runCoachSummaryExportBanLint(files);
+
+  assert.equal(report.ok, false);
+  assert.ok(report.failures.some((failure) => failure.token === "CI_LINT_FORBIDDEN_LANGUAGE_FOUND"), JSON.stringify(report, null, 2));
+});
+
+test("fails when copy says download report", () => {
+  const copySurface = baseCopySurface();
+  copySurface.phrases.push("Download report.");
+
+  const files = makeTempCase({
+    copySurface,
+    fieldBoundary: baseFieldBoundary()
+  });
+
+  const report = runCoachSummaryExportBanLint(files);
+
+  assert.equal(report.ok, false);
+  assert.ok(report.failures.some((failure) => failure.token === "CI_LINT_FORBIDDEN_LANGUAGE_FOUND"), JSON.stringify(report, null, 2));
+});
+
+test("fails when copy says proof-backed summary", () => {
+  const copySurface = baseCopySurface();
+  copySurface.phrases.push("Proof-backed summary.");
+
+  const files = makeTempCase({
+    copySurface,
+    fieldBoundary: baseFieldBoundary()
+  });
+
+  const report = runCoachSummaryExportBanLint(files);
+
+  assert.equal(report.ok, false);
+  assert.ok(report.failures.some((failure) => failure.token === "CI_LINT_FORBIDDEN_CLAIM_SEMANTIC"), JSON.stringify(report, null, 2));
+});
+
+test("fails when field boundary includes report_url as allowed", () => {
+  const fieldBoundary = baseFieldBoundary();
+  fieldBoundary.allowed_fields.push("report_url");
+
+  const files = makeTempCase({
+    copySurface: baseCopySurface(),
+    fieldBoundary
+  });
+
+  const report = runCoachSummaryExportBanLint(files);
+
+  assert.equal(report.ok, false);
+  assert.ok(report.failures.some((failure) => failure.token === "CI_FOREIGN_KEY_FAILURE"), JSON.stringify(report, null, 2));
+});
+
+test("fails when field boundary includes evidence_envelope as allowed", () => {
+  const fieldBoundary = baseFieldBoundary();
+  fieldBoundary.allowed_fields.push("evidence_envelope");
+
+  const files = makeTempCase({
+    copySurface: baseCopySurface(),
+    fieldBoundary
+  });
+
+  const report = runCoachSummaryExportBanLint(files);
+
+  assert.equal(report.ok, false);
+  assert.ok(report.failures.some((failure) => failure.token === "CI_FOREIGN_KEY_FAILURE"), JSON.stringify(report, null, 2));
+});


### PR DESCRIPTION
## Summary
- add coach summary export ban reinforcement for active v0
- add pinned coach summary copy surface
- add pinned coach summary field boundary
- add coach summary export ban lint and targeted proof tests

## Proof
- node --test test/coach_summary_export_ban.test.mjs
- node ci/scripts/run_coach_summary_export_ban_lint.mjs

## Notes
- proves coach-facing summary is view-only and not an export/reporting product
- fails export, report, proof, evidence, and packaging language
- fails packaging-style summary fields