### PR TITLE
feat(engine): add onboarding start gate contract

### DIFF
--- a/shared/pilot-lifecycle/onboardingStartGateContract.mjs
+++ b/shared/pilot-lifecycle/onboardingStartGateContract.mjs
@@ -1,0 +1,129 @@
+export const ONBOARDING_START_TRIGGER_EVENTS = Object.freeze([
+  "coach_invite_sent",
+  "athlete_invite_sent",
+  "link_acceptance_recorded",
+  "phase1_declaration_started",
+  "first_compile_attempt_started",
+]);
+
+export const ONBOARDING_START_TRIGGER_EVENT_SET = new Set(
+  ONBOARDING_START_TRIGGER_EVENTS,
+);
+
+export const ONBOARDING_START_NON_TRIGGER_FACTS = Object.freeze([
+  "commercialSatisfied",
+  "workspaceProvisioned",
+  "coachAccountProvisioned",
+  "athleteAccountProvisioned",
+  "linkAccepted",
+  "scopeLocked",
+  "phase1Accepted",
+  "firstExecutableSessionCompiled",
+  "activationSignalReceived",
+  "pausedByOperator",
+  "stoppedByOperator",
+  "cancelledByOperator",
+]);
+
+function normalizeEventList(events = []) {
+  if (!Array.isArray(events)) {
+    throw new Error("onboarding_start_events_must_be_array");
+  }
+
+  const normalized = [];
+  const seen = new Set();
+
+  for (const eventName of events) {
+    if (typeof eventName !== "string" || eventName.trim() === "") {
+      throw new Error("onboarding_start_event_invalid:" + String(eventName));
+    }
+
+    if (!ONBOARDING_START_TRIGGER_EVENT_SET.has(eventName)) {
+      throw new Error("onboarding_start_event_unknown:" + eventName);
+    }
+
+    if (!seen.has(eventName)) {
+      seen.add(eventName);
+      normalized.push(eventName);
+    }
+  }
+
+  return Object.freeze(normalized);
+}
+
+function coerceContext(input = {}) {
+  return {
+    commercialSatisfied: input.commercialSatisfied === true,
+    workspaceProvisioned: input.workspaceProvisioned === true,
+    coachAccountProvisioned: input.coachAccountProvisioned === true,
+    athleteAccountProvisioned: input.athleteAccountProvisioned === true,
+    linkAccepted: input.linkAccepted === true,
+    scopeLocked: input.scopeLocked === true,
+    phase1Accepted: input.phase1Accepted === true,
+    firstExecutableSessionCompiled: input.firstExecutableSessionCompiled === true,
+    activationSignalReceived: input.activationSignalReceived === true,
+    pausedByOperator: input.pausedByOperator === true,
+    stoppedByOperator: input.stoppedByOperator === true,
+    cancelledByOperator: input.cancelledByOperator === true,
+  };
+}
+
+export function assertOnboardingStartedTriggerLawful(eventName) {
+  if (typeof eventName !== "string" || eventName.trim() === "") {
+    throw new Error("onboarding_start_event_invalid:" + String(eventName));
+  }
+
+  if (!ONBOARDING_START_TRIGGER_EVENT_SET.has(eventName)) {
+    throw new Error("onboarding_start_event_unknown:" + eventName);
+  }
+
+  return true;
+}
+
+export function resolveOnboardingStarted(events = []) {
+  return normalizeEventList(events).length > 0;
+}
+
+export function getOnboardingStartedTriggerEvents(events = []) {
+  return normalizeEventList(events);
+}
+
+export function assertOnboardingStarted(events = []) {
+  const normalized = normalizeEventList(events);
+
+  if (normalized.length === 0) {
+    throw new Error("onboarding_start_not_triggered");
+  }
+
+  return true;
+}
+
+export function assertOnboardingStartNotInferred(context = {}, events = []) {
+  const c = coerceContext(context);
+  const normalized = normalizeEventList(events);
+  const onboardingStarted = resolveOnboardingStarted(normalized);
+
+  const anyAmbientFactTrue =
+    c.commercialSatisfied ||
+    c.workspaceProvisioned ||
+    c.coachAccountProvisioned ||
+    c.athleteAccountProvisioned ||
+    c.linkAccepted ||
+    c.scopeLocked ||
+    c.phase1Accepted ||
+    c.firstExecutableSessionCompiled ||
+    c.activationSignalReceived ||
+    c.pausedByOperator ||
+    c.stoppedByOperator ||
+    c.cancelledByOperator;
+
+  if (normalized.length === 0 && onboardingStarted) {
+    throw new Error("onboarding_start_inference_forbidden");
+  }
+
+  if (normalized.length === 0 && anyAmbientFactTrue && onboardingStarted) {
+    throw new Error("onboarding_start_inference_forbidden");
+  }
+
+  return true;
+}

--- a/shared/pilot-lifecycle/onboardingStartGateContract.test.mjs
+++ b/shared/pilot-lifecycle/onboardingStartGateContract.test.mjs
@@ -1,0 +1,218 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  ONBOARDING_START_NON_TRIGGER_FACTS,
+  ONBOARDING_START_TRIGGER_EVENTS,
+  assertOnboardingStarted,
+  assertOnboardingStartedTriggerLawful,
+  assertOnboardingStartNotInferred,
+  getOnboardingStartedTriggerEvents,
+  resolveOnboardingStarted,
+} from "./onboardingStartGateContract.mjs";
+
+test("onboarding start trigger registry is exact", () => {
+  assert.deepEqual(ONBOARDING_START_TRIGGER_EVENTS, [
+    "coach_invite_sent",
+    "athlete_invite_sent",
+    "link_acceptance_recorded",
+    "phase1_declaration_started",
+    "first_compile_attempt_started",
+  ]);
+});
+
+test("onboarding start non-trigger fact registry is exact", () => {
+  assert.deepEqual(ONBOARDING_START_NON_TRIGGER_FACTS, [
+    "commercialSatisfied",
+    "workspaceProvisioned",
+    "coachAccountProvisioned",
+    "athleteAccountProvisioned",
+    "linkAccepted",
+    "scopeLocked",
+    "phase1Accepted",
+    "firstExecutableSessionCompiled",
+    "activationSignalReceived",
+    "pausedByOperator",
+    "stoppedByOperator",
+    "cancelledByOperator",
+  ]);
+});
+
+test("coach invite sent triggers onboarding start", () => {
+  assert.equal(resolveOnboardingStarted(["coach_invite_sent"]), true);
+  assert.equal(assertOnboardingStarted(["coach_invite_sent"]), true);
+});
+
+test("athlete invite sent triggers onboarding start", () => {
+  assert.equal(resolveOnboardingStarted(["athlete_invite_sent"]), true);
+});
+
+test("link acceptance recorded triggers onboarding start", () => {
+  assert.equal(resolveOnboardingStarted(["link_acceptance_recorded"]), true);
+});
+
+test("phase1 declaration started triggers onboarding start", () => {
+  assert.equal(resolveOnboardingStarted(["phase1_declaration_started"]), true);
+});
+
+test("first compile attempt started triggers onboarding start", () => {
+  assert.equal(resolveOnboardingStarted(["first_compile_attempt_started"]), true);
+});
+
+test("multiple lawful trigger events dedupe and remain factual", () => {
+  assert.deepEqual(
+    getOnboardingStartedTriggerEvents([
+      "coach_invite_sent",
+      "coach_invite_sent",
+      "phase1_declaration_started",
+    ]),
+    ["coach_invite_sent", "phase1_declaration_started"],
+  );
+});
+
+test("no trigger events means onboarding has not started", () => {
+  assert.equal(resolveOnboardingStarted([]), false);
+  assert.throws(
+    () => assertOnboardingStarted([]),
+    /onboarding_start_not_triggered/,
+  );
+});
+
+test("lawful trigger validation accepts all whitelisted events", () => {
+  for (const eventName of ONBOARDING_START_TRIGGER_EVENTS) {
+    assert.equal(assertOnboardingStartedTriggerLawful(eventName), true);
+  }
+});
+
+test("unknown trigger name hard-fails", () => {
+  assert.throws(
+    () => assertOnboardingStartedTriggerLawful("workspace_provisioned"),
+    /onboarding_start_event_unknown:workspace_provisioned/,
+  );
+});
+
+test("invalid trigger type hard-fails", () => {
+  assert.throws(
+    () => assertOnboardingStartedTriggerLawful(""),
+    /onboarding_start_event_invalid:/,
+  );
+
+  assert.throws(
+    () => getOnboardingStartedTriggerEvents([null]),
+    /onboarding_start_event_invalid:null/,
+  );
+});
+
+test("events input must be array", () => {
+  assert.throws(
+    () => resolveOnboardingStarted("coach_invite_sent"),
+    /onboarding_start_events_must_be_array/,
+  );
+});
+
+test("commercial satisfied alone does not trigger onboarding start", () => {
+  const context = { commercialSatisfied: true };
+
+  assert.equal(resolveOnboardingStarted([]), false);
+  assert.equal(assertOnboardingStartNotInferred(context, []), true);
+});
+
+test("workspace provisioned alone does not trigger onboarding start", () => {
+  const context = { workspaceProvisioned: true };
+
+  assert.equal(resolveOnboardingStarted([]), false);
+  assert.equal(assertOnboardingStartNotInferred(context, []), true);
+});
+
+test("accounts provisioned alone do not trigger onboarding start", () => {
+  const context = {
+    coachAccountProvisioned: true,
+    athleteAccountProvisioned: true,
+  };
+
+  assert.equal(resolveOnboardingStarted([]), false);
+  assert.equal(assertOnboardingStartNotInferred(context, []), true);
+});
+
+test("link accepted alone does not trigger onboarding start without trigger event", () => {
+  const context = { linkAccepted: true };
+
+  assert.equal(resolveOnboardingStarted([]), false);
+  assert.equal(assertOnboardingStartNotInferred(context, []), true);
+});
+
+test("scope locked alone does not trigger onboarding start", () => {
+  const context = { scopeLocked: true };
+
+  assert.equal(resolveOnboardingStarted([]), false);
+  assert.equal(assertOnboardingStartNotInferred(context, []), true);
+});
+
+test("phase1 accepted alone does not trigger onboarding start", () => {
+  const context = { phase1Accepted: true };
+
+  assert.equal(resolveOnboardingStarted([]), false);
+  assert.equal(assertOnboardingStartNotInferred(context, []), true);
+});
+
+test("compiled session alone does not trigger onboarding start", () => {
+  const context = { firstExecutableSessionCompiled: true };
+
+  assert.equal(resolveOnboardingStarted([]), false);
+  assert.equal(assertOnboardingStartNotInferred(context, []), true);
+});
+
+test("downstream active conditions alone do not trigger onboarding start", () => {
+  const context = {
+    activationSignalReceived: true,
+    firstExecutableSessionCompiled: true,
+  };
+
+  assert.equal(resolveOnboardingStarted([]), false);
+  assert.equal(assertOnboardingStartNotInferred(context, []), true);
+});
+
+test("paused stopped and cancelled flags alone do not trigger onboarding start", () => {
+  assert.equal(
+    assertOnboardingStartNotInferred({ pausedByOperator: true }, []),
+    true,
+  );
+  assert.equal(
+    assertOnboardingStartNotInferred({ stoppedByOperator: true }, []),
+    true,
+  );
+  assert.equal(
+    assertOnboardingStartNotInferred({ cancelledByOperator: true }, []),
+    true,
+  );
+});
+
+test("explicit trigger remains lawful even when ambient setup facts are present", () => {
+  const context = {
+    commercialSatisfied: true,
+    workspaceProvisioned: true,
+    coachAccountProvisioned: true,
+    athleteAccountProvisioned: true,
+    linkAccepted: true,
+  };
+
+  assert.equal(resolveOnboardingStarted(["coach_invite_sent"]), true);
+  assert.equal(assertOnboardingStartNotInferred(context, ["coach_invite_sent"]), true);
+});
+
+test("trigger list is closed world and rejects ambient fact names", () => {
+  assert.throws(
+    () => getOnboardingStartedTriggerEvents(["commercialSatisfied"]),
+    /onboarding_start_event_unknown:commercialSatisfied/,
+  );
+
+  assert.throws(
+    () => getOnboardingStartedTriggerEvents(["phase1Accepted"]),
+    /onboarding_start_event_unknown:phase1Accepted/,
+  );
+
+  assert.throws(
+    () => getOnboardingStartedTriggerEvents(["firstExecutableSessionCompiled"]),
+    /onboarding_start_event_unknown:firstExecutableSessionCompiled/,
+  );
+});


### PR DESCRIPTION
## Summary
- add explicit onboarding-start gate contract
- add closed trigger registry for lawful onboarding-start events
- reject inferred onboarding-start from setup facts or downstream state
- add proof tests for lawful triggers, non-triggers, and closed-world event validation

## Proof
- node --test .\shared\pilot-lifecycle\pilotLifecycleStateMachine.test.mjs .\shared\pilot-lifecycle\pilotStatusReasonCodes.test.mjs .\shared\pilot-lifecycle\coachOperableGateContract.test.mjs .\shared\pilot-lifecycle\onboardingStartGateContract.test.mjs
- npm run lint:fast
- npm run dev:status