### PR TITLE
docs(commercial): add pilot pricing send pack

### DIFF
--- a/ci/registries/commercial_artefact_registry.json
+++ b/ci/registries/commercial_artefact_registry.json
@@ -225,6 +225,21 @@
                           "artefact_id":  "p184_pilot_qualification_exclusion_list",
                           "path":  "docs/commercial/P184_PILOT_QUALIFICATION_EXCLUSION_LIST.json",
                           "class":  "commercial_registry"
+                      },
+                      {
+                          "artefact_id":  "p185_pilot_pricing_send_pack",
+                          "path":  "docs/commercial/P185_PILOT_PRICING_SEND_PACK.md",
+                          "class":  "commercial_surface"
+                      },
+                      {
+                          "artefact_id":  "p185_pilot_pricing_registry",
+                          "path":  "docs/commercial/P185_PILOT_PRICING_REGISTRY.json",
+                          "class":  "commercial_registry"
+                      },
+                      {
+                          "artefact_id":  "p185_pilot_pricing_guardrails",
+                          "path":  "docs/commercial/P185_PILOT_PRICING_GUARDRAILS.json",
+                          "class":  "commercial_registry"
                       }
                   ]
 }

--- a/docs/commercial/P185_PILOT_PRICING_GUARDRAILS.json
+++ b/docs/commercial/P185_PILOT_PRICING_GUARDRAILS.json
@@ -1,0 +1,35 @@
+{
+  "artefact_id": "p185_pilot_pricing_guardrails",
+  "version": "1.0.0",
+  "rule": "pricing_pack_fails_if_it_outruns_current_v0_coach_16_offer",
+  "allowed_claim_classes": [
+    "bounded_pilot_offer_statement",
+    "price_statement",
+    "seat_cap_statement",
+    "included_surface_statement",
+    "explicit_exclusion_statement",
+    "payment_access_only_statement"
+  ],
+  "banned_claim_classes": [
+    "team_pricing_claim",
+    "gym_pricing_claim",
+    "unit_pricing_claim",
+    "organisation_pricing_claim",
+    "dashboard_or_analytics_claim",
+    "proof_or_audit_claim",
+    "engine_authority_claim",
+    "multi_coach_or_multi_activity_claim"
+  ],
+  "banned_examples": [
+    "team package",
+    "club package",
+    "organisation package",
+    "dashboard insights",
+    "analytics included",
+    "audit pack",
+    "exportable proof",
+    "multi-coach rollout",
+    "multi-activity rollout",
+    "payment changes engine behaviour"
+  ]
+}

--- a/docs/commercial/P185_PILOT_PRICING_REGISTRY.json
+++ b/docs/commercial/P185_PILOT_PRICING_REGISTRY.json
@@ -1,0 +1,42 @@
+{
+  "artefact_id": "p185_pilot_pricing_registry",
+  "version": "1.0.0",
+  "scope": "current_v0_coach_16_only",
+  "offer": {
+    "tier_id": "coach_16",
+    "price_gbp_monthly": 59.99,
+    "activity_lanes_included": 1,
+    "coach_count_included": 1,
+    "athlete_range": {
+      "min": 7,
+      "max": 16
+    }
+  },
+  "included_surfaces": [
+    "lawful_onboarding",
+    "coach_assignment",
+    "factual_session_execution",
+    "split_return",
+    "partial_completion",
+    "coach_viewable_factual_artefacts",
+    "history_counts",
+    "non_binding_coach_notes",
+    "athlete_list_management_up_to_tier_cap"
+  ],
+  "excluded_surfaces": [
+    "dashboards",
+    "analytics",
+    "rankings",
+    "readiness_scoring",
+    "messaging",
+    "team_runtime",
+    "unit_runtime",
+    "gym_runtime",
+    "organisation_runtime",
+    "evidence_sealing",
+    "exportable_proof",
+    "replay_or_audit_product_claims",
+    "multi_coach_rollout",
+    "multi_activity_rollout"
+  ]
+}

--- a/docs/commercial/P185_PILOT_PRICING_SEND_PACK.md
+++ b/docs/commercial/P185_PILOT_PRICING_SEND_PACK.md
@@ -1,0 +1,177 @@
+# P185 - Pilot Pricing Send Pack
+
+Status: draft  
+Audience: founder / operator / commercial  
+Purpose: compact send-after-demo pricing page for the current bounded coach_16 pilot only.
+
+---
+
+## Target
+
+- compact commercial send-after-demo pricing page for coach_16 pilot
+
+## Invariant
+
+- pricing pack must sell only the current coach_16 v0 offer and must not introduce team or organisation pricing drift
+
+## Proof
+
+- price pinned
+- cap pinned
+- included surfaces pinned
+- excluded surfaces pinned
+- any team, gym, unit, or organisation pricing drift fails
+
+---
+
+## 1. Current pilot offer
+
+Current bounded pilot offer:
+
+- one coach
+- coach_16 tier
+- one activity lane
+- 7 to 16 athletes
+- current v0 surface only
+
+Price:
+
+- GBP 59.99 per month
+
+This is a bounded early pilot.
+It is not a broader platform rollout.
+
+---
+
+## 2. What is included
+
+Included in the current pilot offer:
+
+- lawful onboarding
+- coach assignment
+- factual session execution
+- split / return
+- partial completion
+- coach-viewable factual artefacts
+- history counts
+- non-binding coach notes
+- athlete list management up to tier cap
+
+---
+
+## 3. What is not included
+
+Not included in the current pilot offer:
+
+- dashboards
+- analytics
+- rankings
+- readiness scoring
+- messaging
+- team runtime
+- unit runtime
+- gym runtime
+- organisation runtime
+- evidence sealing
+- exportable proof
+- replay or audit product claims
+- multi-coach rollout
+- multi-activity rollout
+
+---
+
+## 4. Commercial framing rule
+
+Use only bounded descriptive language.
+
+Safe framing:
+- bounded early pilot
+- coach_16 pilot
+- current v0 surface
+- deterministic execution alpha
+- one coach
+- one activity lane
+- 7 to 16 athletes
+- current included surfaces only
+
+Do not frame this as:
+- a team package
+- a club package
+- an organisation package
+- an all-in-one coaching platform
+- a dashboard or analytics product
+- a proof or audit product
+
+---
+
+## 5. Payment rule
+
+Payment controls access only.
+
+Payment does not:
+- change engine behaviour
+- change legality
+- change outputs
+- change truth
+- create authority beyond the current coach surface
+
+---
+
+## 6. Suggested send text
+
+Use this only after a demo when the lead is a valid current fit.
+
+Template:
+
+Hi [Name],
+
+Following the demo, the clean current starting point is the bounded coach_16 pilot:
+
+- one coach
+- one activity lane
+- 7 to 16 athletes
+- GBP 59.99 per month
+
+Included now:
+- lawful onboarding
+- coach assignment
+- factual session execution
+- split / return
+- partial completion
+- coach-viewable factual artefacts
+- history counts
+- non-binding coach notes
+
+Not included now:
+- dashboards
+- analytics
+- rankings
+- readiness scoring
+- messaging
+- team or organisation runtime
+- exportable proof
+
+If you want to proceed, reply with:
+- activity lane
+- athlete count
+- preferred start window
+
+Chris
+
+---
+
+## 7. Failure conditions
+
+This pack fails if:
+- it introduces any team, unit, gym, or organisation pricing
+- it implies more than one coach is included
+- it implies more than one activity lane is included
+- it claims dashboards, analytics, rankings, readiness scoring, or messaging
+- it implies proof export, evidence sealing, or audit product access
+- it implies pricing changes engine truth or authority
+
+---
+
+## 8. Final rule
+
+This pack exists to move a valid lead from demo interest to paid pilot decision without drifting off current v0 truth.


### PR DESCRIPTION
## Summary
- add P185 pilot pricing send pack for the bounded coach_16 offer
- pin current price, cap, included surfaces, and excluded surfaces
- ban team or organisation pricing drift beyond current v0 truth
- declare new commercial artefacts in the commercial artefact registry

## Testing
- node ci/scripts/run_commercial_artefact_registry_guard.mjs