### PR TITLE
feat(engine): add declaration acceptance state surface

### DIFF
--- a/shared/pilot-lifecycle/declarationAcceptanceStateSurface.mjs
+++ b/shared/pilot-lifecycle/declarationAcceptanceStateSurface.mjs
@@ -1,0 +1,101 @@
+export const DECLARATION_STATE = Object.freeze({
+  PENDING: "pending",
+  ACCEPTED: "accepted",
+  BLOCKED: "blocked",
+  SUPERSEDED: "superseded",
+});
+
+export const DECLARATION_STATE_LIST = Object.freeze(
+  Object.values(DECLARATION_STATE),
+);
+
+export const DECLARATION_ALLOWED_TRANSITIONS = Object.freeze({
+  [DECLARATION_STATE.PENDING]: Object.freeze([
+    DECLARATION_STATE.ACCEPTED,
+    DECLARATION_STATE.BLOCKED,
+    DECLARATION_STATE.SUPERSEDED,
+  ]),
+  [DECLARATION_STATE.ACCEPTED]: Object.freeze([
+    DECLARATION_STATE.SUPERSEDED,
+  ]),
+  [DECLARATION_STATE.BLOCKED]: Object.freeze([
+    DECLARATION_STATE.PENDING,
+    DECLARATION_STATE.SUPERSEDED,
+  ]),
+  [DECLARATION_STATE.SUPERSEDED]: Object.freeze([]),
+});
+
+function assertKnownState(state, label) {
+  if (!DECLARATION_STATE_LIST.includes(state)) {
+    throw new Error(label + "_unknown:" + String(state));
+  }
+}
+
+function coerceDeclarationContext(input = {}) {
+  return {
+    accepted: input.accepted === true,
+    blocked: input.blocked === true,
+    superseded: input.superseded === true,
+  };
+}
+
+export function canTransitionDeclarationState(fromState, toState) {
+  assertKnownState(fromState, "declaration_state_from");
+  assertKnownState(toState, "declaration_state_to");
+
+  return DECLARATION_ALLOWED_TRANSITIONS[fromState].includes(toState);
+}
+
+export function assertDeclarationTransitionAllowed(fromState, toState) {
+  if (!canTransitionDeclarationState(fromState, toState)) {
+    throw new Error(
+      "declaration_state_transition_forbidden:" + fromState + "->" + toState,
+    );
+  }
+
+  return true;
+}
+
+export function resolveDeclarationState(context = {}) {
+  const c = coerceDeclarationContext(context);
+
+  if (c.accepted && c.blocked) {
+    throw new Error("declaration_state_invalid:accepted_and_blocked");
+  }
+
+  if (c.superseded) {
+    return DECLARATION_STATE.SUPERSEDED;
+  }
+
+  if (c.accepted) {
+    return DECLARATION_STATE.ACCEPTED;
+  }
+
+  if (c.blocked) {
+    return DECLARATION_STATE.BLOCKED;
+  }
+
+  return DECLARATION_STATE.PENDING;
+}
+
+export function assertDeclarationStateMatchesContext(state, context = {}) {
+  assertKnownState(state, "declaration_state");
+  const resolvedState = resolveDeclarationState(context);
+
+  if (resolvedState !== state) {
+    throw new Error(
+      "declaration_state_context_mismatch:" +
+        state +
+        " resolved=" +
+        resolvedState,
+    );
+  }
+
+  return true;
+}
+
+export function assertDeclarationTransitionMatchesContext(fromState, toState, context = {}) {
+  assertDeclarationTransitionAllowed(fromState, toState);
+  assertDeclarationStateMatchesContext(toState, context);
+  return true;
+}

--- a/shared/pilot-lifecycle/declarationAcceptanceStateSurface.test.mjs
+++ b/shared/pilot-lifecycle/declarationAcceptanceStateSurface.test.mjs
@@ -1,0 +1,222 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  DECLARATION_ALLOWED_TRANSITIONS,
+  DECLARATION_STATE,
+  DECLARATION_STATE_LIST,
+  assertDeclarationStateMatchesContext,
+  assertDeclarationTransitionAllowed,
+  assertDeclarationTransitionMatchesContext,
+  canTransitionDeclarationState,
+  resolveDeclarationState,
+} from "./declarationAcceptanceStateSurface.mjs";
+
+test("declaration state enum is exact and closed", () => {
+  assert.deepEqual(DECLARATION_STATE_LIST, [
+    "pending",
+    "accepted",
+    "blocked",
+    "superseded",
+  ]);
+});
+
+test("declaration allowed transitions are exact", () => {
+  assert.deepEqual(DECLARATION_ALLOWED_TRANSITIONS, {
+    pending: ["accepted", "blocked", "superseded"],
+    accepted: ["superseded"],
+    blocked: ["pending", "superseded"],
+    superseded: [],
+  });
+});
+
+test("pending can move to accepted blocked or superseded", () => {
+  assert.equal(canTransitionDeclarationState("pending", "accepted"), true);
+  assert.equal(canTransitionDeclarationState("pending", "blocked"), true);
+  assert.equal(canTransitionDeclarationState("pending", "superseded"), true);
+});
+
+test("accepted can only move to superseded", () => {
+  assert.equal(canTransitionDeclarationState("accepted", "superseded"), true);
+  assert.equal(canTransitionDeclarationState("accepted", "pending"), false);
+  assert.equal(canTransitionDeclarationState("accepted", "blocked"), false);
+  assert.equal(canTransitionDeclarationState("accepted", "accepted"), false);
+});
+
+test("blocked can move back to pending or to superseded", () => {
+  assert.equal(canTransitionDeclarationState("blocked", "pending"), true);
+  assert.equal(canTransitionDeclarationState("blocked", "superseded"), true);
+  assert.equal(canTransitionDeclarationState("blocked", "accepted"), false);
+  assert.equal(canTransitionDeclarationState("blocked", "blocked"), false);
+});
+
+test("superseded is terminal", () => {
+  assert.equal(canTransitionDeclarationState("superseded", "pending"), false);
+  assert.equal(canTransitionDeclarationState("superseded", "accepted"), false);
+  assert.equal(canTransitionDeclarationState("superseded", "blocked"), false);
+  assert.equal(canTransitionDeclarationState("superseded", "superseded"), false);
+});
+
+test("forbidden transition throws", () => {
+  assert.throws(
+    () => assertDeclarationTransitionAllowed("accepted", "blocked"),
+    /declaration_state_transition_forbidden:accepted->blocked/,
+  );
+});
+
+test("resolve declaration state defaults to pending", () => {
+  assert.equal(resolveDeclarationState({}), DECLARATION_STATE.PENDING);
+});
+
+test("resolve declaration state returns accepted when explicit accepted flag is true", () => {
+  assert.equal(
+    resolveDeclarationState({ accepted: true }),
+    DECLARATION_STATE.ACCEPTED,
+  );
+});
+
+test("resolve declaration state returns blocked when explicit blocked flag is true", () => {
+  assert.equal(
+    resolveDeclarationState({ blocked: true }),
+    DECLARATION_STATE.BLOCKED,
+  );
+});
+
+test("resolve declaration state returns superseded when explicit superseded flag is true", () => {
+  assert.equal(
+    resolveDeclarationState({ superseded: true }),
+    DECLARATION_STATE.SUPERSEDED,
+  );
+});
+
+test("superseded has priority over accepted in a lawful context", () => {
+  assert.equal(
+    resolveDeclarationState({
+      accepted: true,
+      blocked: false,
+      superseded: true,
+    }),
+    DECLARATION_STATE.SUPERSEDED,
+  );
+});
+
+test("superseded has priority over blocked in a lawful context", () => {
+  assert.equal(
+    resolveDeclarationState({
+      accepted: false,
+      blocked: true,
+      superseded: true,
+    }),
+    DECLARATION_STATE.SUPERSEDED,
+  );
+});
+
+test("declaration cannot be simultaneously accepted and blocked", () => {
+  assert.throws(
+    () =>
+      resolveDeclarationState({
+        accepted: true,
+        blocked: true,
+        superseded: false,
+      }),
+    /declaration_state_invalid:accepted_and_blocked/,
+  );
+});
+
+test("accepted and blocked remains invalid even if superseded is also true", () => {
+  assert.throws(
+    () =>
+      resolveDeclarationState({
+        accepted: true,
+        blocked: true,
+        superseded: true,
+      }),
+    /declaration_state_invalid:accepted_and_blocked/,
+  );
+});
+
+test("state matches context for lawful states", () => {
+  assert.equal(
+    assertDeclarationStateMatchesContext("pending", {}),
+    true,
+  );
+
+  assert.equal(
+    assertDeclarationStateMatchesContext("accepted", { accepted: true }),
+    true,
+  );
+
+  assert.equal(
+    assertDeclarationStateMatchesContext("blocked", { blocked: true }),
+    true,
+  );
+
+  assert.equal(
+    assertDeclarationStateMatchesContext("superseded", { superseded: true }),
+    true,
+  );
+});
+
+test("state mismatch against context throws", () => {
+  assert.throws(
+    () =>
+      assertDeclarationStateMatchesContext("accepted", { blocked: true }),
+    /declaration_state_context_mismatch:accepted resolved=blocked/,
+  );
+});
+
+test("pending to accepted transition matches explicit accepted context", () => {
+  assert.equal(
+    assertDeclarationTransitionMatchesContext("pending", "accepted", {
+      accepted: true,
+    }),
+    true,
+  );
+});
+
+test("pending to blocked transition matches explicit blocked context", () => {
+  assert.equal(
+    assertDeclarationTransitionMatchesContext("pending", "blocked", {
+      blocked: true,
+    }),
+    true,
+  );
+});
+
+test("accepted to superseded transition matches explicit superseded context", () => {
+  assert.equal(
+    assertDeclarationTransitionMatchesContext("accepted", "superseded", {
+      superseded: true,
+    }),
+    true,
+  );
+});
+
+test("blocked to pending transition matches cleared state context", () => {
+  assert.equal(
+    assertDeclarationTransitionMatchesContext("blocked", "pending", {}),
+    true,
+  );
+});
+
+test("transition context mismatch throws", () => {
+  assert.throws(
+    () =>
+      assertDeclarationTransitionMatchesContext("pending", "accepted", {
+        blocked: true,
+      }),
+    /declaration_state_context_mismatch:accepted resolved=blocked/,
+  );
+});
+
+test("unknown state is rejected", () => {
+  assert.throws(
+    () => canTransitionDeclarationState("unknown", "accepted"),
+    /declaration_state_from_unknown:unknown/,
+  );
+
+  assert.throws(
+    () => canTransitionDeclarationState("pending", "unknown"),
+    /declaration_state_to_unknown:unknown/,
+  );
+});


### PR DESCRIPTION
## Summary
- add declaration acceptance state surface with closed states: pending, accepted, blocked, superseded
- add valid and invalid transition rules for declaration state movement
- enforce invariant that a declaration cannot be simultaneously accepted and blocked
- add proof tests for state resolution, transition legality, and context mismatch failures

## Proof
- node --test .\shared\pilot-lifecycle\pilotLifecycleStateMachine.test.mjs .\shared\pilot-lifecycle\pilotStatusReasonCodes.test.mjs .\shared\pilot-lifecycle\coachOperableGateContract.test.mjs .\shared\pilot-lifecycle\onboardingStartGateContract.test.mjs .\shared\pilot-lifecycle\declarationAcceptanceStateSurface.test.mjs
- npm run lint:fast
- npm run dev:status