### PR TITLE
docs(commercial): add pilot success evidence pack

### DIFF
--- a/ci/registries/commercial_artefact_registry.json
+++ b/ci/registries/commercial_artefact_registry.json
@@ -160,6 +160,21 @@
                           "artefact_id":  "p180_first_paid_pilot_setup_checklist",
                           "path":  "docs/commercial/P180_FIRST_PAID_PILOT_SETUP_CHECKLIST.md",
                           "class":  "commercial_surface"
+                      },
+                      {
+                          "artefact_id":  "p181_pilot_success_evidence_pack",
+                          "path":  "docs/commercial/P181_PILOT_SUCCESS_EVIDENCE_PACK.md",
+                          "class":  "commercial_surface"
+                      },
+                      {
+                          "artefact_id":  "p181_pilot_success_evidence_registry",
+                          "path":  "docs/commercial/P181_PILOT_SUCCESS_EVIDENCE_REGISTRY.json",
+                          "class":  "commercial_registry"
+                      },
+                      {
+                          "artefact_id":  "p181_pilot_success_claim_blacklist",
+                          "path":  "docs/commercial/P181_PILOT_SUCCESS_CLAIM_BLACKLIST.json",
+                          "class":  "commercial_registry"
                       }
                   ]
 }

--- a/docs/commercial/P181_PILOT_SUCCESS_CLAIM_BLACKLIST.json
+++ b/docs/commercial/P181_PILOT_SUCCESS_CLAIM_BLACKLIST.json
@@ -1,0 +1,56 @@
+{
+  "artefact_id": "p181_pilot_success_claim_blacklist",
+  "version": "1.0.0",
+  "ban_rule": "claims_fail_if_they_imply_outcome_improvement_inference_or_proof_layer_completion",
+  "banned_claim_groups": [
+    {
+      "group_id": "outcome_claims",
+      "items": [
+        "improved performance",
+        "got stronger",
+        "better results",
+        "improved compliance",
+        "improved readiness",
+        "improved recovery",
+        "reduced injury risk",
+        "safer training",
+        "better outcomes",
+        "more effective programming"
+      ]
+    },
+    {
+      "group_id": "inference_claims",
+      "items": [
+        "athletes engaged better",
+        "coaches coached better",
+        "athletes were more motivated",
+        "this proved retention",
+        "this proved demand",
+        "this increased adherence",
+        "this improved discipline"
+      ]
+    },
+    {
+      "group_id": "proof_layer_inflation",
+      "items": [
+        "evidence-complete",
+        "audit-proof",
+        "sealed evidence",
+        "lawful proof pack",
+        "exportable proof",
+        "fully proven execution trail"
+      ]
+    },
+    {
+      "group_id": "broader_surface_inflation",
+      "items": [
+        "team analytics",
+        "organisation reporting",
+        "dashboard insights",
+        "athlete ranking",
+        "readiness dashboard",
+        "messaging response data"
+      ]
+    }
+  ]
+}

--- a/docs/commercial/P181_PILOT_SUCCESS_EVIDENCE_PACK.md
+++ b/docs/commercial/P181_PILOT_SUCCESS_EVIDENCE_PACK.md
@@ -1,0 +1,204 @@
+# P181 - Pilot Success Evidence Pack
+
+Status: draft
+Audience: founder / operator / commercial
+Purpose: define the only lawful success evidence that may be collected and reused from an early coach pilot within current v0 limits.
+
+---
+
+## Target
+
+- define what evidence can be lawfully collected from an early coach pilot
+
+## Invariant
+
+- success evidence must be factual, minimal, and non-inferential
+
+## Proof
+
+- allowed evidence list pinned
+- banned outcome and improvement claims pinned
+- every allowed item maps to an existing v0 surface
+- anything outside current v0 surfaces is excluded
+
+---
+
+## 1. Scope lock
+
+This pack applies only to the current v0 surface.
+
+Allowed runtime scope for evidence collection:
+- lawful onboarding / Phase 1 completion facts
+- coach assignment facts
+- factual session execution facts
+- split / return facts
+- partial completion facts
+- coach-viewable factual artefacts
+- history counts
+- non-binding coach notes as surfaces only, not as truth
+
+Not allowed in this pack:
+- Phase 7 truth projection
+- Phase 8 evidence sealing
+- dashboards
+- analytics
+- rankings
+- readiness scoring
+- outcome evaluation
+- organisation / team / unit reporting
+- messaging evidence
+
+**Hard rule:** if an evidence item depends on a surface that does not exist in current v0, it is banned from this pack.
+
+---
+
+## 2. Allowed evidence list
+
+Only the following evidence types are allowed.
+
+### A. Pilot configuration facts
+- coach tier used
+- number of athletes onboarded
+- supported activity lane used
+- pilot start date
+- pilot end date or current active status
+
+### B. Onboarding facts
+- number of athletes who completed lawful onboarding
+- number of rejected onboarding attempts
+- count of accepted declarations
+- count of rejected declarations
+
+### C. Assignment and execution facts
+- number of sessions assigned
+- number of sessions started
+- number of sessions completed
+- number of sessions partially completed
+- number of split / return resumptions
+
+### D. Surface-presence evidence
+- one example of a lawful onboarding surface
+- one example of a coach assignment surface
+- one example of a factual execution artefact
+- one example of a history counts surface
+- one example of a non-binding coach note surface
+
+### E. Bounded system statements
+- deterministic execution alpha
+- factual runtime execution
+- CI-enforced boundaries
+- coach-operable within current v0 limits
+- replay-honest within current v0 scope only
+
+---
+
+## 3. Mapping rule
+
+Every allowed evidence item must map directly to an existing v0 surface.
+
+| Allowed evidence item | Existing surface |
+| --- | --- |
+| lawful onboarding count | Phase 1 onboarding |
+| rejected declaration count | Phase 1 validation outcome |
+| sessions assigned | coach assignment surface |
+| sessions started / completed | session execution surface |
+| partial completion count | partial completion flow |
+| split / return count | split / return flow |
+| factual artefact example | coach factual artefact viewing |
+| history counts example | history counts surface |
+| coach note example | non-binding coach notes surface |
+
+**Hard rule:** if an item cannot be mapped to a current v0 surface, it must not appear in this pack.
+
+---
+
+## 4. Banned claims
+
+The following claim classes are banned and must not appear in any success evidence pack, summary, screenshot caption, founder note, sales page, or follow-up pitch.
+
+### A. Outcome claims
+- improved performance
+- got stronger
+- better results
+- improved compliance
+- improved readiness
+- improved recovery
+- reduced injury risk
+- safer training
+- better outcomes
+- more effective programming
+
+### B. Inference claims
+- athletes engaged better
+- coaches coached better
+- athletes were more motivated
+- this proved retention
+- this proved demand
+- this increased adherence
+- this improved discipline
+
+### C. Proof-layer inflation
+- evidence-complete
+- audit-proof
+- sealed evidence
+- lawful proof pack
+- exportable proof
+- fully proven execution trail
+
+### D. Broader surface inflation
+- team analytics
+- organisation reporting
+- dashboard insights
+- athlete ranking
+- readiness dashboard
+- messaging response data
+
+**Hard rule:** if the claim implies improvement, outcome, safety, readiness, organisational capability, or proof-layer completeness, it is banned.
+
+---
+
+## 5. Allowed summary pattern
+
+Use only bounded descriptive language such as:
+
+> Kolosseum v0 was used as a bounded deterministic execution alpha for an early coach pilot covering lawful onboarding, coach assignment, factual session execution, split / return, partial completion, factual artefact viewing, history counts, and non-binding coach notes within the current v0 surface.
+
+Do not add outcomes, judgement, or implied benefits.
+
+---
+
+## 6. Founder use rule
+
+This pack exists to support the next sale using factual usage proof only.
+
+It does not exist to prove:
+- athlete improvement
+- coaching quality
+- medical or safety value
+- retention quality
+- broader platform maturity
+
+It exists to prove only:
+- the product was used
+- the current v0 surfaces were real
+- the pilot stayed inside lawful boundaries
+
+---
+
+## 7. Minimum pack contents
+
+A reusable pilot success evidence pack must contain only:
+- pilot identity block
+- usage counts block
+- mapped surface examples block
+- allowed bounded summary block
+
+No extra analysis.
+No interpretation.
+No improvements language.
+
+---
+
+## 8. Final rule
+
+If an evidence item is not factual, not minimal, not non-inferential, or not mapped to a current v0 surface, it must not be collected or sold as pilot success evidence.

--- a/docs/commercial/P181_PILOT_SUCCESS_EVIDENCE_REGISTRY.json
+++ b/docs/commercial/P181_PILOT_SUCCESS_EVIDENCE_REGISTRY.json
@@ -1,0 +1,82 @@
+{
+  "artefact_id": "p181_pilot_success_evidence_registry",
+  "version": "1.0.0",
+  "scope": "current_v0_only",
+  "invariant": "factual_minimal_non_inferential_only",
+  "allowed_evidence": [
+    {
+      "evidence_id": "pilot_configuration",
+      "allowed_items": [
+        "coach_tier_used",
+        "athlete_count",
+        "activity_lane_used",
+        "pilot_start_date",
+        "pilot_status"
+      ],
+      "maps_to": [
+        "commercial_tier_surface",
+        "pilot_operator_record"
+      ]
+    },
+    {
+      "evidence_id": "onboarding_facts",
+      "allowed_items": [
+        "lawful_onboarding_completed_count",
+        "onboarding_rejected_count",
+        "accepted_declaration_count",
+        "rejected_declaration_count"
+      ],
+      "maps_to": [
+        "phase1_onboarding_surface"
+      ]
+    },
+    {
+      "evidence_id": "execution_facts",
+      "allowed_items": [
+        "sessions_assigned_count",
+        "sessions_started_count",
+        "sessions_completed_count",
+        "partial_completion_count",
+        "split_return_count"
+      ],
+      "maps_to": [
+        "coach_assignment_surface",
+        "session_execution_surface",
+        "partial_completion_flow",
+        "split_return_flow"
+      ]
+    },
+    {
+      "evidence_id": "surface_examples",
+      "allowed_items": [
+        "onboarding_surface_example",
+        "coach_assignment_surface_example",
+        "factual_execution_artefact_example",
+        "history_counts_surface_example",
+        "non_binding_coach_note_surface_example"
+      ],
+      "maps_to": [
+        "phase1_onboarding_surface",
+        "coach_assignment_surface",
+        "factual_artefact_view",
+        "history_counts_surface",
+        "coach_notes_surface"
+      ]
+    },
+    {
+      "evidence_id": "bounded_system_statements",
+      "allowed_items": [
+        "deterministic_execution_alpha",
+        "factual_runtime_execution",
+        "ci_enforced_boundaries",
+        "coach_operable_within_current_v0_limits",
+        "replay_honest_within_current_v0_scope_only"
+      ],
+      "maps_to": [
+        "approved_commercial_copy_only"
+      ]
+    }
+  ],
+  "mapping_rule": "every_allowed_item_must_map_to_existing_v0_surface",
+  "forbidden_if_unmapped": true
+}


### PR DESCRIPTION
## Summary
- add P181 pilot success evidence pack
- pin allowed factual pilot evidence to current v0 surfaces
- ban outcome, improvement, and proof-layer inflation claims
- declare all new commercial artefacts in the commercial artefact registry

## Testing
- node ci/scripts/run_commercial_artefact_registry_guard.mjs