### PR TITLE
docs(demo): add P196A founder sales script

### DIFF
--- a/docs/demo/P196A_FOUNDER_SALES_SCRIPT.md
+++ b/docs/demo/P196A_FOUNDER_SALES_SCRIPT.md
@@ -1,0 +1,367 @@
+# P196A — Founder Sales Script
+
+Status: Draft  
+Owner: Founder / Sales / Product  
+Scope: v0 only  
+Rewrite policy: rewrite-only  
+Last updated: 2026-04-13
+
+---
+
+## Target
+
+Define the founder-led sales script for Kolosseum v0.
+
+This script exists to:
+- give the founder a repeatable live-call structure
+- keep founder sales language inside the approved P196 claim boundary
+- explain the current v0 product clearly without hype or drift
+- close qualified pilots using real current product truth
+
+---
+
+## Invariant
+
+This script MUST stay inside current v0 boundaries.
+
+It MUST:
+- use only current approved commercial language
+- remain descriptive, mechanical, and outcome-neutral
+- explain current v0 scope clearly
+- explain both what the current version does and what it does not do
+- qualify prospects without inventing roadmap capability
+
+It MUST NOT:
+- imply safety, optimisation, recommendation, or readiness judgement
+- imply broader org, messaging, analytics, dashboard, replay-proof, or evidence scope beyond current v0
+- imply that coaches control engine truth
+- imply that future scope is already present
+- rely on hype to bridge product gaps
+
+---
+
+## Proof
+
+This script is correct only if all of the following are true:
+
+- every major line can be traced back to P196-approved sales language
+- the founder can use the script live without widening scope
+- the script can qualify or disqualify a prospect honestly
+- the script supports pilot closing without overclaiming the product
+- the wording remains commercially strong without becoming misleading
+
+---
+
+## Script usage rule
+
+Use this script for:
+- founder-led sales calls
+- pilot qualification calls
+- demo follow-up calls
+- warm close conversations
+
+Do not use this script for:
+- investor storytelling
+- public marketing copy
+- vision/roadmap pitching
+- future-state narrative selling
+
+---
+
+## Canonical one-line definition
+
+Use this exact sentence when a one-line v0 definition is needed:
+
+"Kolosseum v0 is the Deterministic Execution Alpha: a closed-world, coach-operable execution system for individual and coach-managed sessions across powerlifting, rugby_union, and general_strength, limited to Phase 1-6, factual runtime execution, split/return, partial completion, and CI-enforced deterministic boundaries."
+
+---
+
+## Founder call flow
+
+### 1. Opening
+
+Use:
+
+"Thanks for taking the call. I’ll keep this tight. I’ll show you what Kolosseum v0 is, what it does now, what it does not do, and whether the current pilot surface is a fit for your operation."
+
+Optional shorter version:
+
+"I’ll keep this simple: what it is, what it does now, what it does not do, and whether the current version is commercially useful for you."
+
+---
+
+### 2. Problem framing
+
+Use:
+
+"The problem I’m solving is not ‘another broad coaching app.’ The current problem is operational: getting a real athlete path from declaration to executable session, keeping coach interaction bounded, and keeping the execution surface factual and deterministic."
+
+Alternative:
+
+"The current focus is not broad platform breadth. It is a narrow, real execution path with clear boundaries."
+
+Do not say:
+- "We solve everything for coaches."
+- "This is the full future platform."
+- "This replaces all current tooling."
+
+---
+
+### 3. Product definition
+
+Use:
+
+"Kolosseum v0 is the Deterministic Execution Alpha. It is a closed-world, coach-operable execution system with a narrow current pilot surface."
+
+Then expand:
+
+"In the current version, the product is built around athlete onboarding declaration, first executable session creation, session execution, split/return, partial completion, factual history with counts, coach assignment, and non-binding coach notes."
+
+---
+
+### 4. What v0 does
+
+Use:
+
+"What it does now is straightforward."
+
+- "It gives the athlete a declaration-driven entry path."
+- "It allows a lawful path to the first executable session."
+- "It provides a real execution surface, not just a planning screen."
+- "It supports split/return and partial completion inside the current execution flow."
+- "It records factual execution artefacts and bounded session history."
+- "It gives the coach a scoped surface for assignment, factual artefact viewing, and non-binding notes."
+
+Then summarise:
+
+"So the current value is operational clarity and bounded execution, not broad platform breadth."
+
+---
+
+### 5. What v0 does not do
+
+Use:
+
+"What it does not do is just as important."
+
+- "It is not a broad coaching platform."
+- "It is not an org-ready operating system."
+- "It does not include dashboards, rankings, messaging, or broader runtime org controls."
+- "It is not the later proof-complete or evidence-complete release."
+- "Coach access does not create engine authority."
+- "Payment, billing, or hierarchy do not change engine truth."
+
+Then state plainly:
+
+"If you need broad org controls, proof-layer outputs, or wider communication surfaces today, those sit outside the current v0 product."
+
+---
+
+### 6. Who this is for
+
+Use:
+
+"The current version is for buyers who have a real operational need now and who are comfortable buying a narrow current pilot surface rather than a broad future-state promise."
+
+More specific version:
+
+"It fits best where the buyer values a real execution path, bounded coach interaction, and deterministic behaviour more than broad platform breadth."
+
+Use disqualifier:
+
+"If the requirement is a full club OS, a messaging-heavy coaching platform, or a proof/evidence product today, v0 is not the right commercial answer."
+
+---
+
+### 7. Pilot framing
+
+Use:
+
+"The commercial question is simple: does this narrow current surface solve a real operational problem for you now?"
+
+Then:
+
+"If yes, the right move is a pilot. If no, then I would rather say no cleanly than sell you future scope as if it already exists."
+
+Then define the pilot honestly:
+
+"A pilot means you are buying access to the current v0 path: onboarding, executable session flow, bounded coach use, factual history, and the current deterministic runtime surface."
+
+Do not say:
+- "You’ll get the broader platform later."
+- "We can just add the missing pieces quickly."
+- "We already basically do that."
+
+---
+
+### 8. Close
+
+Use:
+
+"If the narrow current v0 surface solves a real operational problem for you now, we should run a pilot. If you need broader org, proof, or messaging scope today, that is outside the current version."
+
+Alternative stronger close:
+
+"I’m not trying to sell you imaginary breadth. I’m asking whether the current real surface is commercially useful enough to pilot."
+
+Then move to action:
+
+"If it is, the next step is to define the pilot scope, users, and commercial boundary cleanly."
+
+---
+
+## Founder-safe demo narration lines
+
+Use these lines during live screen walkthroughs.
+
+### On onboarding
+"This is the athlete onboarding declaration in the current v0 flow."
+
+### On coach scope
+"This is the coach-scoped athlete view in the current pilot path."
+
+### On execution
+"This is the executable session surface from the current v0 build."
+
+### On split/return
+"This shows split/return handling in the current v0 execution flow."
+
+### On history
+"This is factual session history with counts in the current athlete flow."
+
+### On notes
+"This is the non-binding coach notes surface in the current coach path."
+
+---
+
+## Objection handling
+
+### Objection: “Is this a full coaching platform?”
+Use:
+
+"No. The current version is intentionally narrow. It is a deterministic execution alpha, not a broad coaching platform."
+
+---
+
+### Objection: “Can coaches control the engine?”
+Use:
+
+"No. Coach interaction is bounded. Coaches can assign within limits, view factual artefacts, and write non-binding notes. They do not control engine truth."
+
+---
+
+### Objection: “Does it handle club or organisational management?”
+Use:
+
+"Not in the broad sense. The current v0 surface is not an org-ready operating system."
+
+---
+
+### Objection: “Is this evidence-ready or audit-ready?”
+Use:
+
+"No. The current version is not proof-complete or evidence-complete. The right description today is deterministic and replay-honest within current scope."
+
+---
+
+### Objection: “Will this optimise programming?”
+Use:
+
+"No. I would not describe it that way. The current product is declaration-driven, deterministic, and operational. It is not sold as an optimisation engine."
+
+---
+
+### Objection: “Is this safer for athletes?”
+Use:
+
+"I would not make that claim. The current product is sold as a bounded execution system, not as a safety or medical product."
+
+---
+
+### Objection: “Why is the product narrow?”
+Use:
+
+"Because narrow and real beats broad and fictional. The current v0 path is intentionally constrained so what is sold matches what exists."
+
+---
+
+## Qualification questions
+
+Use these to qualify without drifting.
+
+- "What is the operational problem you need solved right now?"
+- "Do you need a narrow execution system now, or a broader platform?"
+- "Is your current pain around athlete path execution, coach workflow boundaries, or wider org management?"
+- "Would a bounded pilot surface be commercially useful now, or do you need broader scope from day one?"
+- "Are you buying a real current path, or are you looking for roadmap breadth?"
+
+---
+
+## Pilot-close questions
+
+Use:
+
+- "If this current surface existed cleanly in your workflow, would it be useful enough to pilot?"
+- "Who would be inside the first pilot scope?"
+- "Would the first pilot be coach-managed, individual, or mixed within current v0 limits?"
+- "What operational success would justify continuing after pilot?"
+- "What missing capability would make you say no right now?"
+
+---
+
+## Founder-safe reusable lines
+
+Use as needed:
+
+- "The current pilot flow is real, narrow, and operational."
+- "I’m selling the current surface, not future breadth."
+- "The engine is neutral to payment, billing, and hierarchy."
+- "This is a real execution path, not a concept deck."
+- "Broader proof and org packaging sit outside the current version."
+- "The current value is bounded execution, not inflated platform breadth."
+- "If the current version is commercially useful, pilot it. If not, don’t buy fiction."
+
+---
+
+## Forbidden founder phrases
+
+Do not say any of the following on calls:
+
+- "This makes training safer."
+- "This reduces injury risk."
+- "The engine picks the best option."
+- "This is tailored to each athlete."
+- "This is a full club operating system."
+- "This proves compliance."
+- "This is evidence-ready."
+- "This is basically the full platform already."
+- "The coach can control the engine."
+- "We can just layer the rest in afterwards."
+
+---
+
+## Short founder script
+
+Use this condensed version when time is tight:
+
+"Kolosseum v0 is the Deterministic Execution Alpha: a closed-world, coach-operable execution system with a narrow current pilot surface. In the current version, it covers onboarding declaration, first executable session creation, execution flow, split/return, partial completion, factual history with counts, coach assignment, and non-binding coach notes. It does not include broad org controls, messaging, dashboards, or the later proof-complete layer. So the real question is simple: does this narrow current surface solve a real operational problem for you now? If yes, we should pilot it. If no, I’d rather say that cleanly than sell future scope as current product."
+
+---
+
+## Non-goals
+
+This script does not:
+- replace the claim registry
+- approve future-state language
+- sell roadmap breadth
+- function as a marketing landing page
+- widen v0 scope
+- authorise non-approved commercial claims
+
+---
+
+## Final rule
+
+If a founder line exceeds the current v0 truth, do not use it.
+
+If the line sounds stronger only because it implies future scope, safety, optimisation, or proof status, it is forbidden.


### PR DESCRIPTION
## Summary
- add repo-ready P196A founder sales script
- translate P196-approved claims into live-call founder language
- keep qualification and pilot closing inside current v0 truth