### PR TITLE
docs(demo): add P194 athlete invite pack

### DIFF
--- a/docs/demo/P194_ATHLETE_INVITE_PACK.md
+++ b/docs/demo/P194_ATHLETE_INVITE_PACK.md
@@ -1,0 +1,248 @@
+# P194 — Athlete Invite Pack
+
+Status: Draft  
+Owner: Founder / Ops / Product  
+Scope: v0 only  
+Rewrite policy: rewrite-only  
+Last updated: 2026-04-13
+
+---
+
+## Target
+
+Define the minimal athlete-facing invite text for a coach-managed pilot.
+
+This pack exists to:
+- reduce onboarding friction
+- explain the athlete’s first steps clearly
+- set correct expectations about what the current product does
+- avoid unsupported claims about safety, outcomes, optimisation, or readiness
+
+---
+
+## Invariant
+
+This pack MUST remain inside current v0 boundaries.
+
+It MUST:
+- describe the current athlete path in plain terms
+- explain that onboarding is required before a session can exist
+- describe only capabilities that exist now
+- keep wording descriptive and operational
+
+It MUST NOT:
+- imply safety, suitability, or readiness claims
+- imply guaranteed outcomes
+- imply hidden defaults, silent corrections, or auto-completion
+- imply broad platform features that do not exist in current v0
+- imply that the coach can override engine truth on the athlete’s behalf
+
+---
+
+## Proof
+
+This pack is correct only if all of the following are true:
+
+- every described athlete step exists in the current pilot path
+- the wording remains neutral and descriptive
+- the first actions are executable now
+- the copy does not widen v0 scope
+- no line implies safety, outcome, optimisation, or readiness judgement
+
+---
+
+## Audience
+
+This artifact is written for:
+
+- an athlete invited into a coach-managed pilot
+- operating inside current v0
+- completing the first onboarding path needed before session execution
+
+It is not written for:
+- organisations
+- federations
+- teams as admin entities
+- proof/audit operators
+- general public marketing use
+
+---
+
+## Delivery rule
+
+This pack may be sent as:
+- the first athlete invite email body
+- a linked onboarding doc
+- an in-product invite panel
+- an operator handoff message
+
+The wording must stay materially the same across surfaces.
+
+---
+
+## Athlete Invite Pack — canonical draft
+
+## You’ve been invited to Kolosseum
+
+You have been invited to join a coach-managed pilot in Kolosseum.
+
+Kolosseum is the system being used for the current training and execution flow in this pilot. Your first step is to complete the required onboarding information so the system can create your initial executable session path.
+
+### What happens next
+
+Your coach can work with you inside the current system limits, but your path does not begin until your own onboarding declaration is completed and accepted.
+
+That means:
+
+- you receive access to your athlete path
+- you complete the required onboarding information
+- the system checks that the required declaration is complete
+- once accepted, your first executable session can exist
+
+If onboarding is incomplete, the execution path does not exist yet.
+
+### What you get right now
+
+In the current version, you can:
+
+- access your athlete path in the pilot
+- complete the required onboarding declaration
+- view your own executable session when available
+- use the current session execution flow
+- see your own factual session history and simple counts where available
+
+### What this does not mean
+
+This invite does not mean:
+
+- your session already exists
+- missing information will be filled in for you automatically
+- your coach can bypass your declaration on your behalf
+- the system is making safety, readiness, or outcome claims
+- broader dashboards, messaging, rankings, or proof-layer features are part of your current pilot path
+
+### Your first 3 actions
+
+#### 1. Accept the invite and open your athlete path
+Open the invite link and confirm you can access your athlete flow.
+
+If access is missing, treat that as an invite or access issue rather than trying to work around it.
+
+#### 2. Complete the required onboarding information
+Fill in the required onboarding declaration fully and accurately.
+
+Your onboarding declaration is what allows the system to create your executable path. If required fields are missing or invalid, the path cannot move forward.
+
+#### 3. Check whether your first executable session is available
+Once onboarding has been accepted, open your athlete view and check whether your first executable session is available.
+
+If it is available, you can move into the current execution flow.
+If it is not available yet, the issue is still in access, declaration, or compile state.
+
+### What your coach can and cannot do
+
+Your coach can:
+- work with you inside the current pilot scope
+- view factual execution artefacts
+- add non-binding notes
+
+Your coach cannot:
+- silently change your declaration inside the engine path
+- override engine truth
+- force a session into existence before the declaration path is valid
+
+### What “ready” means in practice
+
+For this pilot, your path is live only when:
+
+- your invite/access is active
+- your onboarding declaration has been accepted
+- your first executable session exists
+- you can open that session in your athlete view
+
+If one of those is missing, your live execution path is not ready yet.
+
+### If something looks wrong
+
+If you cannot access the system, cannot finish onboarding, or cannot see a session, treat it as one of three issues:
+
+- access issue
+- declaration issue
+- compile issue
+
+Do not assume the system will guess or fill missing information for you.
+
+### Current scope reminder
+
+The current athlete experience is intentionally narrow.
+
+It is built for:
+- onboarding declaration
+- executable session access
+- session execution
+- factual history and counts
+
+It is not a broad all-in-one platform experience with every future surface enabled.
+
+### Bottom line
+
+Your fastest route through the pilot is:
+
+- accept access
+- complete onboarding
+- wait for accepted declaration
+- open the first executable session
+- use the current execution flow
+
+That is the clean path into the coach-managed pilot.
+
+---
+
+## Short-form version
+
+Use this where a shorter invite is needed.
+
+### You’ve been invited to Kolosseum
+
+You have been invited into a coach-managed pilot.
+
+Your first step is to complete the required onboarding information. Until that declaration is accepted, your executable session path does not exist yet.
+
+What you can do now:
+- access your athlete path
+- complete onboarding
+- open your first executable session when available
+- use the current execution flow
+- view your own factual history where available
+
+What this does not mean:
+- no automatic filling of missing information
+- no coach override of your declaration path
+- no safety, readiness, or outcome claims
+- no wider platform features beyond the current pilot scope
+
+Your first 3 actions:
+1. accept the invite and open your athlete path
+2. complete the required onboarding information
+3. check whether your first executable session is available
+
+If something is missing, treat it as an access, declaration, or compile issue.
+
+---
+
+## Non-goals
+
+This pack does not:
+- explain internal engine phases in depth
+- promise training outcomes
+- imply safety or suitability
+- widen v0 scope
+- describe future platform surfaces as current pilot features
+
+---
+
+## Final rule
+
+If this pack says an athlete can do something, that capability must already exist in the active v0 pilot path.
+
+If it does not exist now, it must not appear here.


### PR DESCRIPTION
## Summary
- add repo-ready P194 athlete invite pack
- explain the first athlete-facing invite path for coach-managed pilot
- keep wording descriptive and inside v0 boundaries