### PR TITLE
docs(commercial): add pilot intake form spec

### DIFF
--- a/ci/registries/commercial_artefact_registry.json
+++ b/ci/registries/commercial_artefact_registry.json
@@ -285,6 +285,21 @@
                           "artefact_id":  "p188_pilot_eligibility_exclusions",
                           "path":  "docs/commercial/P188_PILOT_ELIGIBILITY_EXCLUSIONS.json",
                           "class":  "commercial_registry"
+                      },
+                      {
+                          "artefact_id":  "p189_pilot_intake_form_spec",
+                          "path":  "docs/commercial/P189_PILOT_INTAKE_FORM_SPEC.md",
+                          "class":  "commercial_surface"
+                      },
+                      {
+                          "artefact_id":  "p189_pilot_intake_fields_registry",
+                          "path":  "docs/commercial/P189_PILOT_INTAKE_FIELDS_REGISTRY.json",
+                          "class":  "commercial_registry"
+                      },
+                      {
+                          "artefact_id":  "p189_pilot_intake_guardrails",
+                          "path":  "docs/commercial/P189_PILOT_INTAKE_GUARDRAILS.json",
+                          "class":  "commercial_registry"
                       }
                   ]
 }

--- a/docs/commercial/P189_PILOT_INTAKE_FIELDS_REGISTRY.json
+++ b/docs/commercial/P189_PILOT_INTAKE_FIELDS_REGISTRY.json
@@ -1,0 +1,63 @@
+{
+  "artefact_id": "p189_pilot_intake_fields_registry",
+  "version": "1.0.0",
+  "scope": "current_v0_only",
+  "required_fields": [
+    {
+      "field_id": "coach_full_name",
+      "required": true
+    },
+    {
+      "field_id": "coach_email",
+      "required": true
+    },
+    {
+      "field_id": "activity_lane",
+      "required": true,
+      "allowed_values": [
+        "powerlifting",
+        "rugby_union",
+        "general_strength"
+      ]
+    },
+    {
+      "field_id": "athlete_count",
+      "required": true,
+      "allowed_values": [
+        "bounded_current_pilot_tier_only"
+      ]
+    },
+    {
+      "field_id": "preferred_start_window",
+      "required": true,
+      "allowed_values": [
+        "simple_timing_answer",
+        "specific_week",
+        "specific_date_window",
+        "this_month",
+        "next_month"
+      ]
+    },
+    {
+      "field_id": "coach_tier",
+      "required": true,
+      "allowed_values": [
+        "coach_16"
+      ]
+    }
+  ],
+  "optional_fields": [
+    {
+      "field_id": "short_setup_note",
+      "required": false
+    },
+    {
+      "field_id": "billing_contact_name",
+      "required": false
+    },
+    {
+      "field_id": "billing_contact_email",
+      "required": false
+    }
+  ]
+}

--- a/docs/commercial/P189_PILOT_INTAKE_FORM_SPEC.md
+++ b/docs/commercial/P189_PILOT_INTAKE_FORM_SPEC.md
@@ -1,0 +1,189 @@
+# P189 - Pilot Intake Form Spec
+
+Status: draft
+Audience: founder / operator / commercial
+Purpose: minimal intake schema for paid pilot setup that standardises sales handoff into delivery without collecting anything beyond current v0 setup need.
+
+---
+
+## Target
+
+- minimal intake schema for paid pilot setup
+
+## Invariant
+
+- intake must collect only what current setup actually needs
+
+## Proof
+
+- intake fields pinned
+- required vs optional pinned
+- banned extra fields pinned
+- anything beyond current v0 pilot setup fails
+
+---
+
+## 1. Use rule
+
+Use this intake spec only after:
+- the lead has agreed to proceed
+- the lead is already a valid current v0 fit
+- the pilot is being handed from commercial into setup
+
+Do not use intake to reopen discovery or sneak in broader scope mapping.
+
+---
+
+## 2. Current setup truth
+
+The intake form exists only to capture setup for the bounded current v0 pilot:
+
+- one coach
+- one activity lane
+- bounded athlete count inside current tier
+- preferred start window
+- current coach tier
+
+Current included surfaces:
+- lawful onboarding
+- coach assignment
+- factual session execution
+- split / return
+- partial completion
+- coach-viewable factual artefacts
+- history counts
+- non-binding coach notes
+
+Not included:
+- dashboards
+- analytics
+- rankings
+- readiness scoring
+- messaging
+- team runtime
+- unit runtime
+- gym runtime
+- organisation runtime
+- proof export
+- evidence sealing
+- outcome tracking
+
+---
+
+## 3. Required fields
+
+The intake form must require only:
+
+- coach full name
+- coach email
+- activity lane
+- athlete count
+- preferred start window
+- coach tier
+
+These are the minimum fields required to set up the bounded current pilot.
+
+---
+
+## 4. Optional fields
+
+The intake form may optionally collect:
+
+- short setup note
+- billing contact name
+- billing contact email
+
+Optional means optional.
+If the pilot can start without it, it must not become a hidden required field.
+
+---
+
+## 5. Banned fields
+
+Do not collect:
+
+- organisation hierarchy
+- team hierarchy
+- unit structure
+- gym structure
+- dashboard requirements
+- analytics requirements
+- messaging requirements
+- readiness requirements
+- proof export requirements
+- athlete comparison requirements
+- outcome goals
+- retention goals
+- injury or rehab claims
+- multi-coach rollout planning
+- multi-activity rollout planning
+
+If those fields are needed, the lead is either outside current v0 fit or the intake is being abused.
+
+---
+
+## 6. Suggested exact intake structure
+
+Use this structure:
+
+### Required
+- coach full name
+- coach email
+- activity lane
+- athlete count
+- preferred start window
+- coach tier
+
+### Optional
+- short setup note
+- billing contact name
+- billing contact email
+
+### Excluded
+- everything outside current v0 pilot setup need
+
+---
+
+## 7. Field rules
+
+### Coach full name
+Used to identify the single operating coach for the pilot.
+
+### Coach email
+Used for commercial and setup contact.
+
+### Activity lane
+Must be one of:
+- powerlifting
+- rugby_union
+- general_strength
+
+### Athlete count
+Must be bounded to the current pilot tier and current v0 fit.
+
+### Preferred start window
+Must be a simple timing input only.
+
+### Coach tier
+Must match the bounded current pilot offer.
+
+---
+
+## 8. Failure conditions
+
+This intake spec fails if:
+- it asks for more than the minimum current setup need
+- it turns optional fields into hidden required fields
+- it collects organisation, team, unit, or gym runtime structure
+- it collects dashboard, analytics, messaging, proof, or outcome requirements
+- it drifts away from one coach, one activity lane, and bounded athlete count
+- it becomes discovery instead of setup
+
+---
+
+## 9. Final rule
+
+This intake exists to move from sale to setup cleanly.
+
+Collect only what current setup actually needs.
+Nothing else.

--- a/docs/commercial/P189_PILOT_INTAKE_GUARDRAILS.json
+++ b/docs/commercial/P189_PILOT_INTAKE_GUARDRAILS.json
@@ -1,0 +1,46 @@
+{
+  "artefact_id": "p189_pilot_intake_guardrails",
+  "version": "1.0.0",
+  "rule": "intake_fails_if_it_collects_beyond_current_v0_setup_need",
+  "allowed_field_classes": [
+    "single_coach_identity_field",
+    "single_coach_contact_field",
+    "activity_lane_field",
+    "bounded_athlete_count_field",
+    "preferred_start_window_field",
+    "coach_tier_field",
+    "optional_setup_note_field",
+    "optional_billing_contact_field"
+  ],
+  "banned_field_classes": [
+    "organisation_structure_field",
+    "team_structure_field",
+    "unit_structure_field",
+    "gym_structure_field",
+    "dashboard_requirement_field",
+    "analytics_requirement_field",
+    "messaging_requirement_field",
+    "readiness_requirement_field",
+    "proof_export_requirement_field",
+    "comparison_requirement_field",
+    "outcome_goal_field",
+    "retention_goal_field",
+    "multi_coach_rollout_field",
+    "multi_activity_rollout_field"
+  ],
+  "banned_examples": [
+    "organisation hierarchy",
+    "team hierarchy",
+    "unit structure",
+    "gym structure",
+    "dashboard requirements",
+    "analytics requirements",
+    "messaging requirements",
+    "proof export requirements",
+    "athlete comparison requirements",
+    "outcome goals",
+    "retention goals",
+    "multi-coach rollout planning",
+    "multi-activity rollout planning"
+  ]
+}


### PR DESCRIPTION
## Summary
- add P189 pilot intake form spec
- pin the minimum required and optional fields for paid pilot setup
- ban intake drift beyond current v0 setup need
- declare new commercial artefacts in the commercial artefact registry

## Testing
- node ci/scripts/run_commercial_artefact_registry_guard.mjs