### PR TITLE
docs(commercial): add sales handoff pack

### DIFF
--- a/ci/registries/commercial_artefact_registry.json
+++ b/ci/registries/commercial_artefact_registry.json
@@ -175,6 +175,26 @@
                           "artefact_id":  "p181_pilot_success_claim_blacklist",
                           "path":  "docs/commercial/P181_PILOT_SUCCESS_CLAIM_BLACKLIST.json",
                           "class":  "commercial_registry"
+                      },
+                      {
+                          "artefact_id":  "p182_sales_handoff_pack",
+                          "path":  "docs/commercial/P182_SALES_HANDOFF_PACK.md",
+                          "class":  "commercial_surface"
+                      },
+                      {
+                          "artefact_id":  "p182_sales_handoff_contents_registry",
+                          "path":  "docs/commercial/P182_SALES_HANDOFF_CONTENTS_REGISTRY.json",
+                          "class":  "commercial_registry"
+                      },
+                      {
+                          "artefact_id":  "p182_sales_handoff_claim_guardrails",
+                          "path":  "docs/commercial/P182_SALES_HANDOFF_CLAIM_GUARDRAILS.json",
+                          "class":  "commercial_registry"
+                      },
+                      {
+                          "artefact_id":  "p182_sales_handoff_link_map",
+                          "path":  "docs/commercial/P182_SALES_HANDOFF_LINK_MAP.json",
+                          "class":  "commercial_registry"
                       }
                   ]
 }

--- a/docs/commercial/P182_SALES_HANDOFF_CLAIM_GUARDRAILS.json
+++ b/docs/commercial/P182_SALES_HANDOFF_CLAIM_GUARDRAILS.json
@@ -1,0 +1,37 @@
+{
+  "artefact_id": "p182_sales_handoff_claim_guardrails",
+  "version": "1.0.0",
+  "rule": "any_unbacked_follow_up_claim_fails",
+  "allowed_claim_classes": [
+    "current_v0_scope_statement",
+    "bounded_pilot_offer_statement",
+    "factual_surface_statement",
+    "factual_usage_statement",
+    "explicit_exclusion_statement"
+  ],
+  "banned_claim_classes": [
+    "outcome_claim",
+    "improvement_claim",
+    "safety_claim",
+    "optimisation_claim",
+    "readiness_claim",
+    "proof_layer_completion_claim",
+    "organisation_capability_claim",
+    "dashboard_or_analytics_claim",
+    "inferred_sentiment_or_retention_claim"
+  ],
+  "banned_examples": [
+    "improved performance",
+    "better compliance",
+    "more effective programming",
+    "safer training",
+    "reduced injury risk",
+    "improved readiness",
+    "proved retention",
+    "proved demand",
+    "evidence-complete",
+    "exportable proof",
+    "team analytics",
+    "organisation reporting"
+  ]
+}

--- a/docs/commercial/P182_SALES_HANDOFF_CONTENTS_REGISTRY.json
+++ b/docs/commercial/P182_SALES_HANDOFF_CONTENTS_REGISTRY.json
@@ -1,0 +1,38 @@
+{
+  "artefact_id": "p182_sales_handoff_contents_registry",
+  "version": "1.0.0",
+  "scope": "current_v0_demo_truth_only",
+  "required_sections": [
+    "demo_truth_summary",
+    "pilot_offer_block",
+    "what_the_buyer_gets",
+    "what_the_buyer_does_not_get",
+    "pilot_success_evidence_excerpt",
+    "allowed_summary_sentence",
+    "buyer_next_step",
+    "failure_conditions"
+  ],
+  "allowed_offer_items": [
+    "one_coach",
+    "coach_16_tier",
+    "one_activity_lane",
+    "bounded_early_pilot",
+    "three_to_sixteen_athletes",
+    "current_v0_surface_only"
+  ],
+  "required_exclusions": [
+    "phase7_truth_projection",
+    "phase8_evidence_sealing",
+    "dashboards",
+    "analytics",
+    "rankings",
+    "readiness_scoring",
+    "messaging",
+    "organisation_reporting",
+    "team_runtime",
+    "unit_runtime",
+    "gym_runtime",
+    "organisation_runtime",
+    "exportable_proof"
+  ]
+}

--- a/docs/commercial/P182_SALES_HANDOFF_LINK_MAP.json
+++ b/docs/commercial/P182_SALES_HANDOFF_LINK_MAP.json
@@ -1,0 +1,26 @@
+{
+  "artefact_id": "p182_sales_handoff_link_map",
+  "version": "1.0.0",
+  "references": [
+    {
+      "ref_id": "p180_first_paid_pilot_setup_checklist",
+      "path": "docs/commercial/P180_FIRST_PAID_PILOT_SETUP_CHECKLIST.md",
+      "purpose": "pilot_setup_boundary"
+    },
+    {
+      "ref_id": "p181_pilot_success_evidence_pack",
+      "path": "docs/commercial/P181_PILOT_SUCCESS_EVIDENCE_PACK.md",
+      "purpose": "allowed_success_evidence"
+    },
+    {
+      "ref_id": "p181_pilot_success_evidence_registry",
+      "path": "docs/commercial/P181_PILOT_SUCCESS_EVIDENCE_REGISTRY.json",
+      "purpose": "allowed_evidence_mapping"
+    },
+    {
+      "ref_id": "p181_pilot_success_claim_blacklist",
+      "path": "docs/commercial/P181_PILOT_SUCCESS_CLAIM_BLACKLIST.json",
+      "purpose": "banned_claims"
+    }
+  ]
+}

--- a/docs/commercial/P182_SALES_HANDOFF_PACK.md
+++ b/docs/commercial/P182_SALES_HANDOFF_PACK.md
@@ -1,0 +1,182 @@
+# P182 - Sales Handoff Pack
+
+Status: draft  
+Audience: founder / operator / commercial  
+Purpose: one compact post-demo handoff pack that matches demo truth exactly and does not outrun current v0 scope.
+
+---
+
+## Target
+
+- one compact pack you can send after the first demo
+
+## Invariant
+
+- handoff pack must match demo truth exactly
+
+## Proof
+
+- pack contents pinned
+- all references resolve
+- any unbacked follow-up claim fails
+- anything outside current demo truth is excluded
+
+---
+
+## 1. Demo truth summary
+
+This pack reflects current v0 only.
+
+Current v0 offer truth:
+- deterministic execution alpha
+- individual_user and coach only
+- individual and coach_managed only
+- powerlifting, rugby_union, and general_strength only
+- Phase 1 to Phase 6 only
+- lawful onboarding
+- coach assignment
+- factual session execution
+- split / return
+- partial completion
+- coach-viewable factual artefacts
+- history counts
+- non-binding coach notes
+
+This pack does not claim:
+- Phase 7 truth projection
+- Phase 8 evidence sealing
+- dashboards
+- analytics
+- rankings
+- readiness scoring
+- messaging
+- organisation, team, unit, or gym runtime
+- exportable proof or evidence
+
+**Hard rule:** if it was not shown in the demo or is not part of current v0, it must not appear in this handoff pack.
+
+---
+
+## 2. Pilot offer block
+
+The default post-demo pilot offer is:
+
+- one coach
+- coach_16 tier
+- one activity lane
+- bounded early pilot
+- 3 to 16 athletes
+- current v0 surface only
+
+This offer is not:
+- a team deployment
+- an organisation deployment
+- a dashboard package
+- an analytics product
+- a proof-layer release
+
+---
+
+## 3. What the buyer gets
+
+Only include surfaces that are real and demo-backed:
+
+- lawful onboarding
+- coach assignment
+- factual session execution
+- split / return
+- partial completion
+- coach-viewable factual artefacts
+- history counts
+- non-binding coach notes
+
+---
+
+## 4. What the buyer does not get
+
+Make exclusions explicit:
+
+- dashboards
+- analytics
+- rankings
+- readiness scoring
+- outcome evaluation
+- messaging
+- organisation reporting
+- team / unit / gym / organisation runtime
+- evidence sealing
+- exportable proof packs
+
+---
+
+## 5. Pilot success evidence excerpt
+
+Only lawful factual evidence may appear here.
+
+Allowed:
+- athlete count
+- activity lane used
+- accepted onboarding count
+- rejected onboarding count
+- sessions assigned
+- sessions started
+- sessions completed
+- partial completion count
+- split / return count
+- one lawful surface example
+- one factual artefact example
+- one history counts example
+
+Do not include:
+- improvement claims
+- outcome claims
+- optimisation claims
+- safety claims
+- inferred satisfaction claims
+- retention / demand / compliance claims
+
+---
+
+## 6. Allowed summary sentence
+
+Use only bounded descriptive language such as:
+
+> Kolosseum v0 was demonstrated and offered as a bounded deterministic execution alpha covering lawful onboarding, coach assignment, factual session execution, split / return, partial completion, factual artefact viewing, history counts, and non-binding coach notes within the current v0 surface.
+
+Do not add outcomes, judgement, or implied benefits.
+
+---
+
+## 7. Buyer next step
+
+Use one clean next-step block:
+
+- reply to start pilot
+- confirm activity lane
+- confirm athlete count
+- confirm coach tier
+- confirm pilot start window
+
+Nothing else should be required in the handoff pack.
+
+---
+
+## 8. Failure conditions
+
+This pack fails if:
+- it claims something not shown in the demo
+- it includes future-scope features as current offer
+- it includes proof-layer or evidence-export language
+- it includes outcome or improvement language
+- it references an artefact that does not exist
+- it uses commercial wording that outruns current v0 boundaries
+
+---
+
+## 9. Final rule
+
+This is not a brochure.
+
+It is a post-demo truth pack.
+
+If it says more than the demo proved, it is broken.


### PR DESCRIPTION
## Summary
- add P182 sales handoff pack
- pin post-demo pack contents to current demo truth only
- add claim guardrails and link map for all follow-up references
- declare all new commercial artefacts in the commercial artefact registry

## Testing
- node ci/scripts/run_commercial_artefact_registry_guard.mjs