### PR TITLE
docs(commercial): add P201 not included commercial boundary pack v2

### DIFF
--- a/ci/registries/commercial_artefact_registry.json
+++ b/ci/registries/commercial_artefact_registry.json
@@ -305,6 +305,11 @@
                           "artefact_id":  "p189_pilot_intake_form_spec",
                           "path":  "docs/commercial/P200_FOUNDER_DEMO_SCRIPT_V2.md",
                           "class":  "commercial_surface"
+                      },
+                      {
+                          "artefact_id":  "p201_not_included_commercial_boundary_pack_v2",
+                          "path":  "docs/commercial/P201_NOT_INCLUDED_COMMERCIAL_BOUNDARY_PACK_V2.md",
+                          "class":  "commercial_surface"
                       }
                   ]
 }

--- a/docs/commercial/P201_NOT_INCLUDED_COMMERCIAL_BOUNDARY_PACK_V2.md
+++ b/docs/commercial/P201_NOT_INCLUDED_COMMERCIAL_BOUNDARY_PACK_V2.md
@@ -1,0 +1,200 @@
+# P201 — Not-Included Commercial Boundary Pack v2
+
+## Slice contract
+- Target: one brutal, explicit not-included pack for commercial use.
+- Invariant: the pack states exclusions clearly, commercially, and lawfully without promising dormant or future scope.
+- Proof: the pack lists what is not included in the current paid pilot and keeps every exclusion inside current v0 reality.
+
+## Why this exists
+This pack exists to stop wrong-fit prospects early.
+
+It is designed to:
+- save sales time
+- reduce wrong-fit demos
+- stop future-scope leakage
+- make paid pilot scope explicit before money changes hands
+- give the founder a direct exclusion document to send after or during a commercial conversation
+
+This is not a feature roadmap.
+This is not a future vision deck.
+This is a commercial exclusion pack.
+
+## Current scope lock
+Current commercial pilot scope is limited to current v0 reality:
+- individual_user and coach only
+- individual and coach_managed execution only
+- powerlifting, rugby_union, and general_strength only
+- Phase 1 through Phase 6 only
+- onboarding, compilation, session execution, split/return, partial completion, factual artefact viewing, counts-only history, coach assignment, and non-binding coach notes only
+
+If something is outside that lane, it is not included in the current paid pilot.
+
+## Absolute rule
+If it is not explicitly inside the current paid pilot scope, it is not included.
+
+No implied access.
+No assumed roadmap commitment.
+No soft promise.
+No "coming soon" language inside a paid pilot conversation unless explicitly separated from the current commercial offer.
+
+## What is included
+The current paid pilot may include only:
+- coach onboarding into the current bounded v0 surface
+- athlete onboarding through lawful declaration flow
+- coach-managed or individual execution within current scope
+- first-session compilation
+- factual session execution recording
+- split / return handling
+- partial completion handling
+- factual counts and artefact viewing
+- non-binding coach notes
+- bounded pilot setup, handoff, renewal, expansion, or stop decisions using factual criteria
+
+## What is not included
+The following are not included in the current paid pilot.
+
+### 1. Broad platform runtime
+Not included:
+- team runtime
+- club runtime
+- gym runtime
+- unit runtime
+- organisation runtime
+- federation runtime
+- multi-entity governance
+- state-managed flows
+
+### 2. Proof and evidence layer
+Not included:
+- Phase 7 truth projection as a commercial coach-facing surface
+- Phase 8 evidence sealing
+- exportable evidence packs
+- replay access for pilot coaches
+- audit-proof exports
+- lawful proof portability
+
+### 3. Coaching authority expansion
+Not included:
+- coach override authority
+- coach ability to change legality
+- coach ability to rewrite declarations
+- coach ability to modify registries
+- coach-triggered engine truth changes
+- coach-triggered progression control outside current system limits
+- coach authority over engine decision truth
+
+### 4. Broad analytics and management
+Not included:
+- dashboards
+- organisation analytics
+- rankings
+- readiness scoring
+- compliance scoring
+- athlete scoring
+- performance profiling
+- behavioural profiling
+- monitoring claims
+- surveillance-style views
+
+### 5. Advice and outcome claims
+Not included:
+- advice
+- safety claims
+- optimisation claims
+- readiness claims
+- medical claims
+- rehabilitation claims
+- improvement claims
+- success claims
+- performance outcome claims
+- injury reduction claims
+- suitability claims
+
+### 6. Automation and intelligence claims
+Not included:
+- AI coaching
+- automatic correction
+- automatic behaviour improvement
+- automatic compliance enforcement
+- automatic athlete decision-making
+- automatic programme interpretation beyond current deterministic execution path
+- broad assistant behaviour sold as current pilot product scope
+
+### 7. Commercial assumptions
+Not included:
+- unlimited athletes
+- unlimited coach seats
+- custom enterprise support by default
+- broad custom feature development inside pilot price
+- roadmap commitment as part of pilot payment
+- dormant future features treated as sold access
+- vague "we can probably do that" commitments
+
+## Commercial use rule
+Use this pack when:
+- a prospect asks for features outside current pilot scope
+- a sales call starts drifting into broad platform talk
+- a buyer wants team, club, gym, federation, or analytics runtime now
+- a buyer tries to buy future state as if it already exists
+- a founder needs to protect pilot shape before sending pricing or pilot paperwork
+
+## Founder use lines
+
+### Line 1 — direct exclusion
+"That is not included in the current paid pilot."
+
+### Line 2 — scope correction
+"The current pilot is a bounded v0 operating surface. It does not include broad platform runtime, broad analytics, proof-layer exports, or coach override authority."
+
+### Line 3 — wrong-fit filter
+"If that excluded surface is a must-have right now, this is not the right pilot for you at this stage."
+
+### Line 4 — clean redirect
+"If your need is the current bounded operating surface, this fits. If your need is the broader platform vision today, that is outside the present commercial offer."
+
+## Brutal qualification version
+Use this when speed matters.
+
+"This paid pilot is not a broad coaching platform, not a team operating system, not an analytics layer, not a readiness product, and not a proof export product. It is a narrow coach-operable execution surface for individual and coach-managed use only. If you need the excluded surfaces now, do not buy this pilot."
+
+## Sendable commercial version
+Use this in email, message, proposal appendix, or handoff pack.
+
+### Not included in the current paid pilot
+The current paid pilot does not include:
+- team, club, gym, unit, organisation, or federation runtime
+- dashboards, rankings, readiness scoring, or broad analytics
+- proof exports, evidence sealing, or replay access for pilot coaches
+- coach override authority or engine-truth control
+- safety, medical, optimisation, or outcome claims
+- AI coaching or automatic behaviour correction
+- unlimited expansion or future-scope access by default
+
+The current pilot is a bounded v0 operating surface only.
+
+## Objection handling
+
+### "But we need team management."
+That is not included in the current paid pilot.
+
+### "Can you add dashboards during the pilot?"
+Not as part of the current paid pilot scope.
+
+### "Will this prove athlete improvement?"
+No. That is not part of the current commercial offer.
+
+### "Can our coaches override things manually?"
+No. That is not included.
+
+### "Will pilot payment cover future platform access?"
+No. Pilot payment covers the current bounded pilot scope only.
+
+### "Can we treat this as a federation or club operating system?"
+No. That is outside the current paid pilot.
+
+## Close rule
+A wrong-fit prospect is better stopped before payment than carried into a mis-scoped pilot.
+
+## Acceptance rule
+If this pack starts sounding soft, hopeful, roadmap-heavy, or apologetic, it has failed.
+The purpose is clarity, exclusion, and fit filtering.


### PR DESCRIPTION
## Summary
- add P201 not-included commercial boundary pack v2
- make the current paid pilot exclusions explicit for commercial use
- reduce wrong-fit prospects and future-scope leakage during demo-to-pilot conversion

## Testing
- npm run lint:fast
- npm run dev:status
- gh run list --limit 10