### PR TITLE
docs(commercial): add P200 founder demo script v2

### DIFF
--- a/ci/registries/commercial_artefact_registry.json
+++ b/ci/registries/commercial_artefact_registry.json
@@ -300,6 +300,11 @@
                           "artefact_id":  "p189_pilot_intake_guardrails",
                           "path":  "docs/commercial/P189_PILOT_INTAKE_GUARDRAILS.json",
                           "class":  "commercial_registry"
+                      },
+                      {
+                          "artefact_id":  "p189_pilot_intake_form_spec",
+                          "path":  "docs/commercial/P200_FOUNDER_DEMO_SCRIPT_V2.md",
+                          "class":  "commercial_surface"
                       }
                   ]
 }

--- a/docs/commercial/P200_FOUNDER_DEMO_SCRIPT_V2.md
+++ b/docs/commercial/P200_FOUNDER_DEMO_SCRIPT_V2.md
@@ -1,0 +1,237 @@
+# P200 — Founder Demo Script v2
+
+## Slice contract
+- Target: sharpen the founder demo script around what actually closes.
+- Invariant: the script stays inside current v0 scope, uses lawful factual language, and follows a tight handoff structure.
+- Proof: the script moves from problem to bounded demo to commercial handoff without claiming outcomes, safety, optimisation, or non-v0 capability.
+
+## Why this exists
+The founder demo remains the primary revenue weapon.
+This version is built to close the next conversation, not to over-explain the engine.
+
+The script must:
+- show the narrow v0 truth clearly
+- prove bounded usefulness without invention
+- move the prospect into the next paid or pilot step
+- align tightly to the pilot handoff structure rather than drift into a broad pitch
+
+## v0 boundary lock
+This script is limited to current v0 reality:
+- individual_user and coach only
+- individual and coach_managed execution only
+- powerlifting, rugby_union, and general_strength only
+- Phase 1 through Phase 6 only
+- onboarding, compilation, session execution, split/return, partial completion, factual artefact viewing, counts-only history, coach assignment, and non-binding coach notes only
+
+This script must not claim or imply:
+- Phase 7 truth projection
+- Phase 8 evidence sealing
+- exportable lawful proof
+- replay or evidence access for coach users
+- dashboards
+- analytics beyond lawful factual counts
+- rankings
+- readiness
+- optimisation
+- outcomes
+- safety
+- compliance judgement
+- AI coaching
+- automatic behaviour correction
+
+## Commercial boundary lock
+Commercial logic may control:
+- access
+- seat limits
+- tier visibility
+- continuation or expansion
+
+Commercial logic must not be described as changing:
+- engine truth
+- legality
+- determinism
+- recorded execution facts
+
+## Demo objective
+The objective of the founder demo is not to prove that athletes improve.
+The objective is to prove that:
+- the problem is real
+- the operating surface is narrow and lawful
+- the coach can use it now
+- the pilot shape is clear
+- the next step is commercially clean
+
+## Core close logic
+The demo closes when the prospect can answer yes to all of these:
+- yes, this is the problem I currently have
+- yes, this is narrow enough to trust
+- yes, this matches how I operate
+- yes, I can see how I would use this with real athletes
+- yes, I know what the pilot would look like
+- yes, I know what happens after this call
+
+## Founder demo structure v2
+This script is deliberately short.
+It follows a seven-part sequence.
+
+### 1. Frame the problem
+Use direct operator language.
+
+Example:
+"The problem I am solving is not motivation, readiness scoring, or generic coaching software. The problem is lawful, deterministic execution inside a coach-managed environment where the system records what was declared, what was compiled, and what was actually done."
+
+### 2. Narrow the scope early
+Do this before features.
+
+Example:
+"This is not a full coaching platform. Current v0 is narrow by design. It is coach-operable for individual and coach-managed use only, across powerlifting, rugby_union, and general_strength, and it is limited to the declaration-to-execution path."
+
+### 3. Show the flow, not the dream
+Walk the buyer through the factual path:
+- athlete declaration
+- coach link
+- compile first executable session
+- run the session
+- record split/return, partial completion, substitutions, and factual events
+- view counts and artefacts
+- add non-binding coach notes
+
+Example:
+"The value is not hidden AI. The value is that the operating path is explicit and bounded. You declare. The system compiles within the declared limits. Execution is recorded as facts. The coach can assign, view, and annotate, but cannot change engine truth."
+
+### 4. Show what it does not do
+This increases trust.
+
+Example:
+"It does not override decisions. It does not score readiness. It does not claim to optimise outcomes. It does not invent explanations. It does not give the coach authority to change legality."
+
+### 5. Translate to buyer use
+Keep this operational.
+
+Example:
+"For a real coach, that means you can onboard athletes, get accepted declarations in, compile first sessions, run those sessions, and see exactly who was linked, who declared, who started, who completed, where split/return happened, and where substitutions or partial completions were recorded."
+
+### 6. Show the pilot shape
+This is the bridge to handoff.
+Use the same structure the pilot handoff will use.
+
+Example:
+"The pilot is simple. We define the coach, the athlete cap, the included activity scope, who gets onboarded first, what counts as coach-ready, and the exact operator sequence from paid to live use."
+
+### 7. Ask for the next commercial decision
+Do not end on admiration.
+End on a binary next step.
+
+Example:
+"If this matches how you operate, the next step is not a bigger demo. The next step is a bounded pilot. We lock the cap, define the first athletes, and move from demo to operator use."
+
+## Script v2 — full talk track
+
+### Opening
+"Kolosseum is a deterministic execution product, not a broad coaching platform. I am not trying to sell you dashboards, readiness scores, or claims about athlete outcomes. I am showing you a narrow coach-operable system that lets you move from explicit declaration to compiled session to factual execution inside a controlled operating surface."
+
+### Problem statement
+"Most tools mix programming, messaging, interpretation, outcomes language, and operational noise. That creates drift. It becomes hard to see what was declared, what the system was actually allowed to do, and what actually happened in execution."
+
+### Scope lock
+"Current v0 is intentionally narrow. It supports individual and coach-managed execution only. It supports powerlifting, rugby_union, and general_strength only. It covers the path from onboarding and declaration through compilation and factual session execution. That is deliberate. If it is not in that lane, I do not claim it."
+
+### What the coach actually gets
+"The coach gets a lawful narrow operating surface: assign within system limits, view factual execution artefacts, see counts, and add non-binding notes. The coach does not get override authority. The coach does not get to change constraints, trigger substitutions outside the system path, or rewrite truth."
+
+### What the athlete path looks like
+"The athlete gives explicit declarations. Those declarations are accepted or blocked. The first session is compiled from what was actually declared. Execution then records what happened: started, completed, partial completion, split/return, substitutions, skipped work, dropped work, extra work. The system records those as facts."
+
+### Why that matters commercially
+"That matters because it gives you an operating product, not a pitch deck. You can use it with real athletes inside a bounded commercial shape without pretending it already does everything."
+
+### Trust section
+"I think one of the reasons this closes is that it says no a lot. It does not claim safety. It does not claim optimisation. It does not claim improvement. It does not claim broad organisational runtime. It stays in the lane it can actually support."
+
+### Pilot shape section
+"The pilot is defined before we start. We set the coach, athlete cap, activity scope, included operating surface, and the exact sequence from payment to coach-ready use. There is no vague rollout. There is a bounded first pilot shape."
+
+### Commercial handoff section
+"If the fit is real, the next move is simple. We do not need another six feature calls. We move to a pilot with a defined cap and a defined operator path. If the fit is not real, we stop cleanly."
+
+## P182-aligned handoff structure
+The handoff after the demo must follow this exact structure.
+
+### H1. Confirm operator fit
+- coach identity confirmed
+- activity scope confirmed
+- athlete cap discussed
+- current operating problem named in plain language
+
+### H2. Confirm v0 fit
+- prospect accepts narrow scope
+- no excluded feature is treated as promised
+- coach role is understood as observational and bounded
+
+### H3. Confirm pilot shape
+- pilot owner named
+- coach seat count confirmed
+- athlete cap confirmed
+- first athlete set identified
+- included activities confirmed
+- declaration and compile path understood
+
+### H4. Confirm start condition
+- what counts as paid
+- what counts as coach invited
+- what counts as athlete invited
+- what counts as declaration accepted
+- what counts as coach ready
+
+### H5. Confirm next action
+- pilot goes forward
+- or pilot does not go forward
+- no ambiguous middle state
+
+## Demo do / do not list
+
+### Do
+- talk in operator language
+- narrow the scope early
+- show the declaration to execution path
+- show the coach boundary clearly
+- use factual examples
+- define the pilot shape before ending
+- ask for the next commercial decision directly
+
+### Do not
+- promise outcomes
+- claim broad future scope as current scope
+- use readiness or safety language
+- talk like a generic SaaS founder
+- hide behind technical depth
+- let the call end with "keep me posted"
+- end with admiration instead of a pilot decision
+
+## Fast close version
+Use this when the prospect is sharp and time-constrained.
+
+"Kolosseum v0 is a narrow coach-operable execution product. It lets you move from explicit declaration to compiled session to factual execution for individual and coach-managed use across powerlifting, rugby_union, and general_strength. The coach can assign, view factual artefacts, and add non-binding notes. The system does not claim outcomes, readiness, optimisation, or broad org features. If that matches your operating problem, the next step is a bounded pilot with a defined cap, defined scope, and a clean coach-ready handoff."
+
+## Objection handling lines
+
+### "Does it do team or club runtime?"
+"Not in current v0. Current v0 is individual and coach-managed only."
+
+### "Can coaches override the system?"
+"No. Coach authority is bounded. The coach can assign, observe, and annotate. Engine truth stays separate."
+
+### "Can it prove outcomes?"
+"No. It records declarations, compiled sessions, and execution facts. It does not claim athlete improvement."
+
+### "Why is the scope so narrow?"
+"Because narrow closes. Narrow is more trustworthy. It is easier to use, easier to sell, and easier to operate lawfully."
+
+### "What happens after the pilot?"
+"After the pilot, the commercial decision is explicit: renew, expand, or stop, using factual criteria rather than invented success language."
+
+## Example founder close
+"Based on what I have shown you, I am not asking whether you like the concept. I am asking whether this bounded operating surface fits a real coaching problem you already have. If yes, we define the pilot cap, confirm the first athletes, and move to the handoff. If no, we stop cleanly."
+
+## Acceptance rule
+If the script drifts into future-scope selling, outcome claims, readiness language, safety language, optimisation claims, or generic platform pitch language, it has failed and must be rewritten.


### PR DESCRIPTION
## Summary
- add P200 founder demo script v2
- declare the new commercial artefact in the required registry
- tighten the demo around what actually closes and align the handoff to a bounded pilot structure

## Testing
- npm run lint:fast
- npm run dev:status
- gh run list --limit 10