### PR TITLE
feat(engine): add pilot lifecycle state machine

### DIFF
--- a/shared/pilot-lifecycle/pilotLifecycleStateMachine.mjs
+++ b/shared/pilot-lifecycle/pilotLifecycleStateMachine.mjs
@@ -1,0 +1,209 @@
+export const PILOT_LIFECYCLE_STATES = Object.freeze({
+  ACCEPTED: "accepted",
+  COMMERCIAL_PENDING: "commercial_pending",
+  PLATFORM_PENDING: "platform_pending",
+  COACH_PENDING: "coach_pending",
+  ATHLETE_PENDING: "athlete_pending",
+  LINK_PENDING: "link_pending",
+  SCOPE_PENDING: "scope_pending",
+  PHASE1_PENDING: "phase1_pending",
+  COMPILE_PENDING: "compile_pending",
+  COACH_OPERABLE: "coach_operable",
+  ACTIVE: "active",
+  PAUSED: "paused",
+  STOPPED: "stopped",
+  CANCELLED: "cancelled",
+});
+
+export const PILOT_LIFECYCLE_STATE_LIST = Object.freeze(
+  Object.values(PILOT_LIFECYCLE_STATES),
+);
+
+const OPERABLE_STATES = new Set([
+  PILOT_LIFECYCLE_STATES.COACH_OPERABLE,
+  PILOT_LIFECYCLE_STATES.ACTIVE,
+  PILOT_LIFECYCLE_STATES.PAUSED,
+]);
+
+export const ALLOWED_PILOT_LIFECYCLE_TRANSITIONS = Object.freeze({
+  [PILOT_LIFECYCLE_STATES.ACCEPTED]: Object.freeze([
+    PILOT_LIFECYCLE_STATES.COMMERCIAL_PENDING,
+    PILOT_LIFECYCLE_STATES.CANCELLED,
+  ]),
+  [PILOT_LIFECYCLE_STATES.COMMERCIAL_PENDING]: Object.freeze([
+    PILOT_LIFECYCLE_STATES.PLATFORM_PENDING,
+    PILOT_LIFECYCLE_STATES.CANCELLED,
+  ]),
+  [PILOT_LIFECYCLE_STATES.PLATFORM_PENDING]: Object.freeze([
+    PILOT_LIFECYCLE_STATES.COACH_PENDING,
+    PILOT_LIFECYCLE_STATES.CANCELLED,
+  ]),
+  [PILOT_LIFECYCLE_STATES.COACH_PENDING]: Object.freeze([
+    PILOT_LIFECYCLE_STATES.ATHLETE_PENDING,
+    PILOT_LIFECYCLE_STATES.CANCELLED,
+  ]),
+  [PILOT_LIFECYCLE_STATES.ATHLETE_PENDING]: Object.freeze([
+    PILOT_LIFECYCLE_STATES.LINK_PENDING,
+    PILOT_LIFECYCLE_STATES.CANCELLED,
+  ]),
+  [PILOT_LIFECYCLE_STATES.LINK_PENDING]: Object.freeze([
+    PILOT_LIFECYCLE_STATES.SCOPE_PENDING,
+    PILOT_LIFECYCLE_STATES.CANCELLED,
+  ]),
+  [PILOT_LIFECYCLE_STATES.SCOPE_PENDING]: Object.freeze([
+    PILOT_LIFECYCLE_STATES.PHASE1_PENDING,
+    PILOT_LIFECYCLE_STATES.CANCELLED,
+  ]),
+  [PILOT_LIFECYCLE_STATES.PHASE1_PENDING]: Object.freeze([
+    PILOT_LIFECYCLE_STATES.COMPILE_PENDING,
+    PILOT_LIFECYCLE_STATES.CANCELLED,
+  ]),
+  [PILOT_LIFECYCLE_STATES.COMPILE_PENDING]: Object.freeze([
+    PILOT_LIFECYCLE_STATES.COACH_OPERABLE,
+    PILOT_LIFECYCLE_STATES.CANCELLED,
+  ]),
+  [PILOT_LIFECYCLE_STATES.COACH_OPERABLE]: Object.freeze([
+    PILOT_LIFECYCLE_STATES.ACTIVE,
+    PILOT_LIFECYCLE_STATES.PAUSED,
+    PILOT_LIFECYCLE_STATES.STOPPED,
+  ]),
+  [PILOT_LIFECYCLE_STATES.ACTIVE]: Object.freeze([
+    PILOT_LIFECYCLE_STATES.PAUSED,
+    PILOT_LIFECYCLE_STATES.STOPPED,
+  ]),
+  [PILOT_LIFECYCLE_STATES.PAUSED]: Object.freeze([
+    PILOT_LIFECYCLE_STATES.ACTIVE,
+    PILOT_LIFECYCLE_STATES.STOPPED,
+  ]),
+  [PILOT_LIFECYCLE_STATES.STOPPED]: Object.freeze([]),
+  [PILOT_LIFECYCLE_STATES.CANCELLED]: Object.freeze([]),
+});
+
+function assertKnownState(state, label) {
+  if (!PILOT_LIFECYCLE_STATE_LIST.includes(state)) {
+    throw new Error("${label}_unknown:${String(state)}");
+  }
+}
+
+function coerceBooleanRecord(input = {}) {
+  return {
+    commercialSatisfied: input.commercialSatisfied === true,
+    workspaceProvisioned: input.workspaceProvisioned === true,
+    coachAccountProvisioned: input.coachAccountProvisioned === true,
+    athleteAccountProvisioned: input.athleteAccountProvisioned === true,
+    linkAccepted: input.linkAccepted === true,
+    scopeLocked: input.scopeLocked === true,
+    phase1Accepted: input.phase1Accepted === true,
+    firstExecutableSessionCompiled: input.firstExecutableSessionCompiled === true,
+    activationSignalReceived: input.activationSignalReceived === true,
+    pausedByOperator: input.pausedByOperator === true,
+    stoppedByOperator: input.stoppedByOperator === true,
+    cancelledByOperator: input.cancelledByOperator === true,
+  };
+}
+
+export function canTransitionPilotLifecycle(fromState, toState) {
+  assertKnownState(fromState, "from_state");
+  assertKnownState(toState, "to_state");
+
+  return ALLOWED_PILOT_LIFECYCLE_TRANSITIONS[fromState].includes(toState);
+}
+
+export function assertPilotLifecycleTransitionAllowed(fromState, toState) {
+  if (!canTransitionPilotLifecycle(fromState, toState)) {
+    throw new Error("pilot_lifecycle_transition_forbidden:${fromState}->${toState}");
+  }
+}
+
+export function resolvePilotLifecycleState(context = {}) {
+  const c = coerceBooleanRecord(context);
+
+  if (c.stoppedByOperator) {
+    return PILOT_LIFECYCLE_STATES.STOPPED;
+  }
+
+  if (c.pausedByOperator) {
+    return PILOT_LIFECYCLE_STATES.PAUSED;
+  }
+
+  if (c.cancelledByOperator) {
+    if (c.firstExecutableSessionCompiled || c.activationSignalReceived) {
+      throw new Error("pilot_lifecycle_cancelled_preoperational_only");
+    }
+
+    return PILOT_LIFECYCLE_STATES.CANCELLED;
+  }
+
+  if (c.activationSignalReceived) {
+    if (!c.firstExecutableSessionCompiled) {
+      throw new Error("pilot_lifecycle_active_requires_compiled_session");
+    }
+
+    return PILOT_LIFECYCLE_STATES.ACTIVE;
+  }
+
+  if (c.firstExecutableSessionCompiled) {
+    return PILOT_LIFECYCLE_STATES.COACH_OPERABLE;
+  }
+
+  if (c.phase1Accepted) {
+    return PILOT_LIFECYCLE_STATES.COMPILE_PENDING;
+  }
+
+  if (c.scopeLocked) {
+    return PILOT_LIFECYCLE_STATES.PHASE1_PENDING;
+  }
+
+  if (c.linkAccepted) {
+    return PILOT_LIFECYCLE_STATES.SCOPE_PENDING;
+  }
+
+  if (c.athleteAccountProvisioned && c.coachAccountProvisioned) {
+    return PILOT_LIFECYCLE_STATES.LINK_PENDING;
+  }
+
+  if (c.coachAccountProvisioned) {
+    return PILOT_LIFECYCLE_STATES.ATHLETE_PENDING;
+  }
+
+  if (c.workspaceProvisioned) {
+    return PILOT_LIFECYCLE_STATES.COACH_PENDING;
+  }
+
+  if (c.commercialSatisfied) {
+    return PILOT_LIFECYCLE_STATES.PLATFORM_PENDING;
+  }
+
+  return PILOT_LIFECYCLE_STATES.COMMERCIAL_PENDING;
+}
+
+export function assertPilotLifecycleTransitionMatchesContext(fromState, toState, context = {}) {
+  assertPilotLifecycleTransitionAllowed(fromState, toState);
+
+  const resolvedTargetState = resolvePilotLifecycleState(context);
+  if (resolvedTargetState resolvedTargetState !== toState) {
+    throw new Error(
+      "pilot_lifecycle_transition_context_mismatch:${fromState}->${toState} resolved=${resolvedTargetState}",
+    );
+  }
+
+  if (toState === PILOT_LIFECYCLE_STATES.CANCELLED && OPERABLE_STATES.has(fromState)) {
+    throw new Error("pilot_lifecycle_cancelled_preoperational_only");
+  }
+
+  if (
+    toState === PILOT_LIFECYCLE_STATES.ACTIVE &&
+    context.activationSignalReceived !== true
+  ) {
+    throw new Error("pilot_lifecycle_active_requires_activation_signal");
+  }
+
+  if (
+    toState === PILOT_LIFECYCLE_STATES.COACH_OPERABLE &&
+    context.firstExecutableSessionCompiled !== true
+  ) {
+    throw new Error("pilot_lifecycle_coach_operable_requires_compiled_session");
+  }
+
+  return true;
+}

--- a/shared/pilot-lifecycle/pilotLifecycleStateMachine.test.mjs
+++ b/shared/pilot-lifecycle/pilotLifecycleStateMachine.test.mjs
@@ -1,0 +1,397 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  ALLOWED_PILOT_LIFECYCLE_TRANSITIONS,
+  PILOT_LIFECYCLE_STATES,
+  PILOT_LIFECYCLE_STATE_LIST,
+  assertPilotLifecycleTransitionAllowed,
+  assertPilotLifecycleTransitionMatchesContext,
+  canTransitionPilotLifecycle,
+  resolvePilotLifecycleState,
+} from "./pilotLifecycleStateMachine.mjs";
+
+test("pilot lifecycle state enum is exact and closed", () => {
+  assert.deepEqual(PILOT_LIFECYCLE_STATE_LIST, [
+    "accepted",
+    "commercial_pending",
+    "platform_pending",
+    "coach_pending",
+    "athlete_pending",
+    "link_pending",
+    "scope_pending",
+    "phase1_pending",
+    "compile_pending",
+    "coach_operable",
+    "active",
+    "paused",
+    "stopped",
+    "cancelled",
+  ]);
+});
+
+test("allowed transitions map is exact", () => {
+  assert.deepEqual(ALLOWED_PILOT_LIFECYCLE_TRANSITIONS, {
+    accepted: ["commercial_pending", "cancelled"],
+    commercial_pending: ["platform_pending", "cancelled"],
+    platform_pending: ["coach_pending", "cancelled"],
+    coach_pending: ["athlete_pending", "cancelled"],
+    athlete_pending: ["link_pending", "cancelled"],
+    link_pending: ["scope_pending", "cancelled"],
+    scope_pending: ["phase1_pending", "cancelled"],
+    phase1_pending: ["compile_pending", "cancelled"],
+    compile_pending: ["coach_operable", "cancelled"],
+    coach_operable: ["active", "paused", "stopped"],
+    active: ["paused", "stopped"],
+    paused: ["active", "stopped"],
+    stopped: [],
+    cancelled: [],
+  });
+});
+
+test("positive transition path from acceptance to active is lawful", () => {
+  assert.equal(canTransitionPilotLifecycle("accepted", "commercial_pending"), true);
+  assert.equal(canTransitionPilotLifecycle("commercial_pending", "platform_pending"), true);
+  assert.equal(canTransitionPilotLifecycle("platform_pending", "coach_pending"), true);
+  assert.equal(canTransitionPilotLifecycle("coach_pending", "athlete_pending"), true);
+  assert.equal(canTransitionPilotLifecycle("athlete_pending", "link_pending"), true);
+  assert.equal(canTransitionPilotLifecycle("link_pending", "scope_pending"), true);
+  assert.equal(canTransitionPilotLifecycle("scope_pending", "phase1_pending"), true);
+  assert.equal(canTransitionPilotLifecycle("phase1_pending", "compile_pending"), true);
+  assert.equal(canTransitionPilotLifecycle("compile_pending", "coach_operable"), true);
+  assert.equal(canTransitionPilotLifecycle("coach_operable", "active"), true);
+});
+
+test("operational transitions are lawful", () => {
+  assert.equal(canTransitionPilotLifecycle("coach_operable", "paused"), true);
+  assert.equal(canTransitionPilotLifecycle("coach_operable", "stopped"), true);
+  assert.equal(canTransitionPilotLifecycle("active", "paused"), true);
+  assert.equal(canTransitionPilotLifecycle("active", "stopped"), true);
+  assert.equal(canTransitionPilotLifecycle("paused", "active"), true);
+  assert.equal(canTransitionPilotLifecycle("paused", "stopped"), true);
+});
+
+test("forbidden transitions fail", () => {
+  assert.equal(canTransitionPilotLifecycle("accepted", "active"), false);
+  assert.equal(canTransitionPilotLifecycle("link_pending", "compile_pending"), false);
+  assert.equal(canTransitionPilotLifecycle("compile_pending", "active"), false);
+  assert.equal(canTransitionPilotLifecycle("stopped", "active"), false);
+  assert.equal(canTransitionPilotLifecycle("cancelled", "active"), false);
+  assert.equal(canTransitionPilotLifecycle("active", "accepted"), false);
+
+  assert.throws(
+    () => assertPilotLifecycleTransitionAllowed("accepted", "active"),
+    /pilot_lifecycle_transition_forbidden:accepted->active/,
+  );
+});
+
+test("cancelled is pre-operational only", () => {
+  assert.equal(canTransitionPilotLifecycle("accepted", "cancelled"), true);
+  assert.equal(canTransitionPilotLifecycle("compile_pending", "cancelled"), true);
+  assert.equal(canTransitionPilotLifecycle("coach_operable", "cancelled"), false);
+  assert.equal(canTransitionPilotLifecycle("active", "cancelled"), false);
+  assert.equal(canTransitionPilotLifecycle("paused", "cancelled"), false);
+});
+
+test("resolve state returns commercial_pending by default", () => {
+  assert.equal(resolvePilotLifecycleState({}), PILOT_LIFECYCLE_STATES.COMMERCIAL_PENDING);
+});
+
+test("resolve state returns platform_pending when commercial is satisfied only", () => {
+  assert.equal(
+    resolvePilotLifecycleState({ commercialSatisfied: true }),
+    PILOT_LIFECYCLE_STATES.PLATFORM_PENDING,
+  );
+});
+
+test("resolve state returns coach_pending when workspace is provisioned", () => {
+  assert.equal(
+    resolvePilotLifecycleState({
+      commercialSatisfied: true,
+      workspaceProvisioned: true,
+    }),
+    PILOT_LIFECYCLE_STATES.COACH_PENDING,
+  );
+});
+
+test("resolve state returns athlete_pending when coach account is provisioned", () => {
+  assert.equal(
+    resolvePilotLifecycleState({
+      commercialSatisfied: true,
+      workspaceProvisioned: true,
+      coachAccountProvisioned: true,
+    }),
+    PILOT_LIFECYCLE_STATES.ATHLETE_PENDING,
+  );
+});
+
+test("resolve state returns link_pending when both accounts are provisioned", () => {
+  assert.equal(
+    resolvePilotLifecycleState({
+      commercialSatisfied: true,
+      workspaceProvisioned: true,
+      coachAccountProvisioned: true,
+      athleteAccountProvisioned: true,
+    }),
+    PILOT_LIFECYCLE_STATES.LINK_PENDING,
+  );
+});
+
+test("resolve state returns scope_pending when link is accepted", () => {
+  assert.equal(
+    resolvePilotLifecycleState({
+      commercialSatisfied: true,
+      workspaceProvisioned: true,
+      coachAccountProvisioned: true,
+      athleteAccountProvisioned: true,
+      linkAccepted: true,
+    }),
+    PILOT_LIFECYCLE_STATES.SCOPE_PENDING,
+  );
+});
+
+test("resolve state returns phase1_pending when scope is locked", () => {
+  assert.equal(
+    resolvePilotLifecycleState({
+      commercialSatisfied: true,
+      workspaceProvisioned: true,
+      coachAccountProvisioned: true,
+      athleteAccountProvisioned: true,
+      linkAccepted: true,
+      scopeLocked: true,
+    }),
+    PILOT_LIFECYCLE_STATES.PHASE1_PENDING,
+  );
+});
+
+test("resolve state returns compile_pending when phase1 is accepted", () => {
+  assert.equal(
+    resolvePilotLifecycleState({
+      commercialSatisfied: true,
+      workspaceProvisioned: true,
+      coachAccountProvisioned: true,
+      athleteAccountProvisioned: true,
+      linkAccepted: true,
+      scopeLocked: true,
+      phase1Accepted: true,
+    }),
+    PILOT_LIFECYCLE_STATES.COMPILE_PENDING,
+  );
+});
+
+test("resolve state returns coach_operable when first executable session is compiled", () => {
+  assert.equal(
+    resolvePilotLifecycleState({
+      commercialSatisfied: true,
+      workspaceProvisioned: true,
+      coachAccountProvisioned: true,
+      athleteAccountProvisioned: true,
+      linkAccepted: true,
+      scopeLocked: true,
+      phase1Accepted: true,
+      firstExecutableSessionCompiled: true,
+    }),
+    PILOT_LIFECYCLE_STATES.COACH_OPERABLE,
+  );
+});
+
+test("resolve state returns active only when activation signal exists", () => {
+  assert.equal(
+    resolvePilotLifecycleState({
+      commercialSatisfied: true,
+      workspaceProvisioned: true,
+      coachAccountProvisioned: true,
+      athleteAccountProvisioned: true,
+      linkAccepted: true,
+      scopeLocked: true,
+      phase1Accepted: true,
+      firstExecutableSessionCompiled: true,
+      activationSignalReceived: true,
+    }),
+    PILOT_LIFECYCLE_STATES.ACTIVE,
+  );
+});
+
+test("resolve state returns paused and stopped as explicit operator states", () => {
+  assert.equal(
+    resolvePilotLifecycleState({
+      commercialSatisfied: true,
+      workspaceProvisioned: true,
+      coachAccountProvisioned: true,
+      athleteAccountProvisioned: true,
+      linkAccepted: true,
+      scopeLocked: true,
+      phase1Accepted: true,
+      firstExecutableSessionCompiled: true,
+      pausedByOperator: true,
+    }),
+    PILOT_LIFECYCLE_STATES.PAUSED,
+  );
+
+  assert.equal(
+    resolvePilotLifecycleState({
+      stoppedByOperator: true,
+    }),
+    PILOT_LIFECYCLE_STATES.STOPPED,
+  );
+});
+
+test("resolve state returns cancelled only when pre-operational", () => {
+  assert.equal(
+    resolvePilotLifecycleState({
+      commercialSatisfied: true,
+      workspaceProvisioned: true,
+      cancelledByOperator: true,
+    }),
+    PILOT_LIFECYCLE_STATES.CANCELLED,
+  );
+
+  assert.throws(
+    () =>
+      resolvePilotLifecycleState({
+        commercialSatisfied: true,
+        workspaceProvisioned: true,
+        coachAccountProvisioned: true,
+        athleteAccountProvisioned: true,
+        linkAccepted: true,
+        scopeLocked: true,
+        phase1Accepted: true,
+        firstExecutableSessionCompiled: true,
+        cancelledByOperator: true,
+      }),
+    /pilot_lifecycle_cancelled_preoperational_only/,
+  );
+});
+
+test("active requires compiled session", () => {
+  assert.throws(
+    () =>
+      resolvePilotLifecycleState({
+        activationSignalReceived: true,
+      }),
+    /pilot_lifecycle_active_requires_compiled_session/,
+  );
+});
+
+test("transition-to-state context checks are enforced", () => {
+  assert.equal(
+    assertPilotLifecycleTransitionMatchesContext("accepted", "commercial_pending", {
+      commercialSatisfied: false,
+    }),
+    true,
+  );
+
+  assert.equal(
+    assertPilotLifecycleTransitionMatchesContext("compile_pending", "coach_operable", {
+      commercialSatisfied: true,
+      workspaceProvisioned: true,
+      coachAccountProvisioned: true,
+      athleteAccountProvisioned: true,
+      linkAccepted: true,
+      scopeLocked: true,
+      phase1Accepted: true,
+      firstExecutableSessionCompiled: true,
+    }),
+    true,
+  );
+
+  assert.equal(
+    assertPilotLifecycleTransitionMatchesContext("coach_operable", "active", {
+      commercialSatisfied: true,
+      workspaceProvisioned: true,
+      coachAccountProvisioned: true,
+      athleteAccountProvisioned: true,
+      linkAccepted: true,
+      scopeLocked: true,
+      phase1Accepted: true,
+      firstExecutableSessionCompiled: true,
+      activationSignalReceived: true,
+    }),
+    true,
+  );
+});
+
+test("transition context mismatch fails", () => {
+  assert.throws(
+    () =>
+      assertPilotLifecycleTransitionMatchesContext("phase1_pending", "compile_pending", {
+        commercialSatisfied: true,
+        workspaceProvisioned: true,
+        coachAccountProvisioned: true,
+        athleteAccountProvisioned: true,
+        linkAccepted: true,
+        scopeLocked: true,
+        phase1Accepted: false,
+      }),
+    /pilot_lifecycle_transition_context_mismatch/,
+  );
+});
+
+test("coach_operable requires compiled session in transition checks", () => {
+  assert.throws(
+    () =>
+      assertPilotLifecycleTransitionMatchesContext("compile_pending", "coach_operable", {
+        commercialSatisfied: true,
+        workspaceProvisioned: true,
+        coachAccountProvisioned: true,
+        athleteAccountProvisioned: true,
+        linkAccepted: true,
+        scopeLocked: true,
+        phase1Accepted: true,
+        firstExecutableSessionCompiled: false,
+      }),
+    /pilot_lifecycle_transition_context_mismatch/,
+  );
+});
+
+test("active requires activation signal in transition checks", () => {
+  assert.throws(
+    () =>
+      assertPilotLifecycleTransitionMatchesContext("coach_operable", "active", {
+        commercialSatisfied: true,
+        workspaceProvisioned: true,
+        coachAccountProvisioned: true,
+        athleteAccountProvisioned: true,
+        linkAccepted: true,
+        scopeLocked: true,
+        phase1Accepted: true,
+        firstExecutableSessionCompiled: true,
+        activationSignalReceived: false,
+      }),
+    /pilot_lifecycle_transition_context_mismatch/,
+  );
+});
+
+test("single explicit lifecycle state resolves for representative contexts", () => {
+  const resolvedStates = [
+    resolvePilotLifecycleState({}),
+    resolvePilotLifecycleState({ commercialSatisfied: true }),
+    resolvePilotLifecycleState({ commercialSatisfied: true, workspaceProvisioned: true }),
+    resolvePilotLifecycleState({
+      commercialSatisfied: true,
+      workspaceProvisioned: true,
+      coachAccountProvisioned: true,
+      athleteAccountProvisioned: true,
+      linkAccepted: true,
+      scopeLocked: true,
+      phase1Accepted: true,
+      firstExecutableSessionCompiled: true,
+      activationSignalReceived: true,
+    }),
+    resolvePilotLifecycleState({
+      commercialSatisfied: true,
+      workspaceProvisioned: true,
+      coachAccountProvisioned: true,
+      athleteAccountProvisioned: true,
+      linkAccepted: true,
+      scopeLocked: true,
+      phase1Accepted: true,
+      firstExecutableSessionCompiled: true,
+      pausedByOperator: true,
+    }),
+  ];
+
+  for (const state of resolvedStates) {
+    assert.equal(PILOT_LIFECYCLE_STATE_LIST.includes(state), true);
+  }
+});


### PR DESCRIPTION
## Summary
- add canonical pilot lifecycle state enum
- add allowed and forbidden lifecycle transitions
- add deterministic lifecycle resolver and transition assertions
- add targeted proof tests for path legality, context gates, and terminal states

## Proof
- node --test .\shared\pilot-lifecycle\pilotLifecycleStateMachine.test.mjs
- npm run lint:fast
- npm run dev:status