### PR TITLE
docs(commercial): add pilot objection handling pack v2

### DIFF
--- a/ci/registries/commercial_artefact_registry.json
+++ b/ci/registries/commercial_artefact_registry.json
@@ -255,6 +255,21 @@
                           "artefact_id":  "p186_demo_to_pilot_cta_guardrails",
                           "path":  "docs/commercial/P186_DEMO_TO_PILOT_CTA_GUARDRAILS.json",
                           "class":  "commercial_registry"
+                      },
+                      {
+                          "artefact_id":  "p187_pilot_objection_handling_pack_v2",
+                          "path":  "docs/commercial/P187_PILOT_OBJECTION_HANDLING_PACK_V2.md",
+                          "class":  "commercial_surface"
+                      },
+                      {
+                          "artefact_id":  "p187_pilot_objection_response_registry",
+                          "path":  "docs/commercial/P187_PILOT_OBJECTION_RESPONSE_REGISTRY.json",
+                          "class":  "commercial_registry"
+                      },
+                      {
+                          "artefact_id":  "p187_pilot_objection_claim_guardrails",
+                          "path":  "docs/commercial/P187_PILOT_OBJECTION_CLAIM_GUARDRAILS.json",
+                          "class":  "commercial_registry"
                       }
                   ]
 }

--- a/docs/commercial/P187_PILOT_OBJECTION_CLAIM_GUARDRAILS.json
+++ b/docs/commercial/P187_PILOT_OBJECTION_CLAIM_GUARDRAILS.json
@@ -1,0 +1,34 @@
+{
+  "artefact_id": "p187_pilot_objection_claim_guardrails",
+  "version": "1.0.0",
+  "rule": "objection_answers_fail_if_they_imply_capability_beyond_current_v0_truth",
+  "allowed_claim_classes": [
+    "direct_no_answer",
+    "bounded_v0_scope_statement",
+    "explicit_exclusion_statement",
+    "fit_result_statement"
+  ],
+  "banned_claim_classes": [
+    "coming_soon_claim",
+    "soft_yes_without_capability",
+    "workaround_claim",
+    "roadmap_as_current_truth_claim",
+    "comparison_claim",
+    "proof_export_claim",
+    "outcome_tracking_claim",
+    "team_runtime_claim"
+  ],
+  "banned_examples": [
+    "coming soon",
+    "nearly there",
+    "basically yes",
+    "we can probably do that",
+    "we can work around that",
+    "it is in the roadmap so yes",
+    "we can treat it like a team setup",
+    "you can infer that from the data",
+    "export is not built but we can sort something",
+    "outcomes can be estimated",
+    "dashboards are not there yet but the same thing is available"
+  ]
+}

--- a/docs/commercial/P187_PILOT_OBJECTION_HANDLING_PACK_V2.md
+++ b/docs/commercial/P187_PILOT_OBJECTION_HANDLING_PACK_V2.md
@@ -1,0 +1,198 @@
+# P187 - Pilot Objection Handling Pack v2
+
+Status: draft  
+Audience: founder / operator / commercial  
+Purpose: structured, truth-bound answers to common pilot objections without drifting beyond current v0.
+
+---
+
+## Target
+
+- structured answers to common objections
+
+## Invariant
+
+- every answer must stay truth-bound to current v0
+
+## Proof
+
+- objection answers pinned
+- allowed response pattern pinned
+- banned claim inflation pinned
+- anything outside current v0 truth is excluded
+
+---
+
+## 1. Use rule
+
+Use this pack:
+- after demo
+- during follow-up calls
+- in post-demo replies
+- in pricing follow-up
+- in qualification conversations
+
+Do not improvise broader capability to rescue a weak-fit lead.
+
+---
+
+## 2. Response pattern
+
+Use this structure every time:
+
+1. answer directly
+2. state the current truth
+3. state the boundary
+4. restate the bounded pilot if still relevant
+
+Do not:
+- dodge
+- imply hidden capability
+- promise near-term delivery as if it exists now
+- convert a red-fit objection into a fake green-fit answer
+
+---
+
+## 3. Objection: "Do you have dashboards?"
+
+Answer:
+
+Not in the current v0 pilot.
+
+Current v0 covers:
+- lawful onboarding
+- coach assignment
+- factual session execution
+- split / return
+- partial completion
+- coach-viewable factual artefacts
+- history counts
+- non-binding coach notes
+
+It does not currently include dashboards or analytics surfaces.
+
+If a bounded early pilot is still useful without dashboards, the clean current fit is one coach, one activity lane, and a bounded athlete group.
+
+---
+
+## 4. Objection: "Can this work for teams?"
+
+Answer:
+
+Not as team runtime in current v0.
+
+The current pilot is bounded around:
+- one coach
+- one activity lane
+- current v0 surfaces only
+
+So the honest answer is:
+- it can support a bounded coach-run pilot
+- it is not being sold as team, unit, gym, or organisation runtime
+
+If team runtime is required now, that is not a current v0 fit.
+
+---
+
+## 5. Objection: "Can I compare athletes?"
+
+Answer:
+
+Not through dashboard or comparison tooling in current v0.
+
+Current v0 supports factual execution surfaces and history counts, but it is not being sold as athlete comparison, ranking, or analytics software.
+
+If athlete comparison is a must-have now, that is outside the current bounded pilot.
+
+---
+
+## 6. Objection: "Can I export proof?"
+
+Answer:
+
+Not in the current v0 pilot.
+
+Current v0 is not being sold as:
+- exportable proof
+- sealed evidence
+- audit product
+- replay or proof-completion layer
+
+The current pilot is about bounded onboarding and execution surfaces only.
+
+If exportable proof is required now, that is not a current v0 fit.
+
+---
+
+## 7. Objection: "Can this track outcomes?"
+
+Answer:
+
+Not as outcome tracking or performance proof in current v0.
+
+The current product truth is about factual execution flow, not outcome evaluation.
+
+So the honest boundary is:
+- yes to factual onboarding and execution surfaces
+- no to outcome tracking, readiness scoring, improvement claims, or performance proof
+
+If outcome tracking is essential now, that is outside current v0.
+
+---
+
+## 8. Short answer variants
+
+### Dashboards
+No. Current v0 does not include dashboards.
+
+### Teams
+No as team runtime. Current v0 is a bounded one-coach pilot.
+
+### Compare athletes
+No as comparison or ranking tooling. Current v0 supports factual surfaces and history counts only.
+
+### Export proof
+No. Current v0 does not include proof export or evidence sealing.
+
+### Track outcomes
+No. Current v0 is not an outcome tracking or performance proof layer.
+
+---
+
+## 9. Allowed phrases
+
+Safe phrases:
+- current v0
+- bounded early pilot
+- one coach
+- one activity lane
+- factual execution surfaces
+- history counts
+- non-binding coach notes
+- not in current v0
+- not a current v0 fit
+
+---
+
+## 10. Banned phrases
+
+Do not use:
+- coming soon
+- nearly there
+- basically yes
+- we can probably do that
+- we can work around that
+- it is in the roadmap so yes
+- we can treat it like a team setup
+- you can infer that from the data
+- export is not built but we can sort something
+- outcomes can be estimated
+- dashboards are not there yet but the same thing is available
+
+---
+
+## 11. Final rule
+
+The purpose of this pack is to remove stalls without lying.
+
+If the truthful answer is no, say no and hold the boundary.

--- a/docs/commercial/P187_PILOT_OBJECTION_RESPONSE_REGISTRY.json
+++ b/docs/commercial/P187_PILOT_OBJECTION_RESPONSE_REGISTRY.json
@@ -1,0 +1,43 @@
+{
+  "artefact_id": "p187_pilot_objection_response_registry",
+  "version": "1.0.0",
+  "scope": "current_v0_only",
+  "objections": [
+    {
+      "objection_id": "dashboards",
+      "question": "Do you have dashboards?",
+      "truth_bound_answer": "No. Current v0 does not include dashboards.",
+      "fit_result_if_required_now": "red"
+    },
+    {
+      "objection_id": "teams",
+      "question": "Can this work for teams?",
+      "truth_bound_answer": "No as team runtime. Current v0 is a bounded one-coach pilot.",
+      "fit_result_if_required_now": "red"
+    },
+    {
+      "objection_id": "compare_athletes",
+      "question": "Can I compare athletes?",
+      "truth_bound_answer": "No as comparison or ranking tooling. Current v0 supports factual surfaces and history counts only.",
+      "fit_result_if_required_now": "red"
+    },
+    {
+      "objection_id": "export_proof",
+      "question": "Can I export proof?",
+      "truth_bound_answer": "No. Current v0 does not include proof export or evidence sealing.",
+      "fit_result_if_required_now": "red"
+    },
+    {
+      "objection_id": "track_outcomes",
+      "question": "Can this track outcomes?",
+      "truth_bound_answer": "No. Current v0 is not an outcome tracking or performance proof layer.",
+      "fit_result_if_required_now": "red"
+    }
+  ],
+  "response_pattern": [
+    "answer_directly",
+    "state_current_truth",
+    "state_boundary",
+    "restate_bounded_pilot_if_still_relevant"
+  ]
+}


### PR DESCRIPTION
## Summary
- add P187 pilot objection handling pack v2
- pin truth-bound answers to common pilot objections
- ban claim inflation and soft-yes workaround language
- declare new commercial artefacts in the commercial artefact registry

## Testing
- node ci/scripts/run_commercial_artefact_registry_guard.mjs