### PR TITLE
feat(engine): add pilot status reason codes

### DIFF
--- a/shared/pilot-lifecycle/pilotLifecycleStateMachine.mjs
+++ b/shared/pilot-lifecycle/pilotLifecycleStateMachine.mjs
@@ -81,7 +81,7 @@ export const ALLOWED_PILOT_LIFECYCLE_TRANSITIONS = Object.freeze({
 
 function assertKnownState(state, label) {
   if (!PILOT_LIFECYCLE_STATE_LIST.includes(state)) {
-    throw new Error("${label}_unknown:${String(state)}");
+    throw new Error(label + "_unknown:" + String(state));
   }
 }
 
@@ -111,7 +111,7 @@ export function canTransitionPilotLifecycle(fromState, toState) {
 
 export function assertPilotLifecycleTransitionAllowed(fromState, toState) {
   if (!canTransitionPilotLifecycle(fromState, toState)) {
-    throw new Error("pilot_lifecycle_transition_forbidden:${fromState}->${toState}");
+    throw new Error("pilot_lifecycle_transition_forbidden:" + fromState + "->" + toState);
   }
 }
 
@@ -181,9 +181,14 @@ export function assertPilotLifecycleTransitionMatchesContext(fromState, toState,
   assertPilotLifecycleTransitionAllowed(fromState, toState);
 
   const resolvedTargetState = resolvePilotLifecycleState(context);
-  if (resolvedTargetState resolvedTargetState !== toState) {
+  if (resolvedTargetState !== toState) {
     throw new Error(
-      "pilot_lifecycle_transition_context_mismatch:${fromState}->${toState} resolved=${resolvedTargetState}",
+      "pilot_lifecycle_transition_context_mismatch:" +
+        fromState +
+        "->" +
+        toState +
+        " resolved=" +
+        resolvedTargetState,
     );
   }
 

--- a/shared/pilot-lifecycle/pilotStatusReasonCodes.mjs
+++ b/shared/pilot-lifecycle/pilotStatusReasonCodes.mjs
@@ -1,0 +1,300 @@
+import {
+  PILOT_LIFECYCLE_STATES,
+  PILOT_LIFECYCLE_STATE_LIST,
+  resolvePilotLifecycleState,
+} from "./pilotLifecycleStateMachine.mjs";
+
+export const PILOT_STATUS_REASON_CODES = Object.freeze({
+  COMMERCIAL_UNSETTLED: "commercial_unsettled",
+  WORKSPACE_UNPROVISIONED: "workspace_unprovisioned",
+  COACH_ACCOUNT_UNPROVISIONED: "coach_account_unprovisioned",
+  ATHLETE_ACCOUNT_UNPROVISIONED: "athlete_account_unprovisioned",
+  COACH_ATHLETE_LINK_UNACCEPTED: "coach_athlete_link_unaccepted",
+  SCOPE_UNLOCKED: "scope_unlocked",
+  PHASE1_UNACCEPTED: "phase1_unaccepted",
+  FIRST_EXECUTABLE_SESSION_UNCOMPILED: "first_executable_session_uncompiled",
+  ACTIVATION_SIGNAL_UNRECEIVED: "activation_signal_unreceived",
+  PAUSED_BY_OPERATOR: "paused_by_operator",
+  STOPPED_BY_OPERATOR: "stopped_by_operator",
+  CANCELLED_BY_OPERATOR: "cancelled_by_operator",
+  RENEWAL_REQUIRED: "renewal_required",
+  EXPANSION_REVIEW_REQUIRED: "expansion_review_required",
+});
+
+export const PILOT_STATUS_REASON_CODE_LIST = Object.freeze(
+  Object.values(PILOT_STATUS_REASON_CODES),
+);
+
+export const PILOT_STATE_REQUIRED_REASON_POLICY = Object.freeze({
+  [PILOT_LIFECYCLE_STATES.ACCEPTED]: Object.freeze([
+    PILOT_STATUS_REASON_CODES.COMMERCIAL_UNSETTLED,
+  ]),
+  [PILOT_LIFECYCLE_STATES.COMMERCIAL_PENDING]: Object.freeze([
+    PILOT_STATUS_REASON_CODES.COMMERCIAL_UNSETTLED,
+  ]),
+  [PILOT_LIFECYCLE_STATES.PLATFORM_PENDING]: Object.freeze([
+    PILOT_STATUS_REASON_CODES.WORKSPACE_UNPROVISIONED,
+  ]),
+  [PILOT_LIFECYCLE_STATES.COACH_PENDING]: Object.freeze([
+    PILOT_STATUS_REASON_CODES.COACH_ACCOUNT_UNPROVISIONED,
+  ]),
+  [PILOT_LIFECYCLE_STATES.ATHLETE_PENDING]: Object.freeze([
+    PILOT_STATUS_REASON_CODES.ATHLETE_ACCOUNT_UNPROVISIONED,
+  ]),
+  [PILOT_LIFECYCLE_STATES.LINK_PENDING]: Object.freeze([
+    PILOT_STATUS_REASON_CODES.COACH_ATHLETE_LINK_UNACCEPTED,
+  ]),
+  [PILOT_LIFECYCLE_STATES.SCOPE_PENDING]: Object.freeze([
+    PILOT_STATUS_REASON_CODES.SCOPE_UNLOCKED,
+  ]),
+  [PILOT_LIFECYCLE_STATES.PHASE1_PENDING]: Object.freeze([
+    PILOT_STATUS_REASON_CODES.PHASE1_UNACCEPTED,
+  ]),
+  [PILOT_LIFECYCLE_STATES.COMPILE_PENDING]: Object.freeze([
+    PILOT_STATUS_REASON_CODES.FIRST_EXECUTABLE_SESSION_UNCOMPILED,
+  ]),
+  [PILOT_LIFECYCLE_STATES.COACH_OPERABLE]: Object.freeze([
+    PILOT_STATUS_REASON_CODES.ACTIVATION_SIGNAL_UNRECEIVED,
+  ]),
+  [PILOT_LIFECYCLE_STATES.ACTIVE]: Object.freeze([]),
+  [PILOT_LIFECYCLE_STATES.PAUSED]: Object.freeze([
+    PILOT_STATUS_REASON_CODES.PAUSED_BY_OPERATOR,
+  ]),
+  [PILOT_LIFECYCLE_STATES.STOPPED]: Object.freeze([
+    PILOT_STATUS_REASON_CODES.STOPPED_BY_OPERATOR,
+  ]),
+  [PILOT_LIFECYCLE_STATES.CANCELLED]: Object.freeze([
+    PILOT_STATUS_REASON_CODES.CANCELLED_BY_OPERATOR,
+  ]),
+});
+
+const ACTIVE_OPTIONAL_REASON_CODES = new Set([
+  PILOT_STATUS_REASON_CODES.RENEWAL_REQUIRED,
+  PILOT_STATUS_REASON_CODES.EXPANSION_REVIEW_REQUIRED,
+]);
+
+function assertKnownState(state, label) {
+  if (!PILOT_LIFECYCLE_STATE_LIST.includes(state)) {
+    throw new Error(label + "_unknown:" + String(state));
+  }
+}
+
+function assertKnownReasonCode(reasonCode) {
+  if (!PILOT_STATUS_REASON_CODE_LIST.includes(reasonCode)) {
+    throw new Error("pilot_status_reason_code_unknown:" + String(reasonCode));
+  }
+}
+
+function normalizeReasonCodes(reasonCodes = []) {
+  if (!Array.isArray(reasonCodes)) {
+    throw new Error("pilot_status_reason_codes_must_be_array");
+  }
+
+  const deduped = [];
+  const seen = new Set();
+
+  for (const reasonCode of reasonCodes) {
+    assertKnownReasonCode(reasonCode);
+
+    if (!seen.has(reasonCode)) {
+      seen.add(reasonCode);
+      deduped.push(reasonCode);
+    }
+  }
+
+  return deduped;
+}
+
+function coerceReasonContext(input = {}) {
+  return {
+    commercialSatisfied: input.commercialSatisfied === true,
+    workspaceProvisioned: input.workspaceProvisioned === true,
+    coachAccountProvisioned: input.coachAccountProvisioned === true,
+    athleteAccountProvisioned: input.athleteAccountProvisioned === true,
+    linkAccepted: input.linkAccepted === true,
+    scopeLocked: input.scopeLocked === true,
+    phase1Accepted: input.phase1Accepted === true,
+    firstExecutableSessionCompiled: input.firstExecutableSessionCompiled === true,
+    activationSignalReceived: input.activationSignalReceived === true,
+    pausedByOperator: input.pausedByOperator === true,
+    stoppedByOperator: input.stoppedByOperator === true,
+    cancelledByOperator: input.cancelledByOperator === true,
+    renewalRequired: input.renewalRequired === true,
+    expansionReviewRequired: input.expansionReviewRequired === true,
+  };
+}
+
+function appendActiveOptionalReasons(reasonCodes, context) {
+  if (context.renewalRequired) {
+    reasonCodes.push(PILOT_STATUS_REASON_CODES.RENEWAL_REQUIRED);
+  }
+
+  if (context.expansionReviewRequired) {
+    reasonCodes.push(PILOT_STATUS_REASON_CODES.EXPANSION_REVIEW_REQUIRED);
+  }
+}
+
+export function resolvePilotStatusReasonCodes(context = {}) {
+  const lifecycleState = resolvePilotLifecycleState(context);
+  const c = coerceReasonContext(context);
+  const reasonCodes = [];
+
+  switch (lifecycleState) {
+    case PILOT_LIFECYCLE_STATES.ACCEPTED:
+    case PILOT_LIFECYCLE_STATES.COMMERCIAL_PENDING:
+      reasonCodes.push(PILOT_STATUS_REASON_CODES.COMMERCIAL_UNSETTLED);
+      break;
+
+    case PILOT_LIFECYCLE_STATES.PLATFORM_PENDING:
+      reasonCodes.push(PILOT_STATUS_REASON_CODES.WORKSPACE_UNPROVISIONED);
+      break;
+
+    case PILOT_LIFECYCLE_STATES.COACH_PENDING:
+      reasonCodes.push(PILOT_STATUS_REASON_CODES.COACH_ACCOUNT_UNPROVISIONED);
+      break;
+
+    case PILOT_LIFECYCLE_STATES.ATHLETE_PENDING:
+      reasonCodes.push(PILOT_STATUS_REASON_CODES.ATHLETE_ACCOUNT_UNPROVISIONED);
+      break;
+
+    case PILOT_LIFECYCLE_STATES.LINK_PENDING:
+      reasonCodes.push(PILOT_STATUS_REASON_CODES.COACH_ATHLETE_LINK_UNACCEPTED);
+      break;
+
+    case PILOT_LIFECYCLE_STATES.SCOPE_PENDING:
+      reasonCodes.push(PILOT_STATUS_REASON_CODES.SCOPE_UNLOCKED);
+      break;
+
+    case PILOT_LIFECYCLE_STATES.PHASE1_PENDING:
+      reasonCodes.push(PILOT_STATUS_REASON_CODES.PHASE1_UNACCEPTED);
+      break;
+
+    case PILOT_LIFECYCLE_STATES.COMPILE_PENDING:
+      reasonCodes.push(PILOT_STATUS_REASON_CODES.FIRST_EXECUTABLE_SESSION_UNCOMPILED);
+      break;
+
+    case PILOT_LIFECYCLE_STATES.COACH_OPERABLE:
+      reasonCodes.push(PILOT_STATUS_REASON_CODES.ACTIVATION_SIGNAL_UNRECEIVED);
+      appendActiveOptionalReasons(reasonCodes, c);
+      break;
+
+    case PILOT_LIFECYCLE_STATES.ACTIVE:
+      appendActiveOptionalReasons(reasonCodes, c);
+      break;
+
+    case PILOT_LIFECYCLE_STATES.PAUSED:
+      reasonCodes.push(PILOT_STATUS_REASON_CODES.PAUSED_BY_OPERATOR);
+      appendActiveOptionalReasons(reasonCodes, c);
+      break;
+
+    case PILOT_LIFECYCLE_STATES.STOPPED:
+      reasonCodes.push(PILOT_STATUS_REASON_CODES.STOPPED_BY_OPERATOR);
+      break;
+
+    case PILOT_LIFECYCLE_STATES.CANCELLED:
+      reasonCodes.push(PILOT_STATUS_REASON_CODES.CANCELLED_BY_OPERATOR);
+      break;
+
+    default:
+      throw new Error("pilot_lifecycle_state_unhandled:" + lifecycleState);
+  }
+
+  return normalizeReasonCodes(reasonCodes);
+}
+
+export function assertPilotStateHasRequiredReasonCodes(state, reasonCodes = []) {
+  assertKnownState(state, "pilot_lifecycle_state");
+  const normalizedReasonCodes = normalizeReasonCodes(reasonCodes);
+  const requiredReasonCodes = PILOT_STATE_REQUIRED_REASON_POLICY[state];
+
+  if (state !== PILOT_LIFECYCLE_STATES.ACTIVE && normalizedReasonCodes.length === 0) {
+    throw new Error("pilot_status_reason_codes_required_for_state:" + state);
+  }
+
+  for (const requiredReasonCode of requiredReasonCodes) {
+    if (!normalizedReasonCodes.includes(requiredReasonCode)) {
+      throw new Error(
+        "pilot_status_reason_code_required_missing:" + state + ":" + requiredReasonCode,
+      );
+    }
+  }
+
+  for (const reasonCode of normalizedReasonCodes) {
+    if (state === PILOT_LIFECYCLE_STATES.ACTIVE) {
+      if (!ACTIVE_OPTIONAL_REASON_CODES.has(reasonCode)) {
+        throw new Error(
+          "pilot_status_reason_code_not_allowed_for_state:" + state + ":" + reasonCode,
+        );
+      }
+
+      continue;
+    }
+
+    if (
+      state === PILOT_LIFECYCLE_STATES.COACH_OPERABLE ||
+      state === PILOT_LIFECYCLE_STATES.PAUSED
+    ) {
+      const allowedReasonCodes = new Set([
+        ...requiredReasonCodes,
+        PILOT_STATUS_REASON_CODES.RENEWAL_REQUIRED,
+        PILOT_STATUS_REASON_CODES.EXPANSION_REVIEW_REQUIRED,
+      ]);
+
+      if (!allowedReasonCodes.has(reasonCode)) {
+        throw new Error(
+          "pilot_status_reason_code_not_allowed_for_state:" + state + ":" + reasonCode,
+        );
+      }
+
+      continue;
+    }
+
+    if (!requiredReasonCodes.includes(reasonCode)) {
+      throw new Error(
+        "pilot_status_reason_code_not_allowed_for_state:" + state + ":" + reasonCode,
+      );
+    }
+  }
+
+  return true;
+}
+
+export function assertPilotStatusReasonCodesMatchContext(state, context = {}, reasonCodes = []) {
+  assertKnownState(state, "pilot_lifecycle_state");
+  const resolvedState = resolvePilotLifecycleState(context);
+
+  if (resolvedState !== state) {
+    throw new Error(
+      "pilot_status_reason_context_state_mismatch:" + state + " resolved=" + resolvedState,
+    );
+  }
+
+  const resolvedReasonCodes = resolvePilotStatusReasonCodes(context);
+  const normalizedReasonCodes = normalizeReasonCodes(reasonCodes);
+
+  assertPilotStateHasRequiredReasonCodes(state, normalizedReasonCodes);
+
+  if (resolvedReasonCodes.length !== normalizedReasonCodes.length) {
+    throw new Error(
+      "pilot_status_reason_codes_context_mismatch:" +
+        state +
+        " expected=" +
+        resolvedReasonCodes.join(",") +
+        " actual=" +
+        normalizedReasonCodes.join(","),
+    );
+  }
+
+  for (const resolvedReasonCode of resolvedReasonCodes) {
+    if (!normalizedReasonCodes.includes(resolvedReasonCode)) {
+      throw new Error(
+        "pilot_status_reason_codes_context_mismatch:" +
+          state +
+          " missing=" +
+          resolvedReasonCode,
+      );
+    }
+  }
+
+  return true;
+}

--- a/shared/pilot-lifecycle/pilotStatusReasonCodes.test.mjs
+++ b/shared/pilot-lifecycle/pilotStatusReasonCodes.test.mjs
@@ -1,0 +1,418 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  PILOT_STATE_REQUIRED_REASON_POLICY,
+  PILOT_STATUS_REASON_CODES,
+  PILOT_STATUS_REASON_CODE_LIST,
+  assertPilotStateHasRequiredReasonCodes,
+  assertPilotStatusReasonCodesMatchContext,
+  resolvePilotStatusReasonCodes,
+} from "./pilotStatusReasonCodes.mjs";
+
+test("pilot status reason code registry is exact and closed", () => {
+  assert.deepEqual(PILOT_STATUS_REASON_CODE_LIST, [
+    "commercial_unsettled",
+    "workspace_unprovisioned",
+    "coach_account_unprovisioned",
+    "athlete_account_unprovisioned",
+    "coach_athlete_link_unaccepted",
+    "scope_unlocked",
+    "phase1_unaccepted",
+    "first_executable_session_uncompiled",
+    "activation_signal_unreceived",
+    "paused_by_operator",
+    "stopped_by_operator",
+    "cancelled_by_operator",
+    "renewal_required",
+    "expansion_review_required",
+  ]);
+});
+
+test("state required reason policy is exact", () => {
+  assert.deepEqual(PILOT_STATE_REQUIRED_REASON_POLICY, {
+    accepted: ["commercial_unsettled"],
+    commercial_pending: ["commercial_unsettled"],
+    platform_pending: ["workspace_unprovisioned"],
+    coach_pending: ["coach_account_unprovisioned"],
+    athlete_pending: ["athlete_account_unprovisioned"],
+    link_pending: ["coach_athlete_link_unaccepted"],
+    scope_pending: ["scope_unlocked"],
+    phase1_pending: ["phase1_unaccepted"],
+    compile_pending: ["first_executable_session_uncompiled"],
+    coach_operable: ["activation_signal_unreceived"],
+    active: [],
+    paused: ["paused_by_operator"],
+    stopped: ["stopped_by_operator"],
+    cancelled: ["cancelled_by_operator"],
+  });
+});
+
+test("reason resolution returns commercial_unsettled for default unresolved pilot", () => {
+  assert.deepEqual(resolvePilotStatusReasonCodes({}), [
+    PILOT_STATUS_REASON_CODES.COMMERCIAL_UNSETTLED,
+  ]);
+});
+
+test("reason resolution returns workspace_unprovisioned for platform_pending", () => {
+  assert.deepEqual(
+    resolvePilotStatusReasonCodes({
+      commercialSatisfied: true,
+    }),
+    [PILOT_STATUS_REASON_CODES.WORKSPACE_UNPROVISIONED],
+  );
+});
+
+test("reason resolution returns coach_account_unprovisioned for coach_pending", () => {
+  assert.deepEqual(
+    resolvePilotStatusReasonCodes({
+      commercialSatisfied: true,
+      workspaceProvisioned: true,
+    }),
+    [PILOT_STATUS_REASON_CODES.COACH_ACCOUNT_UNPROVISIONED],
+  );
+});
+
+test("reason resolution returns athlete_account_unprovisioned for athlete_pending", () => {
+  assert.deepEqual(
+    resolvePilotStatusReasonCodes({
+      commercialSatisfied: true,
+      workspaceProvisioned: true,
+      coachAccountProvisioned: true,
+    }),
+    [PILOT_STATUS_REASON_CODES.ATHLETE_ACCOUNT_UNPROVISIONED],
+  );
+});
+
+test("reason resolution returns link reason for link_pending", () => {
+  assert.deepEqual(
+    resolvePilotStatusReasonCodes({
+      commercialSatisfied: true,
+      workspaceProvisioned: true,
+      coachAccountProvisioned: true,
+      athleteAccountProvisioned: true,
+    }),
+    [PILOT_STATUS_REASON_CODES.COACH_ATHLETE_LINK_UNACCEPTED],
+  );
+});
+
+test("reason resolution returns scope reason for scope_pending", () => {
+  assert.deepEqual(
+    resolvePilotStatusReasonCodes({
+      commercialSatisfied: true,
+      workspaceProvisioned: true,
+      coachAccountProvisioned: true,
+      athleteAccountProvisioned: true,
+      linkAccepted: true,
+    }),
+    [PILOT_STATUS_REASON_CODES.SCOPE_UNLOCKED],
+  );
+});
+
+test("reason resolution returns phase1 reason for phase1_pending", () => {
+  assert.deepEqual(
+    resolvePilotStatusReasonCodes({
+      commercialSatisfied: true,
+      workspaceProvisioned: true,
+      coachAccountProvisioned: true,
+      athleteAccountProvisioned: true,
+      linkAccepted: true,
+      scopeLocked: true,
+    }),
+    [PILOT_STATUS_REASON_CODES.PHASE1_UNACCEPTED],
+  );
+});
+
+test("reason resolution returns compile reason for compile_pending", () => {
+  assert.deepEqual(
+    resolvePilotStatusReasonCodes({
+      commercialSatisfied: true,
+      workspaceProvisioned: true,
+      coachAccountProvisioned: true,
+      athleteAccountProvisioned: true,
+      linkAccepted: true,
+      scopeLocked: true,
+      phase1Accepted: true,
+    }),
+    [PILOT_STATUS_REASON_CODES.FIRST_EXECUTABLE_SESSION_UNCOMPILED],
+  );
+});
+
+test("reason resolution returns activation reason for coach_operable", () => {
+  assert.deepEqual(
+    resolvePilotStatusReasonCodes({
+      commercialSatisfied: true,
+      workspaceProvisioned: true,
+      coachAccountProvisioned: true,
+      athleteAccountProvisioned: true,
+      linkAccepted: true,
+      scopeLocked: true,
+      phase1Accepted: true,
+      firstExecutableSessionCompiled: true,
+    }),
+    [PILOT_STATUS_REASON_CODES.ACTIVATION_SIGNAL_UNRECEIVED],
+  );
+});
+
+test("reason resolution returns no required reason for active without adjunct conditions", () => {
+  assert.deepEqual(
+    resolvePilotStatusReasonCodes({
+      commercialSatisfied: true,
+      workspaceProvisioned: true,
+      coachAccountProvisioned: true,
+      athleteAccountProvisioned: true,
+      linkAccepted: true,
+      scopeLocked: true,
+      phase1Accepted: true,
+      firstExecutableSessionCompiled: true,
+      activationSignalReceived: true,
+    }),
+    [],
+  );
+});
+
+test("reason resolution returns adjunct reasons for active when flagged", () => {
+  assert.deepEqual(
+    resolvePilotStatusReasonCodes({
+      commercialSatisfied: true,
+      workspaceProvisioned: true,
+      coachAccountProvisioned: true,
+      athleteAccountProvisioned: true,
+      linkAccepted: true,
+      scopeLocked: true,
+      phase1Accepted: true,
+      firstExecutableSessionCompiled: true,
+      activationSignalReceived: true,
+      renewalRequired: true,
+      expansionReviewRequired: true,
+    }),
+    [
+      PILOT_STATUS_REASON_CODES.RENEWAL_REQUIRED,
+      PILOT_STATUS_REASON_CODES.EXPANSION_REVIEW_REQUIRED,
+    ],
+  );
+});
+
+test("reason resolution returns operator reason for paused", () => {
+  assert.deepEqual(
+    resolvePilotStatusReasonCodes({
+      commercialSatisfied: true,
+      workspaceProvisioned: true,
+      coachAccountProvisioned: true,
+      athleteAccountProvisioned: true,
+      linkAccepted: true,
+      scopeLocked: true,
+      phase1Accepted: true,
+      firstExecutableSessionCompiled: true,
+      pausedByOperator: true,
+    }),
+    [PILOT_STATUS_REASON_CODES.PAUSED_BY_OPERATOR],
+  );
+});
+
+test("reason resolution returns operator reason for stopped", () => {
+  assert.deepEqual(
+    resolvePilotStatusReasonCodes({
+      stoppedByOperator: true,
+    }),
+    [PILOT_STATUS_REASON_CODES.STOPPED_BY_OPERATOR],
+  );
+});
+
+test("reason resolution returns operator reason for cancelled", () => {
+  assert.deepEqual(
+    resolvePilotStatusReasonCodes({
+      cancelledByOperator: true,
+    }),
+    [PILOT_STATUS_REASON_CODES.CANCELLED_BY_OPERATOR],
+  );
+});
+
+test("non-active state requires at least one explicit reason code", () => {
+  assert.throws(
+    () => assertPilotStateHasRequiredReasonCodes("platform_pending", []),
+    /pilot_status_reason_codes_required_for_state:platform_pending/,
+  );
+});
+
+test("required reason code missing is rejected", () => {
+  assert.throws(
+    () =>
+      assertPilotStateHasRequiredReasonCodes("compile_pending", [
+        PILOT_STATUS_REASON_CODES.PHASE1_UNACCEPTED,
+      ]),
+    /pilot_status_reason_code_required_missing:compile_pending:first_executable_session_uncompiled/,
+  );
+});
+
+test("wrong reason code for non-active state is rejected", () => {
+  assert.throws(
+    () =>
+      assertPilotStateHasRequiredReasonCodes("coach_pending", [
+        PILOT_STATUS_REASON_CODES.WORKSPACE_UNPROVISIONED,
+      ]),
+    /pilot_status_reason_code_required_missing:coach_pending:coach_account_unprovisioned/,
+  );
+});
+
+test("non-active state rejects extra unrelated reason code", () => {
+  assert.throws(
+    () =>
+      assertPilotStateHasRequiredReasonCodes("stopped", [
+        PILOT_STATUS_REASON_CODES.STOPPED_BY_OPERATOR,
+        PILOT_STATUS_REASON_CODES.RENEWAL_REQUIRED,
+      ]),
+    /pilot_status_reason_code_not_allowed_for_state:stopped:renewal_required/,
+  );
+});
+
+test("coach_operable allows activation reason plus adjunct commercial flags", () => {
+  assert.equal(
+    assertPilotStateHasRequiredReasonCodes("coach_operable", [
+      PILOT_STATUS_REASON_CODES.ACTIVATION_SIGNAL_UNRECEIVED,
+      PILOT_STATUS_REASON_CODES.RENEWAL_REQUIRED,
+      PILOT_STATUS_REASON_CODES.EXPANSION_REVIEW_REQUIRED,
+    ]),
+    true,
+  );
+});
+
+test("paused allows operator reason plus adjunct commercial flags", () => {
+  assert.equal(
+    assertPilotStateHasRequiredReasonCodes("paused", [
+      PILOT_STATUS_REASON_CODES.PAUSED_BY_OPERATOR,
+      PILOT_STATUS_REASON_CODES.RENEWAL_REQUIRED,
+    ]),
+    true,
+  );
+});
+
+test("active allows only adjunct commercial flags", () => {
+  assert.equal(
+    assertPilotStateHasRequiredReasonCodes("active", [
+      PILOT_STATUS_REASON_CODES.RENEWAL_REQUIRED,
+      PILOT_STATUS_REASON_CODES.EXPANSION_REVIEW_REQUIRED,
+    ]),
+    true,
+  );
+
+  assert.throws(
+    () =>
+      assertPilotStateHasRequiredReasonCodes("active", [
+        PILOT_STATUS_REASON_CODES.STOPPED_BY_OPERATOR,
+      ]),
+    /pilot_status_reason_code_not_allowed_for_state:active:stopped_by_operator/,
+  );
+});
+
+test("unknown state is rejected", () => {
+  assert.throws(
+    () =>
+      assertPilotStateHasRequiredReasonCodes("not_a_state", [
+        PILOT_STATUS_REASON_CODES.COMMERCIAL_UNSETTLED,
+      ]),
+    /pilot_lifecycle_state_unknown:not_a_state/,
+  );
+});
+
+test("unknown reason code is rejected", () => {
+  assert.throws(
+    () =>
+      assertPilotStateHasRequiredReasonCodes("commercial_pending", [
+        "not_a_reason_code",
+      ]),
+    /pilot_status_reason_code_unknown:not_a_reason_code/,
+  );
+});
+
+test("reason codes must be an array", () => {
+  assert.throws(
+    () => assertPilotStateHasRequiredReasonCodes("commercial_pending", "nope"),
+    /pilot_status_reason_codes_must_be_array/,
+  );
+});
+
+test("duplicate reason codes are normalized and still pass", () => {
+  assert.equal(
+    assertPilotStateHasRequiredReasonCodes("commercial_pending", [
+      PILOT_STATUS_REASON_CODES.COMMERCIAL_UNSETTLED,
+      PILOT_STATUS_REASON_CODES.COMMERCIAL_UNSETTLED,
+    ]),
+    true,
+  );
+});
+
+test("state and reason codes must match context", () => {
+  assert.equal(
+    assertPilotStatusReasonCodesMatchContext(
+      "compile_pending",
+      {
+        commercialSatisfied: true,
+        workspaceProvisioned: true,
+        coachAccountProvisioned: true,
+        athleteAccountProvisioned: true,
+        linkAccepted: true,
+        scopeLocked: true,
+        phase1Accepted: true,
+      },
+      [PILOT_STATUS_REASON_CODES.FIRST_EXECUTABLE_SESSION_UNCOMPILED],
+    ),
+    true,
+  );
+
+  assert.equal(
+    assertPilotStatusReasonCodesMatchContext(
+      "active",
+      {
+        commercialSatisfied: true,
+        workspaceProvisioned: true,
+        coachAccountProvisioned: true,
+        athleteAccountProvisioned: true,
+        linkAccepted: true,
+        scopeLocked: true,
+        phase1Accepted: true,
+        firstExecutableSessionCompiled: true,
+        activationSignalReceived: true,
+        renewalRequired: true,
+      },
+      [PILOT_STATUS_REASON_CODES.RENEWAL_REQUIRED],
+    ),
+    true,
+  );
+});
+
+test("state mismatch against context is rejected", () => {
+  assert.throws(
+    () =>
+      assertPilotStatusReasonCodesMatchContext(
+        "active",
+        {
+          commercialSatisfied: true,
+        },
+        [],
+      ),
+    /pilot_status_reason_context_state_mismatch:active resolved=platform_pending/,
+  );
+});
+
+test("reason mismatch against context is rejected", () => {
+  assert.throws(
+    () =>
+      assertPilotStatusReasonCodesMatchContext(
+        "coach_operable",
+        {
+          commercialSatisfied: true,
+          workspaceProvisioned: true,
+          coachAccountProvisioned: true,
+          athleteAccountProvisioned: true,
+          linkAccepted: true,
+          scopeLocked: true,
+          phase1Accepted: true,
+          firstExecutableSessionCompiled: true,
+          renewalRequired: true,
+        },
+        [PILOT_STATUS_REASON_CODES.ACTIVATION_SIGNAL_UNRECEIVED],
+      ),
+    /pilot_status_reason_codes_context_mismatch:coach_operable expected=activation_signal_unreceived,renewal_required actual=activation_signal_unreceived/,
+  );
+});


### PR DESCRIPTION
## Summary
- add machine-readable pilot status reason code registry
- add required reason policy by canonical lifecycle state
- add deterministic status reason resolution from explicit context
- repair pilot lifecycle state machine syntax on this branch so lifecycle and reason proofs run together

## Proof
- node --test .\shared\pilot-lifecycle\pilotLifecycleStateMachine.test.mjs .\shared\pilot-lifecycle\pilotStatusReasonCodes.test.mjs
- npm run lint:fast
- npm run dev:status