### PR TITLE
docs(pilots): add P198 pilot status update template

### DIFF
--- a/docs/pilots/P198_PILOT_STATUS_UPDATE_TEMPLATE.md
+++ b/docs/pilots/P198_PILOT_STATUS_UPDATE_TEMPLATE.md
@@ -1,0 +1,192 @@
+# P198 — Pilot Status Update Template
+
+## Slice contract
+- Target: exact weekly update format for active coach pilots.
+- Invariant: update content stays factual, bounded, and within current v0 claims.
+- Proof: template contains factual counts, current blockers, and current next actions only.
+
+## Why this exists
+This template keeps active coach pilots warm and progressing without invention.
+It is a bounded operator update, not a sales layer, not a coaching judgement, and not a performance report.
+
+## v0 boundary lock
+This template is limited to current v0 reality:
+- individual_user and coach only
+- individual and coach_managed execution only
+- powerlifting, rugby_union, and general_strength only
+- Phase 1 through Phase 6 only
+- factual artefact viewing, counts, coach assignment, and non-binding coach notes only
+
+This template must not claim or imply:
+- Phase 7 truth projection
+- Phase 8 evidence sealing
+- replay or evidence access for coaches
+- dashboards
+- analytics
+- rankings
+- readiness
+- outcomes
+- advice
+- optimisation
+- compliance judgement
+
+## Allowed content only
+The update may contain only:
+- factual counts
+- current bounded status
+- current blockers
+- current next actions
+
+## Forbidden content
+Do not include:
+- recommendations
+- praise or criticism
+- readiness language
+- safety language
+- outcome language
+- engagement interpretation
+- compliance interpretation
+- motivational copy
+- forecasting
+- broad product claims
+
+Examples of forbidden wording:
+- improving
+- on track
+- high engagement
+- low engagement
+- compliant
+- non-compliant
+- ready
+- safer
+- better
+- optimal
+- successful
+- struggling
+- risk
+- likely to
+- should
+
+## Canonical template
+
+**Subject:** Kolosseum pilot weekly update — [Pilot Name] — [Week Ending DD MMM YYYY]
+
+**Pilot:** [Pilot Name]  
+**Coach:** [Coach Name]  
+**Week ending:** [DD MMM YYYY]  
+**Current status:** [Active / Blocked / Pending declaration / Pending compile / Coach ready]
+
+### 1) Factual counts this week
+- Athlete cap: [X]
+- Active athletes linked: [X]
+- New athletes added this week: [X]
+- Phase 1 declarations accepted this week: [X]
+- First executable sessions compiled this week: [X]
+- Sessions assigned this week: [X]
+- Sessions started this week: [X]
+- Sessions completed this week: [X]
+- Partial completions this week: [X]
+- Split / return events this week: [X]
+- Extra work events this week: [X]
+- Skipped work events this week: [X]
+- Dropped work events this week: [X]
+- Substitution events this week: [X]
+- Coach notes added this week: [X]
+
+### 2) Current pilot position
+- Linked athletes currently in scope: [X]
+- Athletes with accepted declaration: [X]
+- Athletes with at least one compiled session: [X]
+- Athletes with at least one started session: [X]
+- Athletes with at least one completed session: [X]
+
+### 3) Current blockers
+- [Blocker 1 or "None"]
+- [Blocker 2 or "None"]
+- [Blocker 3 or "None"]
+
+### 4) Next actions
+- [Action 1]
+- [Action 2]
+- [Action 3]
+
+### 5) This week's operator note
+- [Single factual sentence only, or "No additional note."]
+
+## Short-form operator version
+
+**Kolosseum pilot weekly update — [Pilot Name] — [Week Ending DD MMM YYYY]**
+
+**Status:** [Active / Blocked / Pending declaration / Pending compile / Coach ready]
+
+**This week**
+- Active athletes linked: [X] / [Cap]
+- Declarations accepted: [X]
+- Sessions compiled: [X]
+- Sessions assigned: [X]
+- Sessions started: [X]
+- Sessions completed: [X]
+- Partial completions: [X]
+- Split / return events: [X]
+- Extra work: [X]
+- Skipped work: [X]
+- Dropped work: [X]
+- Substitutions: [X]
+- Coach notes added: [X]
+
+**Current blockers**
+- [None / blocker]
+
+**Next actions**
+- [Action 1]
+- [Action 2]
+- [Action 3]
+
+## Example filled version
+
+**Subject:** Kolosseum pilot weekly update — Northside Strength — Week Ending 12 Apr 2026**
+
+**Pilot:** Northside Strength  
+**Coach:** Jamie Carter  
+**Week ending:** 12 Apr 2026  
+**Current status:** Active
+
+### 1) Factual counts this week
+- Athlete cap: 16
+- Active athletes linked: 9
+- New athletes added this week: 2
+- Phase 1 declarations accepted this week: 2
+- First executable sessions compiled this week: 2
+- Sessions assigned this week: 9
+- Sessions started this week: 7
+- Sessions completed this week: 5
+- Partial completions this week: 1
+- Split / return events this week: 1
+- Extra work events this week: 3
+- Skipped work events this week: 2
+- Dropped work events this week: 0
+- Substitution events this week: 1
+- Coach notes added this week: 4
+
+### 2) Current pilot position
+- Linked athletes currently in scope: 9
+- Athletes with accepted declaration: 9
+- Athletes with at least one compiled session: 9
+- Athletes with at least one started session: 7
+- Athletes with at least one completed session: 5
+
+### 3) Current blockers
+- 2 linked athletes still pending declaration acceptance
+- 1 athlete has not started first assigned session
+- None
+
+### 4) Next actions
+- Complete Phase 1 declarations for remaining linked athletes
+- Compile first executable session for any newly accepted athlete within scope
+- Confirm first-start completion for athletes not yet started
+
+### 5) This week's operator note
+- Pilot remains within current athlete cap and current coach-managed v0 scope.
+
+## Acceptance rule
+If a weekly update includes anything beyond factual counts, current blockers, and current next actions, the template has drifted and must be corrected.


### PR DESCRIPTION
## Summary
- add P198 pilot weekly status update template for active coach pilots
- lock the template to factual counts, current blockers, and next actions only
- keep the document inside current v0 scope and non-claim boundaries

## Testing
- npm run lint:fast
- npm run dev:status
- gh run list --limit 10