### PR TITLE
docs(commercial): add post-demo reply templates

### DIFF
--- a/ci/registries/commercial_artefact_registry.json
+++ b/ci/registries/commercial_artefact_registry.json
@@ -195,6 +195,21 @@
                           "artefact_id":  "p182_sales_handoff_link_map",
                           "path":  "docs/commercial/P182_SALES_HANDOFF_LINK_MAP.json",
                           "class":  "commercial_registry"
+                      },
+                      {
+                          "artefact_id":  "p183_post_demo_reply_templates",
+                          "path":  "docs/commercial/P183_POST_DEMO_REPLY_TEMPLATES.md",
+                          "class":  "commercial_surface"
+                      },
+                      {
+                          "artefact_id":  "p183_post_demo_reply_variant_registry",
+                          "path":  "docs/commercial/P183_POST_DEMO_REPLY_VARIANT_REGISTRY.json",
+                          "class":  "commercial_registry"
+                      },
+                      {
+                          "artefact_id":  "p183_post_demo_reply_claim_guardrails",
+                          "path":  "docs/commercial/P183_POST_DEMO_REPLY_CLAIM_GUARDRAILS.json",
+                          "class":  "commercial_registry"
                       }
                   ]
 }

--- a/docs/commercial/P183_POST_DEMO_REPLY_CLAIM_GUARDRAILS.json
+++ b/docs/commercial/P183_POST_DEMO_REPLY_CLAIM_GUARDRAILS.json
@@ -1,0 +1,37 @@
+{
+  "artefact_id": "p183_post_demo_reply_claim_guardrails",
+  "version": "1.0.0",
+  "rule": "reply_templates_fail_if_they_outrun_demo_truth_or_current_v0_scope",
+  "allowed_claim_classes": [
+    "bounded_pilot_offer_statement",
+    "current_v0_scope_statement",
+    "factual_surface_statement",
+    "explicit_exclusion_statement",
+    "next_step_request"
+  ],
+  "banned_claim_classes": [
+    "outcome_claim",
+    "improvement_claim",
+    "safety_claim",
+    "optimisation_claim",
+    "readiness_claim",
+    "organisation_capability_claim",
+    "dashboard_or_analytics_claim",
+    "proof_layer_or_export_claim",
+    "inferred_sentiment_or_retention_claim"
+  ],
+  "banned_examples": [
+    "improved performance",
+    "better outcomes",
+    "safer training",
+    "improved compliance",
+    "improved readiness",
+    "more effective programming",
+    "organisation-ready",
+    "dashboard insights",
+    "exportable proof",
+    "evidence-complete",
+    "proven retention",
+    "increased adherence"
+  ]
+}

--- a/docs/commercial/P183_POST_DEMO_REPLY_TEMPLATES.md
+++ b/docs/commercial/P183_POST_DEMO_REPLY_TEMPLATES.md
@@ -1,0 +1,252 @@
+# P183 - Post-Demo Reply Templates
+
+Status: draft  
+Audience: founder / operator / commercial  
+Purpose: exact post-demo reply templates for warm, cold, and hesitant leads that stay inside current v0 truth boundaries.
+
+---
+
+## Target
+
+- exact follow-up messages for warm, cold, and hesitant demo leads
+
+## Invariant
+
+- every reply must match demo truth exactly and stay inside current v0 boundaries
+
+## Proof
+
+- reply templates pinned
+- claim-safe variants pinned
+- banned follow-up claims pinned
+- anything outside demo truth is excluded
+
+---
+
+## 1. Scope lock
+
+These reply templates may only reference what is true now.
+
+Current v0 demo-safe truth:
+- deterministic execution alpha
+- one coach pilot
+- coach_16 as the default bounded pilot tier
+- one activity lane
+- 3 to 16 athletes
+- lawful onboarding
+- coach assignment
+- factual session execution
+- split / return
+- partial completion
+- coach-viewable factual artefacts
+- history counts
+- non-binding coach notes
+
+These templates must not claim:
+- dashboards
+- analytics
+- rankings
+- readiness scoring
+- messaging
+- organisation runtime
+- team runtime
+- unit runtime
+- proof exports
+- evidence sealing
+- outcome improvement
+
+**Hard rule:** if a sentence says more than the demo proved, it must not be used.
+
+---
+
+## 2. Warm lead reply
+
+Use when the lead was engaged, asked practical setup questions, or is clearly close to pilot discussion.
+
+Template:
+
+Hi [Name],
+
+Good speaking with you earlier.
+
+Based on what I showed, the clean starting point is a bounded early pilot:
+- one coach
+- one activity lane
+- 3 to 16 athletes
+- current v0 surface only
+
+What is in scope right now:
+- lawful onboarding
+- coach assignment
+- factual session execution
+- split / return
+- partial completion
+- coach-viewable factual artefacts
+- history counts
+- non-binding coach notes
+
+What is not in scope right now:
+- dashboards
+- analytics
+- rankings
+- readiness scoring
+- messaging
+- organisation / team runtime
+- evidence export
+
+If you want to move forward, reply with:
+- activity lane
+- athlete count
+- preferred start window
+
+Chris
+
+---
+
+## 3. Cold lead reply
+
+Use when the lead was polite but non-committal, or when you need a low-pressure follow-up.
+
+Template:
+
+Hi [Name],
+
+Thanks again for your time.
+
+To keep this simple, what I showed is a bounded early pilot rather than a broad platform rollout.
+
+Current v0 is suited to:
+- one coach
+- one activity lane
+- a small athlete group
+- factual onboarding and execution flow
+
+That means the current offer is about:
+- lawful onboarding
+- coach assignment
+- factual execution
+- split / return
+- partial completion
+- factual artefact viewing
+- history counts
+- non-binding coach notes
+
+It is not being positioned as:
+- a dashboard product
+- an analytics product
+- an organisation system
+- an evidence export layer
+
+If a tight early pilot is useful, reply with your likely athlete count and activity lane and I will send the cleanest starting option.
+
+Chris
+
+---
+
+## 4. Hesitant lead reply
+
+Use when the lead liked the idea but is concerned about scope, fit, or whether it is "ready enough."
+
+Template:
+
+Hi [Name],
+
+That is a fair concern.
+
+The honest position is that this is a bounded v0 pilot, not a broad all-in-one coaching platform.
+
+What it does already:
+- lawful onboarding
+- coach assignment
+- factual session execution
+- split / return
+- partial completion
+- coach-viewable factual artefacts
+- history counts
+- non-binding coach notes
+
+What it does not pretend to do yet:
+- dashboards
+- analytics
+- rankings
+- readiness scoring
+- messaging
+- organisation runtime
+- proof exports
+
+So the right question is not "does it do everything?"
+The right question is whether a tight early pilot around one coach, one activity lane, and a small athlete group is enough to be commercially useful now.
+
+If yes, send me:
+- activity lane
+- athlete count
+- preferred start window
+
+Chris
+
+---
+
+## 5. Tight nudge follow-up
+
+Use if there is no reply after the first follow-up.
+
+Template:
+
+Hi [Name],
+
+Just nudging this in case a bounded early pilot is still relevant.
+
+The clean current fit is:
+- one coach
+- one activity lane
+- 3 to 16 athletes
+- current v0 execution surface only
+
+If useful, send over:
+- activity lane
+- athlete count
+- preferred start window
+
+Chris
+
+---
+
+## 6. Allowed phrases
+
+Safe phrases:
+- bounded early pilot
+- deterministic execution alpha
+- current v0 surface
+- lawful onboarding
+- factual session execution
+- coach-viewable factual artefacts
+- non-binding coach notes
+- one coach
+- one activity lane
+- 3 to 16 athletes
+
+---
+
+## 7. Banned phrases
+
+Do not use:
+- improved performance
+- better outcomes
+- safer training
+- improved compliance
+- improved readiness
+- more effective programming
+- organisation-ready
+- dashboard insights
+- exportable proof
+- evidence-complete
+- proven retention
+- increased adherence
+
+---
+
+## 8. Final rule
+
+These templates exist to start pilot conversations immediately without drifting off demo truth.
+
+If a reply introduces an unbacked capability, outcome claim, or future-scope promise, it fails.

--- a/docs/commercial/P183_POST_DEMO_REPLY_VARIANT_REGISTRY.json
+++ b/docs/commercial/P183_POST_DEMO_REPLY_VARIANT_REGISTRY.json
@@ -1,0 +1,66 @@
+{
+  "artefact_id": "p183_post_demo_reply_variant_registry",
+  "version": "1.0.0",
+  "scope": "current_v0_demo_truth_only",
+  "variants": [
+    {
+      "variant_id": "warm_lead",
+      "use_when": [
+        "lead_engaged",
+        "lead_asked_setup_questions",
+        "lead_close_to_pilot_discussion"
+      ],
+      "must_include": [
+        "bounded_early_pilot",
+        "one_coach",
+        "one_activity_lane",
+        "three_to_sixteen_athletes",
+        "current_scope_list",
+        "current_exclusions_list",
+        "clean_next_step_request"
+      ]
+    },
+    {
+      "variant_id": "cold_lead",
+      "use_when": [
+        "lead_polite_non_committal",
+        "light_follow_up_required",
+        "low_pressure_reengagement"
+      ],
+      "must_include": [
+        "bounded_v0_positioning",
+        "current_scope_list",
+        "current_exclusions_list",
+        "light_cta"
+      ]
+    },
+    {
+      "variant_id": "hesitant_lead",
+      "use_when": [
+        "lead_scope_concern",
+        "lead_fit_concern",
+        "lead_ready_enough_concern"
+      ],
+      "must_include": [
+        "bounded_v0_positioning",
+        "what_it_does_already",
+        "what_it_does_not_do",
+        "commercial_usefulness_question",
+        "clean_next_step_request"
+      ]
+    },
+    {
+      "variant_id": "tight_nudge",
+      "use_when": [
+        "no_reply_after_first_follow_up"
+      ],
+      "must_include": [
+        "bounded_early_pilot",
+        "one_coach",
+        "one_activity_lane",
+        "three_to_sixteen_athletes",
+        "short_cta"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add P183 post-demo reply templates for warm, cold, and hesitant leads
- pin claim-safe reply variants to current v0 demo truth only
- declare new commercial artefacts in the commercial artefact registry

## Testing
- node ci/scripts/run_commercial_artefact_registry_guard.mjs