### PR TITLE
docs(commercial): add demo-to-pilot cta contract

### DIFF
--- a/ci/registries/commercial_artefact_registry.json
+++ b/ci/registries/commercial_artefact_registry.json
@@ -240,6 +240,21 @@
                           "artefact_id":  "p185_pilot_pricing_guardrails",
                           "path":  "docs/commercial/P185_PILOT_PRICING_GUARDRAILS.json",
                           "class":  "commercial_registry"
+                      },
+                      {
+                          "artefact_id":  "p186_demo_to_pilot_cta_contract",
+                          "path":  "docs/commercial/P186_DEMO_TO_PILOT_CTA_CONTRACT.md",
+                          "class":  "commercial_surface"
+                      },
+                      {
+                          "artefact_id":  "p186_demo_to_pilot_cta_fields_registry",
+                          "path":  "docs/commercial/P186_DEMO_TO_PILOT_CTA_FIELDS_REGISTRY.json",
+                          "class":  "commercial_registry"
+                      },
+                      {
+                          "artefact_id":  "p186_demo_to_pilot_cta_guardrails",
+                          "path":  "docs/commercial/P186_DEMO_TO_PILOT_CTA_GUARDRAILS.json",
+                          "class":  "commercial_registry"
                       }
                   ]
 }

--- a/docs/commercial/P186_DEMO_TO_PILOT_CTA_CONTRACT.md
+++ b/docs/commercial/P186_DEMO_TO_PILOT_CTA_CONTRACT.md
@@ -1,0 +1,134 @@
+# P186 - Demo-to-Pilot CTA Contract
+
+Status: draft  
+Audience: founder / operator / commercial  
+Purpose: single exact next-step block for all post-demo follow-ups.
+
+---
+
+## Target
+
+- single exact next-step block used in all follow-ups
+
+## Invariant
+
+- CTA must ask only for activity lane, athlete count, preferred start window, and coach tier
+
+## Proof
+
+- CTA block pinned
+- allowed fields pinned
+- banned extra asks pinned
+- anything beyond the exact next-step contract is excluded
+
+---
+
+## 1. Use rule
+
+Use this CTA block:
+- after demo follow-up
+- after pricing send
+- after sales handoff
+- after warm / cold / hesitant follow-up
+- after qualification when the lead is still a valid fit
+
+Do not improvise a different close unless product truth changes.
+
+---
+
+## 2. Exact CTA block
+
+Use this exact block:
+
+If you want to move forward, reply with:
+- activity lane
+- athlete count
+- preferred start window
+- coach tier
+
+That is the contract.
+
+---
+
+## 3. Allowed values
+
+### Activity lane
+Allowed:
+- powerlifting
+- rugby_union
+- general_strength
+
+### Athlete count
+Allowed:
+- bounded pilot count only
+- expected current fit is within current pilot tier limits
+
+### Preferred start window
+Allowed:
+- a simple start timing answer
+- for example: this month, next month, specific week, or specific date window
+
+### Coach tier
+Allowed:
+- current bounded pilot tier only
+- coach_16
+
+---
+
+## 4. Banned extra asks
+
+Do not ask for:
+- team structure
+- organisation hierarchy
+- unit structure
+- gym structure
+- dashboard requirements
+- analytics requirements
+- messaging requirements
+- readiness requirements
+- proof export requirements
+- injury / outcome goals
+- retention goals
+- extra discovery questions inside the CTA block
+
+If those are needed, the lead is either not current v0 fit or the conversation should stay in qualification, not CTA.
+
+---
+
+## 5. Suggested exact send usage
+
+Template:
+
+Hi [Name],
+
+If you want to move forward, reply with:
+- activity lane
+- athlete count
+- preferred start window
+- coach tier
+
+Chris
+
+---
+
+## 6. Failure conditions
+
+This CTA fails if:
+- it asks for more than four fields
+- it asks for fields outside current v0 pilot setup need
+- it asks for organisation or team structure
+- it asks for unsupported surfaces
+- it asks for outcome or readiness information
+- it drifts away from coach_16 as the bounded current pilot tier
+
+---
+
+## 7. Final rule
+
+The purpose of this CTA is to remove friction, not reopen discovery.
+
+Ask only for:
+- activity lane
+- athlete count
+- preferred start window
+- coach tier

--- a/docs/commercial/P186_DEMO_TO_PILOT_CTA_FIELDS_REGISTRY.json
+++ b/docs/commercial/P186_DEMO_TO_PILOT_CTA_FIELDS_REGISTRY.json
@@ -1,0 +1,38 @@
+{
+  "artefact_id": "p186_demo_to_pilot_cta_fields_registry",
+  "version": "1.0.0",
+  "scope": "current_v0_only",
+  "cta_fields": [
+    {
+      "field_id": "activity_lane",
+      "allowed_values": [
+        "powerlifting",
+        "rugby_union",
+        "general_strength"
+      ]
+    },
+    {
+      "field_id": "athlete_count",
+      "allowed_values": [
+        "bounded_pilot_count_only"
+      ]
+    },
+    {
+      "field_id": "preferred_start_window",
+      "allowed_values": [
+        "simple_timing_answer",
+        "specific_week",
+        "specific_date_window",
+        "this_month",
+        "next_month"
+      ]
+    },
+    {
+      "field_id": "coach_tier",
+      "allowed_values": [
+        "coach_16"
+      ]
+    }
+  ],
+  "field_count_required": 4
+}

--- a/docs/commercial/P186_DEMO_TO_PILOT_CTA_GUARDRAILS.json
+++ b/docs/commercial/P186_DEMO_TO_PILOT_CTA_GUARDRAILS.json
@@ -1,0 +1,26 @@
+{
+  "artefact_id": "p186_demo_to_pilot_cta_guardrails",
+  "version": "1.0.0",
+  "rule": "cta_fails_if_it_asks_for_anything_beyond_the_four_pinned_fields",
+  "allowed_asks": [
+    "activity_lane",
+    "athlete_count",
+    "preferred_start_window",
+    "coach_tier"
+  ],
+  "banned_asks": [
+    "team_structure",
+    "organisation_hierarchy",
+    "unit_structure",
+    "gym_structure",
+    "dashboard_requirements",
+    "analytics_requirements",
+    "messaging_requirements",
+    "readiness_requirements",
+    "proof_export_requirements",
+    "injury_goals",
+    "outcome_goals",
+    "retention_goals",
+    "extra_discovery_questions"
+  ]
+}


### PR DESCRIPTION
## Summary
- add P186 demo-to-pilot CTA contract
- pin the exact four-field next-step block for all follow-ups
- ban extra discovery asks inside the CTA
- declare new commercial artefacts in the commercial artefact registry

## Testing
- node ci/scripts/run_commercial_artefact_registry_guard.mjs