### PR TITLE
docs(commercial): add P202 pilot conversion proof pack

### DIFF
--- a/ci/registries/commercial_artefact_registry.json
+++ b/ci/registries/commercial_artefact_registry.json
@@ -310,6 +310,11 @@
                           "artefact_id":  "p201_not_included_commercial_boundary_pack_v2",
                           "path":  "docs/commercial/P201_NOT_INCLUDED_COMMERCIAL_BOUNDARY_PACK_V2.md",
                           "class":  "commercial_surface"
+                      },
+                      {
+                          "artefact_id":  "p202_pilot_conversion_proof_pack",
+                          "path":  "docs/commercial/P202_PILOT_CONVERSION_PROOF_PACK.md",
+                          "class":  "commercial_surface"
                       }
                   ]
 }

--- a/docs/commercial/P202_PILOT_CONVERSION_PROOF_PACK.md
+++ b/docs/commercial/P202_PILOT_CONVERSION_PROOF_PACK.md
@@ -1,0 +1,294 @@
+# P202 — Pilot Conversion Proof Pack
+
+## Slice contract
+- Target: one compact internal pack showing the full chain: demo shown -> handoff sent -> pilot accepted -> onboarding started.
+- Invariant: proof remains factual only and does not drift into performance, readiness, optimisation, or outcome claims.
+- Proof: the pack records only explicit commercial and operator events in sequence.
+
+## Why this exists
+This pack turns one founder-led sale into a repeatable conversion proof chain.
+
+It exists to:
+- prove the commercial path happened
+- show the exact handoff-to-pilot chain
+- reduce founder memory drift
+- support repeatable commercial operation
+- provide an internal factual basis for repeating what closes
+
+This is an internal proof pack.
+It is not a case study.
+It is not a public success story.
+It is not a performance report.
+
+## Current scope lock
+This pack is limited to current v0 commercial and operator reality:
+- individual_user and coach only
+- individual and coach_managed execution only
+- powerlifting, rugby_union, and general_strength only
+- Phase 1 through Phase 6 only
+- bounded sales handoff, pilot setup, declaration, compilation, and onboarding-start state only
+
+## Absolute rule
+This pack records chain-of-events proof only.
+
+It must not claim:
+- athlete improvement
+- pilot success beyond explicit accepted state
+- operational quality beyond explicit factual events
+- readiness
+- safety
+- optimisation
+- suitability
+- behavioural compliance
+- broad platform maturity
+
+## Canonical proof chain
+The pack records the following chain and nothing broader:
+
+1. Demo shown
+2. Handoff sent
+3. Pilot accepted
+4. Onboarding started
+
+Each stage must be backed by explicit factual artefacts or explicit recorded events.
+
+If a stage cannot be proven, it must be marked not proven.
+No inference is allowed.
+
+## Allowed proof inputs
+The pack may use only the following proof inputs:
+
+### A. Demo proof
+- demo date
+- prospect name
+- coach name
+- founder/demo owner
+- exact demo asset or script used
+- explicit statement that demo was shown
+- explicit next-step output from the call
+
+### B. Handoff proof
+- handoff pack sent date
+- exact handoff artefact set sent
+- recipient
+- send channel
+- acknowledgement or reply received, if any
+
+### C. Pilot acceptance proof
+- pilot acceptance date
+- accepted pilot cap
+- accepted scope
+- named pilot owner
+- commercial continuation state
+- explicit go-forward decision
+
+### D. Onboarding-start proof
+- coach invited date
+- athlete invited date
+- declaration request sent
+- declaration accepted
+- first compile triggered
+- onboarding started state
+- coach-ready pending or achieved
+
+## Forbidden proof inputs
+Do not use:
+- improvement language
+- satisfaction language
+- value judgement
+- likely renewal inference
+- success framing
+- engagement scoring
+- outcome interpretation
+- behavioural interpretation
+- readiness framing
+- optimisation framing
+- advisory language
+
+Forbidden wording includes:
+- successful
+- high engagement
+- low engagement
+- effective
+- better
+- improving
+- on track
+- likely to convert
+- strong fit
+- working well
+- good signs
+
+## Stage definitions
+
+### 1. Demo shown
+This stage is proven only if:
+- a named prospect exists
+- a demo date exists
+- the founder or demo owner is named
+- the specific demo artefact or script used is named
+- the next-step ask is recorded
+
+Not proven if any of the above is missing.
+
+### 2. Handoff sent
+This stage is proven only if:
+- a send date exists
+- a recipient exists
+- the sent handoff artefacts are listed
+- the send channel is recorded
+
+Not proven if any of the above is missing.
+
+### 3. Pilot accepted
+This stage is proven only if:
+- an explicit go-forward decision exists
+- pilot owner is named
+- cap is named
+- included scope is named
+- pilot accepted date exists
+
+Not proven if any of the above is missing.
+
+### 4. Onboarding started
+This stage is proven only if at least one of the following factual triggers exists:
+- coach invited
+- athlete invited
+- declaration request sent
+- accepted declaration exists
+- first compile exists
+
+This stage must record which trigger(s) occurred.
+Do not compress them into vague language.
+
+## Canonical template
+
+**Prospect / Pilot:** [Name]  
+**Coach:** [Name]  
+**Founder / Demo Owner:** [Name]  
+**Proof pack date:** [DD MMM YYYY]
+
+### 1) Demo shown
+- Demo shown: [Yes / No]
+- Demo date: [DD MMM YYYY]
+- Demo artefact used: [Exact artefact or script name]
+- Activity scope discussed: [powerlifting / rugby_union / general_strength]
+- Athlete cap discussed: [X or "Not recorded"]
+- Next-step ask made: [Yes / No]
+- Next-step ask text: [Single factual sentence or "Not recorded"]
+
+### 2) Handoff sent
+- Handoff sent: [Yes / No]
+- Handoff date: [DD MMM YYYY or "Not recorded"]
+- Handoff artefacts sent:
+  - [Artefact 1]
+  - [Artefact 2]
+  - [Artefact 3]
+- Recipient: [Name / email / organisation]
+- Send channel: [email / message / call follow-up / other]
+- Acknowledgement received: [Yes / No]
+- Acknowledgement date: [DD MMM YYYY or "Not recorded"]
+
+### 3) Pilot accepted
+- Pilot accepted: [Yes / No]
+- Acceptance date: [DD MMM YYYY or "Not recorded"]
+- Pilot owner: [Name or "Not recorded"]
+- Coach seat count: [X or "Not recorded"]
+- Athlete cap accepted: [X or "Not recorded"]
+- Included scope accepted: [Single factual sentence]
+- Go-forward decision recorded: [Yes / No]
+
+### 4) Onboarding started
+- Onboarding started: [Yes / No]
+- Coach invited: [Yes / No]
+- Athlete invited: [Yes / No]
+- Declaration request sent: [Yes / No]
+- Declaration accepted: [Yes / No]
+- First compile triggered: [Yes / No]
+- Coach ready: [Yes / No / Pending]
+- First onboarding event date: [DD MMM YYYY or "Not recorded"]
+
+### 5) Proof chain verdict
+- Demo shown proven: [Yes / No]
+- Handoff sent proven: [Yes / No]
+- Pilot accepted proven: [Yes / No]
+- Onboarding started proven: [Yes / No]
+
+### 6) Internal note
+- [Single factual sentence only.]
+
+## Compact operator version
+
+**Pilot conversion proof — [Prospect / Pilot Name]**
+
+- Demo shown: [Yes / No] — [Date]
+- Handoff sent: [Yes / No] — [Date]
+- Pilot accepted: [Yes / No] — [Date]
+- Onboarding started: [Yes / No] — [Date]
+
+**Proven artefacts**
+- Demo artefact: [Name]
+- Handoff pack: [Name]
+- Accepted cap: [X]
+- First onboarding trigger: [coach invited / athlete invited / declaration request / declaration accepted / first compile]
+
+## Example filled version
+
+**Prospect / Pilot:** Northside Strength  
+**Coach:** Jamie Carter  
+**Founder / Demo Owner:** Chris Roberts  
+**Proof pack date:** 14 Apr 2026
+
+### 1) Demo shown
+- Demo shown: Yes
+- Demo date: 08 Apr 2026
+- Demo artefact used: P200_FOUNDER_DEMO_SCRIPT_V2
+- Activity scope discussed: powerlifting
+- Athlete cap discussed: 16
+- Next-step ask made: Yes
+- Next-step ask text: Founder asked for a bounded paid pilot decision.
+
+### 2) Handoff sent
+- Handoff sent: Yes
+- Handoff date: 08 Apr 2026
+- Handoff artefacts sent:
+  - P182_SALES_HANDOFF_PACK
+  - P185_PILOT_PRICING_SEND_PACK
+  - P201_NOT_INCLUDED_COMMERCIAL_BOUNDARY_PACK_V2
+- Recipient: Jamie Carter
+- Send channel: email
+- Acknowledgement received: Yes
+- Acknowledgement date: 09 Apr 2026
+
+### 3) Pilot accepted
+- Pilot accepted: Yes
+- Acceptance date: 10 Apr 2026
+- Pilot owner: Jamie Carter
+- Coach seat count: 1
+- Athlete cap accepted: 16
+- Included scope accepted: Coach-managed powerlifting pilot inside current v0 scope.
+- Go-forward decision recorded: Yes
+
+### 4) Onboarding started
+- Onboarding started: Yes
+- Coach invited: Yes
+- Athlete invited: Yes
+- Declaration request sent: Yes
+- Declaration accepted: Yes
+- First compile triggered: Yes
+- Coach ready: Pending
+- First onboarding event date: 11 Apr 2026
+
+### 5) Proof chain verdict
+- Demo shown proven: Yes
+- Handoff sent proven: Yes
+- Pilot accepted proven: Yes
+- Onboarding started proven: Yes
+
+### 6) Internal note
+- Conversion chain is proven from demo through onboarding-start state using explicit recorded events only.
+
+## Usage rule
+Use this pack internally after the first real pilot conversion and for each future pilot conversion.
+
+## Acceptance rule
+If this pack contains any performance claim, satisfaction claim, success claim, readiness language, or inferred explanation, it has failed.


### PR DESCRIPTION
## Summary
- add P202 pilot conversion proof pack
- capture the factual chain from demo shown to onboarding started
- turn the founder sales path into a repeatable internal conversion proof artefact

## Testing
- npm run lint:fast
- npm run dev:status
- gh run list --limit 10