### PR TITLE
docs(demo): add P193 coach welcome pack

### DIFF
--- a/docs/demo/P193_COACH_WELCOME_PACK.md
+++ b/docs/demo/P193_COACH_WELCOME_PACK.md
@@ -1,0 +1,240 @@
+# P193 — Coach Welcome Pack
+
+Status: Draft  
+Owner: Founder / Ops / Product  
+Scope: v0 only  
+Rewrite policy: rewrite-only  
+Last updated: 2026-04-13
+
+---
+
+## Target
+
+Define the first coach-facing welcome pack a paid coach receives after activation.
+
+This pack exists to:
+- improve first-use activation
+- reduce confusion about scope and authority
+- get a paid coach to first useful action quickly
+- avoid implying unsupported product behaviour
+
+---
+
+## Invariant
+
+This pack MUST remain inside current v0 boundaries.
+
+It MUST:
+- describe only coach capabilities that exist now
+- separate platform access from engine authority
+- describe coach permissions in neutral terms
+- avoid promising unsupported product, org, audit, replay, or evidence features
+
+It MUST NOT:
+- imply coaching authority over engine truth
+- imply declaration editing
+- imply engine override power
+- imply dashboards, messaging, rankings, or org runtime features
+- imply proof-complete, evidence, audit, or export behaviour beyond v0
+
+---
+
+## Proof
+
+This pack is correct only if all of the following are true:
+
+- every stated coach capability exists in current v0
+- every excluded capability is clearly stated
+- the first three actions are executable in the current product path
+- the wording improves activation without widening scope
+- no sentence implies safety, recommendation, optimisation, or unsupported authority
+
+---
+
+## Audience
+
+This artifact is written for:
+
+- a newly activated paid coach
+- operating inside current v0
+- using coach-managed or individual workflows only
+
+It is not written for:
+- organisations
+- federations
+- teams
+- units
+- gyms
+- proof/audit operators
+
+---
+
+## Delivery rule
+
+This pack may be sent as:
+- the first welcome email body
+- a linked onboarding doc
+- an in-product welcome panel
+- an operator handoff message
+
+The wording must stay materially the same across surfaces.
+
+---
+
+## Coach Welcome Pack — canonical draft
+
+## Welcome to Kolosseum
+
+You now have access to the current coach surface in Kolosseum.
+
+Kolosseum is built to keep execution, records, and boundaries clear. Your coach access is designed to let you work with athletes inside the current system limits without giving you hidden override power over engine truth.
+
+### What you get right now
+
+As a coach in the current version, you can:
+
+- work with assigned athletes inside your coach scope
+- view factual execution artefacts for those athletes
+- assign within the system’s current boundaries
+- add non-binding coach notes
+- see simple historical views such as counts and execution history where available
+
+### What you do not get
+
+Your current coach access does not include:
+
+- editing athlete declarations directly
+- overriding engine decisions
+- changing legality, constraints, or substitutions at engine level
+- registry access or logic editing
+- cross-athlete access outside your assigned scope
+- dashboards, rankings, messaging, or broader org runtime controls
+- proof, evidence, replay, or export authority beyond the current v0 surface
+
+### How to think about your role
+
+Your role in the current product is operational and observational.
+
+That means you can:
+- work with athletes assigned to you
+- see what was executed
+- add context through notes
+
+It also means you cannot:
+- rewrite engine truth
+- force outcomes through hidden controls
+- change athlete declarations on their behalf inside the engine path
+
+### Your first 3 actions
+
+#### 1. Confirm your assigned athletes
+Open your coach view and confirm which athletes are currently linked to you.
+
+You should only see athletes who are explicitly assigned to your coach scope. If someone is missing, that is a platform linkage issue, not something to solve by workaround.
+
+#### 2. Check that each athlete is onboarding-complete
+Before a session can exist, the athlete must have a lawful accepted declaration.
+
+Your immediate job is to check who is:
+- ready for execution
+- still pending onboarding
+- blocked before compile
+
+Do not try to bypass missing declarations. If Phase 1 is not accepted, the engine path does not exist yet for that athlete.
+
+#### 3. Open the first executable session and use notes only where needed
+For athletes who are ready, open the first executable session and review the factual artefact.
+
+Where useful, add a non-binding coach note. Keep notes for context and communication, not for trying to steer engine behaviour.
+
+### What “ready” means in practice
+
+An athlete is coach-ready only when:
+- they are linked to you
+- their declaration is accepted
+- the first executable session exists
+- you can view the factual artefact
+
+If any of those are missing, the athlete is not yet in a live coach-operable state.
+
+### What to do if something looks wrong
+
+If you cannot see an athlete, cannot see a session, or something appears blocked, treat it as one of three issues:
+
+- commercial / access issue
+- platform linkage issue
+- declaration or compile issue
+
+Do not assume the system will fill gaps automatically. Kolosseum does not rely on hidden defaults or silent corrections in the engine path.
+
+### Current scope reminder
+
+The current coach experience is intentionally narrow.
+
+It is built for:
+- assignment within current limits
+- factual artefact viewing
+- non-binding notes
+- clean operational use
+
+It is not yet a broad coaching platform with full org controls, messaging, or proof-layer outputs.
+
+### Bottom line
+
+Use Kolosseum to work cleanly inside the declared system path:
+
+- confirm assignment
+- confirm athlete readiness
+- open the executable session
+- add notes where useful
+- do not try to override the engine path
+
+That is the fastest route to productive use in the current version.
+
+---
+
+## Short-form version
+
+Use this where a shorter welcome is needed.
+
+### Welcome to Kolosseum
+
+You now have access to the current coach surface.
+
+What you can do:
+- view assigned athletes
+- view factual execution artefacts
+- assign within current system limits
+- add non-binding notes
+
+What you cannot do:
+- edit athlete declarations
+- override engine decisions
+- change logic or registries
+- access wider dashboards, rankings, or proof-layer surfaces
+
+Your first 3 actions:
+1. confirm your assigned athletes
+2. check which athletes are onboarding-complete
+3. open the first executable session and add notes only where useful
+
+If something is missing, treat it as an access, linkage, declaration, or compile issue rather than trying to work around the system.
+
+---
+
+## Non-goals
+
+This pack does not:
+- sell broad future scope
+- explain internal engine phases in depth
+- promise unsupported coach power
+- widen v0 boundaries
+- describe org/team/federation features as current coach features
+
+---
+
+## Final rule
+
+If this pack says a coach can do something, that capability must already exist in the active v0 surface.
+
+If it does not exist now, it must not appear here.


### PR DESCRIPTION
## Summary
- add repo-ready P193 coach welcome pack
- explain what a paid coach gets and does not get
- define the first 3 activation actions without widening v0 scope