### PR TITLE
docs(demo): add P196 sales claim registry

### DIFF
--- a/docs/demo/P196_SALES_CLAIM_REGISTRY.md
+++ b/docs/demo/P196_SALES_CLAIM_REGISTRY.md
@@ -1,0 +1,498 @@
+# P196 — Sales Claim Registry
+
+Status: Draft  
+Owner: Founder / Sales / Product  
+Scope: v0 only  
+Rewrite policy: rewrite-only  
+Last updated: 2026-04-13
+
+---
+
+## Target
+
+Define the central registry of allowed commercial phrases for Kolosseum v0.
+
+This registry exists to:
+- prevent sales-language drift
+- keep founder, sales, and follow-up wording aligned
+- provide a reusable claim source for demos, follow-up emails, decks, and one-pagers
+- stop commercial language from exceeding current v0 product truth
+
+---
+
+## Invariant
+
+This registry MUST stay inside current v0 boundaries.
+
+It MUST:
+- use only claims that are real in the current product
+- keep language descriptive, mechanical, and outcome-neutral
+- separate access, visibility, and workflow from engine truth
+- reflect the current v0 scope exactly
+
+It MUST NOT:
+- imply safety, suitability, injury prevention, or medical benefit
+- imply optimisation, recommendation, personalisation, or readiness judgement
+- imply coaching authority, expert endorsement, or proof-complete status
+- imply broader org, dashboard, messaging, audit, replay, or evidence capability beyond current v0
+- imply that payment, tier, or hierarchy changes engine truth
+
+---
+
+## Proof
+
+This registry is correct only if all of the following are true:
+
+- every allowed claim is supported by current v0 product scope
+- every forbidden claim is blocked by current legal/commercial boundaries
+- the registry can be reused across sales surfaces without widening scope
+- no approved phrase requires caveats to stop it from becoming misleading
+- the wording remains commercially usable without becoming legally or technically false
+
+---
+
+## Authority basis
+
+This registry consolidates current sales-safe wording from the active v0 boundary and current claim limits.
+
+Binding basis:
+- commercial access does not create engine authority
+- coach surface in v0 is limited
+- v0 is the Deterministic Execution Alpha, not the proof-complete system
+- all external representation must remain descriptive, mechanical, and neutral
+- absence from the allowed set means the phrase is not approved
+
+---
+
+## Canonical short definition
+
+Use this exact sentence where a one-line v0 definition is needed:
+
+"Kolosseum v0 is the Deterministic Execution Alpha: a closed-world, coach-operable execution system for individual and coach-managed sessions across powerlifting, rugby_union, and general_strength, limited to Phase 1-6, factual runtime execution, split/return, partial completion, and CI-enforced deterministic boundaries."
+
+---
+
+## Claim classes
+
+Every commercial phrase must fall into exactly one of these classes:
+
+1. approved  
+2. restricted  
+3. forbidden  
+
+If a phrase does not clearly fit, it is not approved.
+
+---
+
+## 1. Approved claim classes
+
+### 1.1 Product definition claims
+
+Approved phrases:
+- "Deterministic Execution Alpha"
+- "closed-world execution system"
+- "coach-operable execution system"
+- "engine-backed execution flow"
+- "minimal product surface"
+- "current v0 build"
+- "current v0 pilot path"
+
+Approved example sentences:
+- "Kolosseum v0 is a coach-operable deterministic execution alpha."
+- "The current v0 build is a closed-world execution system with a minimal product surface."
+- "This pilot uses the current v0 path, not the later proof-complete scope."
+
+---
+
+### 1.2 Scope claims
+
+Approved phrases:
+- "individual and coach-managed sessions"
+- "three supported activities"
+- "powerlifting, rugby_union, and general_strength"
+- "Phase 1-6 only"
+- "factual runtime execution"
+- "split/return"
+- "partial completion"
+- "coach assignment"
+- "non-binding coach notes"
+
+Approved example sentences:
+- "The current v0 scope supports individual and coach-managed execution only."
+- "v0 supports three activities: powerlifting, rugby_union, and general_strength."
+- "The current pilot path includes onboarding, execution, split/return, partial completion, and bounded coach interaction."
+
+---
+
+### 1.3 Mechanical behaviour claims
+
+Approved phrases:
+- "deterministic behaviour"
+- "constraint-responsive"
+- "declaration-driven"
+- "registry-driven"
+- "canonical input"
+- "factual artefacts"
+- "records what happened"
+- "engine-neutral to payment"
+- "access does not change engine truth"
+
+Approved example sentences:
+- "The system is declaration-driven and registry-driven."
+- "The current path records factual execution artefacts."
+- "Payment and commercial access do not change engine truth."
+
+---
+
+### 1.4 Coach-surface claims
+
+Approved phrases:
+- "coach-scoped athlete view"
+- "view factual execution artefacts"
+- "assign within current system limits"
+- "write non-binding coach notes"
+- "bounded coach interaction"
+
+Approved example sentences:
+- "In v0, coaches can assign within current limits, view factual artefacts, and write non-binding notes."
+- "Coach access is scoped and bounded in the current pilot path."
+
+---
+
+### 1.5 Athlete-path claims
+
+Approved phrases:
+- "athlete onboarding declaration"
+- "first executable session"
+- "session execution flow"
+- "history with counts only"
+- "current athlete path"
+
+Approved example sentences:
+- "The athlete path starts with a required onboarding declaration."
+- "Once the declaration path is valid, the first executable session can exist."
+- "The current athlete path includes execution and factual history with counts."
+
+---
+
+### 1.6 Replay / proof boundary claims
+
+Approved phrases:
+- "CI-enforced deterministic boundaries"
+- "replay-honest"
+- "deterministic verification within current scope"
+- "not evidence-complete"
+- "not proof-complete"
+- "v1 is the later lawful proof boundary"
+
+Approved example sentences:
+- "v0 includes deterministic verification within the current declared scope."
+- "This is not the proof-complete system."
+- "Truth projection, sealing, export, and the full proof boundary sit in v1, not v0."
+
+---
+
+## 2. Restricted claims
+
+Restricted claims may be used only in the exact approved form.
+
+### 2.1 “Deterministic”
+Allowed only when referring to:
+- execution
+- behaviour
+- boundaries
+- verification within current declared scope
+
+Approved:
+- "deterministic execution"
+- "deterministic boundaries"
+- "deterministic verification within current scope"
+
+Not approved:
+- "deterministically optimal"
+- "deterministically safer"
+- "deterministically better"
+
+---
+
+### 2.2 “Replay”
+Allowed only when narrowed to current proven scope.
+
+Approved:
+- "replay-honest within current scope"
+- "deterministic verification within the current replay boundary"
+
+Not approved:
+- "full replay proof"
+- "lawful proof of all outputs"
+- "evidence-grade replay" for v0
+
+---
+
+### 2.3 “Coach-operable”
+Allowed only to describe bounded workflow.
+
+Approved:
+- "coach-operable execution system"
+- "coach-operable pilot path"
+
+Not approved:
+- "coach-led intelligence layer"
+- "coach-controlled engine"
+- "coach-directed decision engine"
+
+---
+
+### 2.4 “Auditable” / “audit”
+Do not use for v0 external sales wording unless narrowly scoped and necessary.
+
+Prefer instead:
+- "factual artefacts"
+- "recorded execution history"
+- "deterministic boundaries"
+
+Avoid:
+- "audit-ready"
+- "audit-grade"
+- "compliance-ready"
+- "evidence-ready"
+
+---
+
+## 3. Forbidden claim classes
+
+### 3.1 Safety / medical / health claims
+
+Forbidden phrases include:
+- safe
+- safer
+- safety
+- reduces risk
+- lowers injury risk
+- prevents injury
+- protects athletes
+- rehab
+- recovery
+- treatment
+- diagnosis
+- pain management
+- medically informed
+- clinically validated
+
+Forbidden example sentences:
+- "Kolosseum helps coaches make safer decisions."
+- "This reduces athlete risk."
+- "The system helps prevent injury."
+
+---
+
+### 3.2 Optimisation / recommendation / tailoring claims
+
+Forbidden phrases include:
+- optimise
+- optimisation
+- best
+- ideal
+- recommended
+- tailored
+- designed for you
+- personalised
+- readiness
+- preparedness
+- performance improvement
+- smarter programming
+
+Forbidden example sentences:
+- "Kolosseum optimises training."
+- "The engine recommends the best session."
+- "The system is tailored to the athlete."
+
+---
+
+### 3.3 Authority / validation / expertise claims
+
+Forbidden phrases include:
+- coach-approved
+- expert-designed
+- scientifically validated
+- clinically validated
+- professional oversight
+- compliance enforcement
+- system-approved
+- trusted decision engine
+
+Forbidden example sentences:
+- "The platform gives coaches approved decisions."
+- "This is expert-designed training logic."
+- "The system validates the right path."
+
+---
+
+### 3.4 Broader-scope product claims
+
+Forbidden phrases include:
+- full coaching platform
+- club operating system
+- team operating system
+- org-ready platform
+- compliance platform
+- messaging platform
+- dashboard suite
+- analytics layer
+- ranking engine
+- surveillance layer
+
+Forbidden example sentences:
+- "Kolosseum is a full club operating system."
+- "The platform includes org dashboards and messaging."
+- "This gives leadership performance oversight."
+
+---
+
+### 3.5 Evidence / proof / export overclaims
+
+Forbidden phrases include:
+- evidence-ready
+- audit-grade proof
+- proof-complete
+- fully attestable
+- sealed proof
+- export-ready evidence
+- legally proven execution
+
+Forbidden example sentences:
+- "Every session is evidence-ready."
+- "The platform provides audit-grade proof."
+- "Execution is fully proven in v0."
+
+---
+
+## Approved reusable phrases
+
+These are safe for repeated sales use.
+
+### Approved one-liners
+- "Kolosseum v0 is the Deterministic Execution Alpha."
+- "The current v0 path is coach-operable and bounded."
+- "The system is declaration-driven, deterministic, and outcome-neutral."
+- "The current pilot flow is real, narrow, and operational."
+- "Coach access in v0 is scoped to assignment, factual artefact viewing, and non-binding notes."
+- "The engine is neutral to payment, billing, and hierarchy."
+- "This is the first shippable execution alpha, not the later proof-complete release."
+
+### Approved feature-summary phrases
+- "athlete onboarding declaration"
+- "coach assignment"
+- "first executable session"
+- "split/return"
+- "partial completion"
+- "history with counts only"
+- "factual execution artefacts"
+- "non-binding coach notes"
+
+### Approved scope-limit phrases
+- "not evidence-complete"
+- "not a broad coaching platform"
+- "not org-ready"
+- "limited to the current v0 surface"
+- "limited to the current pilot path"
+- "broader proof and org packaging sit in v1"
+
+---
+
+## Approved claim templates
+
+Use these templates for follow-up copy.
+
+### Template A — product definition
+"Kolosseum v0 is [approved short definition]."
+
+### Template B — scope summary
+"The current v0 surface includes [approved scope items] and excludes [major excluded scope items]."
+
+### Template C — coach summary
+"In the current pilot path, coaches can [approved coach actions] but do not get [explicit non-authority items]."
+
+### Template D — athlete summary
+"In the current athlete path, onboarding comes first, then the first executable session becomes available once the declaration path is valid."
+
+### Template E — proof boundary
+"This version is replay-honest and CI-bounded within current scope, but it is not the later proof-complete release."
+
+---
+
+## Sales-safe approved sentences
+
+Use as-is if needed.
+
+- "The current v0 build is a coach-operable deterministic execution alpha."
+- "The current pilot path is narrow by design and limited to real current v0 surfaces."
+- "Kolosseum records factual execution artefacts and bounded session history."
+- "The coach surface is intentionally limited to assignment, factual artefact viewing, and non-binding notes."
+- "Payment and tier state control access, not engine truth."
+- "This is a real execution path, not a mockup of future breadth."
+- "Truth projection, sealing, export, and the broader proof layer are later-scope work, not current v0."
+
+---
+
+## Not-approved example sentences
+
+These must not appear in sales copy, demo narration, or follow-up.
+
+- "Kolosseum helps coaches make safer decisions."
+- "The engine picks the best option for each athlete."
+- "This is a full club operating system."
+- "The system proves compliance."
+- "This improves performance while reducing risk."
+- "The platform is tailored to the athlete."
+- "The coach can control the engine path."
+- "The product is evidence-ready."
+
+---
+
+## Surface usage rule
+
+This registry applies to:
+- live demo narration
+- sales follow-up emails
+- one-pagers
+- screenshot captions
+- founder talking points
+- pilot proposals
+- sales decks
+- website copy for current v0
+
+If a phrase is not approved here, it should not be used on these surfaces.
+
+---
+
+## Escalation rule
+
+If sales wants to use a phrase that is:
+- not listed
+- broader than current v0
+- likely to imply safety, optimisation, authority, proof, or future scope
+
+then the phrase is blocked until rewritten into an approved descriptive form.
+
+No “close enough” rule exists.
+
+---
+
+## Non-goals
+
+This registry does not:
+- define legal gates directly
+- replace canonical legal/commercial authority
+- approve future-state messaging
+- approve investor vision language
+- widen v0 scope
+- authorise claims for v1 proof or org packaging
+
+---
+
+## Final rule
+
+If a commercial phrase exceeds current v0 truth, it is forbidden.
+
+If a phrase is not explicitly approved or safely templated here, it must not be used in sales surfaces.


### PR DESCRIPTION
## Summary
- add repo-ready P196 sales claim registry
- consolidate allowed and forbidden v0 commercial phrases
- provide reusable law-like sales wording reference