### PR TITLE
docs(demo): add P196B founder objection handling card

### DIFF
--- a/docs/demo/P196B_FOUNDER_OBJECTION_HANDLING_CARD.md
+++ b/docs/demo/P196B_FOUNDER_OBJECTION_HANDLING_CARD.md
@@ -1,0 +1,444 @@
+# P196B — Founder Objection Handling Card
+
+Status: Draft
+Owner: Founder / Sales / Product
+Scope: v0 only
+Rewrite policy: rewrite-only
+Last updated: 2026-04-13
+
+---
+
+## Target
+
+Define the founder objection-handling card for Kolosseum v0.
+
+This card exists to:
+- give the founder fast approved responses during live calls
+- stop objection handling from drifting outside current v0 truth
+- preserve commercial strength without using hype or roadmap fantasy
+- keep live responses aligned to the P196 claim registry and P196A founder sales script
+
+---
+
+## Invariant
+
+This card MUST stay inside current v0 boundaries.
+
+It MUST:
+- answer objections directly
+- stay commercially clear and operational
+- use only approved or safely bounded language
+- keep responses short enough for live use
+- distinguish current product truth from later scope
+
+It MUST NOT:
+- imply safety, suitability, readiness, or optimisation
+- imply coach control over engine truth
+- imply broader org, dashboard, messaging, audit, replay-proof, or evidence scope beyond current v0
+- imply future scope is already present
+- rely on vague reassurance to hide missing capability
+
+---
+
+## Proof
+
+This card is correct only if all of the following are true:
+
+- every response is consistent with P196
+- every response is usable live without adding cleanup caveats
+- every response is commercially firm without becoming false
+- the founder can answer and re-anchor the call quickly
+- no response becomes stronger by implying broader product truth than currently exists
+
+---
+
+## Usage rule
+
+Use this card:
+- during founder-led sales calls
+- during pilot qualification
+- during live objection handling
+- during demo follow-up when scope pressure appears
+
+Do not use this card:
+- as a broad sales script
+- as investor language
+- as future roadmap positioning
+- as permission to improvise outside P196
+
+---
+
+## Objection handling standard
+
+Use this pattern where possible:
+
+1. answer directly
+2. state the current truth
+3. state the boundary
+4. re-anchor to the current commercial question
+
+Preferred structure:
+
+- "No."
+- "Here is the current truth."
+- "That sits outside the current version."
+- "The real question is whether the current narrow surface is useful enough to pilot."
+
+---
+
+## Objection → approved response
+
+### 1. “Is it safer?”
+
+Use:
+
+"No. I would not describe it that way. The current version is a bounded deterministic execution alpha, not a safety or medical product."
+
+Stronger reset:
+
+"I do not sell it on safety claims. I sell it as a narrow, real execution system."
+
+Do not say:
+- "It helps reduce risk."
+- "It makes training safer."
+- "It protects athletes."
+
+---
+
+### 2. “Does it optimise training?”
+
+Use:
+
+"No. I would not describe it as an optimisation engine. The current version is declaration-driven, deterministic, and operational."
+
+Alternative:
+
+"It is not sold as a system that finds the best option. It is sold as a bounded execution path."
+
+Do not say:
+- "It optimises programming."
+- "It finds the best plan."
+- "It improves outcomes automatically."
+
+---
+
+### 3. “Is it tailored or personalised?”
+
+Use:
+
+"Not in the way you mean. The current product is declaration-driven and constraint-responsive, but I do not sell it as personalised optimisation."
+
+Alternative:
+
+"The current truth is narrower: declaration-driven input, bounded execution, and factual runtime flow."
+
+Do not say:
+- "It is tailored to each athlete."
+- "It personalises everything."
+- "It adapts intelligently to the user."
+
+---
+
+### 4. “Can coaches control the engine?”
+
+Use:
+
+"No. Coach interaction is bounded. Coaches can assign within limits, view factual artefacts, and write non-binding notes. They do not control engine truth."
+
+Short version:
+
+"No. Coach access is scoped. It is not engine authority."
+
+Do not say:
+- "The coach can steer the engine."
+- "The coach can force decisions."
+- "The coach can override the path."
+
+---
+
+### 5. “Is this a full club or team OS?”
+
+Use:
+
+"No. The current version is not a full club or team operating system. It is a narrow deterministic execution alpha."
+
+Alternative:
+
+"If you need broad club or org management today, that sits outside the current version."
+
+Do not say:
+- "Basically yes."
+- "It is heading there anyway."
+- "It already covers most of that."
+
+---
+
+### 6. “Does it include dashboards or messaging?”
+
+Use:
+
+"No. The current v0 surface does not include broader dashboards, rankings, or messaging."
+
+Alternative:
+
+"Those are outside the current pilot surface. What exists today is the real narrow execution path."
+
+Do not say:
+- "Not yet, but soon."
+- "We can add that later."
+- "That is more or less there already."
+
+---
+
+### 7. “Is it evidence-ready or audit-ready?”
+
+Use:
+
+"No. The current version is not proof-complete or evidence-complete. The right description today is deterministic and replay-honest within current scope."
+
+Alternative:
+
+"I would not market v0 as evidence-ready. That would exceed the current product truth."
+
+Do not say:
+- "Yes, basically."
+- "It is audit-grade."
+- "It proves everything."
+
+---
+
+### 8. “Can it prove compliance?”
+
+Use:
+
+"No. I would not make that claim. The current product records factual execution artefacts and bounded history, but it is not sold as a compliance-proof system."
+
+Alternative:
+
+"The current truth is factual runtime recording within a narrow execution boundary, not compliance proof."
+
+Do not say:
+- "Yes, it proves compliance."
+- "It is compliance-ready."
+- "It handles audit proof."
+
+---
+
+### 9. “Why is it so narrow?”
+
+Use:
+
+"Because narrow and real beats broad and fictional. The current v0 path is intentionally constrained so what is sold matches what exists."
+
+Alternative:
+
+"The narrowness is deliberate. It preserves truth between product, demo, and sales language."
+
+Do not say:
+- "We just have not built the rest yet."
+- "It will all open up later."
+- "That is temporary, ignore it."
+
+---
+
+### 10. “What happens if we need broader scope later?”
+
+Use:
+
+"Then we handle that honestly as a separate scope question. I will not sell later breadth as if it already exists in v0."
+
+Alternative:
+
+"The current buying decision should be based on the current surface, not on assumed future packaging."
+
+Do not say:
+- "You will definitely get that later."
+- "That is already basically covered."
+- "Just buy now and we will sort it out."
+
+---
+
+### 11. “Why should I buy this now instead of waiting?”
+
+Use:
+
+"You should only buy it now if the current narrow surface solves a real operational problem for you now. If you need broader scope than current v0, waiting may be the right answer."
+
+Alternative:
+
+"I would rather lose a sale cleanly than sell you future scope as if it already exists."
+
+Do not say:
+- "Buy now before it gets bigger."
+- "Trust the roadmap."
+- "You may as well start and hope."
+
+---
+
+### 12. “So what exactly am I buying?”
+
+Use:
+
+"You are buying access to the current v0 path: onboarding declaration, first executable session creation, execution flow, split/return, partial completion, factual history with counts, coach assignment, and non-binding coach notes."
+
+Shorter version:
+
+"You are buying the current real execution surface, not broad future platform breadth."
+
+Do not say:
+- "You are buying the full vision."
+- "You are buying what comes next as well."
+- "You are buying the complete platform."
+
+---
+
+### 13. “Is this just another coaching app?”
+
+Use:
+
+"No. The current product is not positioned as a broad coaching app. It is a narrow, closed-world, coach-operable execution system."
+
+Alternative:
+
+"The real distinction is that this is built around a bounded execution path, not broad lifestyle platform breadth."
+
+Do not say:
+- "It does everything coaching apps do, but better."
+- "It replaces all your stack."
+- "It is the next generation of coaching software."
+
+---
+
+### 14. “Does this replace our current tools?”
+
+Use:
+
+"Not necessarily. The current question is whether this narrow execution surface solves a specific operational problem cleanly enough to pilot."
+
+Alternative:
+
+"I do not position v0 as universal replacement software."
+
+Do not say:
+- "Yes, it replaces everything."
+- "You can throw the rest out."
+- "It will become your whole stack."
+
+---
+
+### 15. “What if the pilot exposes missing capability?”
+
+Use:
+
+"Then we evaluate that honestly. A pilot is there to test whether the current narrow surface is commercially useful, not to pretend missing scope is already solved."
+
+Alternative:
+
+"If the missing capability is essential and outside v0, the honest answer may be that current v0 is not enough."
+
+Do not say:
+- "We will just patch it in."
+- "That will not matter."
+- "We can promise the rest."
+
+---
+
+## Fast fallback lines
+
+Use these when you need to reset the call quickly.
+
+- "Let me bring that back to current v0 scope."
+- "That sits outside the current version."
+- "I would not describe it that way."
+- "The current truth is narrower than that."
+- "What exists today is narrow, real, and operational."
+- "I’m selling the current surface, not future breadth."
+- "Coach access is scoped. It is not engine authority."
+- "This is not the proof-complete release."
+- "The commercial question is whether the current surface is useful enough to pilot."
+- "I would rather say no cleanly than sell fiction."
+
+---
+
+## One-line resets
+
+Use when the conversation drifts.
+
+- "Let me bring that back to current v0 truth."
+- "That is broader than the current version."
+- "The current surface is real; that broader claim is not."
+- "I’m not going to inflate the product to close the sale."
+- "What I can defend is the current narrow execution path."
+- "The buying decision should be based on what exists now."
+- "That is a later-scope question, not a current v0 claim."
+- "The right question is whether the current real surface solves your immediate operational problem."
+
+---
+
+## Red-flag phrases not to say
+
+Do not say these live:
+
+- "safe"
+- "safer"
+- "reduces risk"
+- "prevents injury"
+- "optimises"
+- "best option"
+- "tailored"
+- "personalised"
+- "readiness"
+- "coach-approved"
+- "evidence-ready"
+- "audit-grade"
+- "compliance-ready"
+- "full club OS"
+- "team OS"
+- "org-ready"
+- "the coach controls the engine"
+- "we already basically do that"
+- "you will get the rest later"
+
+---
+
+## Live-call discipline
+
+When pressured on scope:
+- do not fill silence with roadmap
+- do not soften the boundary
+- do not improvise capability
+- do not trade truth for momentum
+
+When cornered:
+- answer directly
+- state the current product truth
+- state the limit
+- re-anchor to pilot usefulness
+
+---
+
+## Short founder objection card
+
+Use this condensed version if needed:
+
+"No. I would not describe it that way. The current version is a narrow deterministic execution alpha, not a safety, optimisation, or proof-complete product. Coach interaction is bounded, payment does not change engine truth, and broader org or messaging scope sits outside current v0. The real question is whether the current real surface is commercially useful enough to pilot."
+
+---
+
+## Non-goals
+
+This card does not:
+- replace P196
+- replace the full founder sales script
+- approve future-state language
+- widen v0 scope
+- function as a roadmap promise
+- authorise unbounded objection handling
+
+---
+
+## Final rule
+
+If an objection response becomes stronger only by implying safety, optimisation, proof, or broader scope than current v0, do not use it.
+
+If the truthful answer is narrower, say the narrower answer.


### PR DESCRIPTION
## Summary
- add repo-ready P196B founder objection handling card
- give founder fast approved objection responses for live sales calls
- keep objection handling inside current v0 truth and P196 claim boundaries