### PR TITLE
S37 coach assignment execution pack

### DIFF
--- a/ci/scripts/guards/s37_coach_assignment_execution_pack_guard.mjs
+++ b/ci/scripts/guards/s37_coach_assignment_execution_pack_guard.mjs
@@ -1,0 +1,119 @@
+import fs from "node:fs";
+
+const docPath = "docs/pilot/S37_COACH_ASSIGNMENT_EXECUTION_PACK.md";
+const fixturePath = "docs/pilot/fixtures/s37_coach_assignment_execution_pack.valid.json";
+
+const allowedEvents = new Set([
+  "coach_assignment_requested",
+  "coach_athlete_link_verified",
+  "coach_assignment_recorded",
+  "athlete_session_available"
+]);
+
+const allowedLinkStatuses = new Set(["accepted"]);
+const blockedLinkStatuses = new Set(["missing", "pending", "refused", "revoked", "expired"]);
+
+const requiredDocStrings = [
+  "S37 - Coach Assignment Execution Pack",
+  "linked athlete",
+  "coach_assignment_requested",
+  "coach_athlete_link_verified",
+  "coach_assignment_recorded",
+  "athlete_session_available",
+  "assignment_scope: coach_managed",
+  "linked_athlete_only: true",
+  "engine_authority_created: false",
+  "phase1_mutated: false",
+  "recompilation_triggered: false",
+  "legality_changed: false",
+  "engine_output_overridden: false",
+  "A coach can assign an existing lawful session target to an accepted linked athlete, making it available as factual platform state without creating engine authority."
+];
+
+function fail(message) {
+  console.error(JSON.stringify({ ok: false, slice: "S37", message }, null, 2));
+  process.exit(1);
+}
+
+if (!fs.existsSync(docPath)) fail(`Missing ${docPath}`);
+if (!fs.existsSync(fixturePath)) fail(`Missing ${fixturePath}`);
+
+const doc = fs.readFileSync(docPath, "utf8");
+const fixture = JSON.parse(fs.readFileSync(fixturePath, "utf8"));
+
+for (const value of requiredDocStrings) {
+  if (!doc.includes(value)) fail(`Missing required S37 doc string: ${value}`);
+}
+
+if (fixture.slice !== "S37") fail("Fixture slice must be S37.");
+if (fixture.proof_name !== "coach_assignment_execution_pack") fail("Fixture proof_name mismatch.");
+if (!fixture.coach_id) fail("coach_id missing.");
+if (!fixture.athlete_id) fail("athlete_id missing.");
+if (!fixture.session_id) fail("session_id missing.");
+if (!fixture.link_id) fail("link_id missing.");
+if (!allowedLinkStatuses.has(fixture.link_status)) fail("link_status must be accepted.");
+if (fixture.assignment_scope !== "coach_managed") fail("assignment_scope must be coach_managed.");
+if (fixture.availability_status !== "available_to_athlete") fail("availability_status must be available_to_athlete.");
+if (fixture.linked_athlete_only !== true) fail("linked_athlete_only must be true.");
+if (fixture.unlinked_assignment_blocked !== true) fail("unlinked_assignment_blocked must be true.");
+if (fixture.pending_link_assignment_blocked !== true) fail("pending_link_assignment_blocked must be true.");
+if (fixture.revoked_link_assignment_blocked !== true) fail("revoked_link_assignment_blocked must be true.");
+if (fixture.engine_authority_created !== false) fail("engine_authority_created must be false.");
+if (fixture.phase1_mutated !== false) fail("phase1_mutated must be false.");
+if (fixture.recompilation_triggered !== false) fail("recompilation_triggered must be false.");
+if (fixture.legality_changed !== false) fail("legality_changed must be false.");
+if (fixture.engine_output_overridden !== false) fail("engine_output_overridden must be false.");
+if (fixture.readiness_claim_present !== false) fail("readiness_claim_present must be false.");
+if (fixture.safety_claim_present !== false) fail("safety_claim_present must be false.");
+if (fixture.recommendation_present !== false) fail("recommendation_present must be false.");
+
+if (!Array.isArray(fixture.events)) fail("events must be an array.");
+if (fixture.events.length !== fixture.event_count) fail("event_count must match events length.");
+
+const ids = new Set();
+for (const [index, event] of fixture.events.entries()) {
+  if (!event.event_id) fail(`events[${index}].event_id missing.`);
+  if (ids.has(event.event_id)) fail(`Duplicate event_id ${event.event_id}.`);
+  ids.add(event.event_id);
+
+  if (event.coach_id !== fixture.coach_id) fail(`events[${index}].coach_id mismatch.`);
+  if (event.athlete_id !== fixture.athlete_id) fail(`events[${index}].athlete_id mismatch.`);
+  if (event.session_id !== fixture.session_id) fail(`events[${index}].session_id mismatch.`);
+  if (event.actor !== "coach") fail(`events[${index}].actor must be coach.`);
+  if (!allowedEvents.has(event.event_type)) fail(`events[${index}].event_type is not allowed: ${event.event_type}`);
+  if (!event.occurred_at_utc) fail(`events[${index}].occurred_at_utc missing.`);
+
+  if (event.event_type === "coach_athlete_link_verified") {
+    if (event.link_id !== fixture.link_id) fail(`events[${index}].link_id mismatch.`);
+    if (event.link_status !== "accepted") fail(`events[${index}].link_status must be accepted.`);
+  }
+
+  if (event.event_type === "coach_assignment_recorded") {
+    if (event.assignment_id !== fixture.assignment_id) fail(`events[${index}].assignment_id mismatch.`);
+    if (event.assignment_scope !== "coach_managed") fail(`events[${index}].assignment_scope must be coach_managed.`);
+  }
+
+  if (event.event_type === "athlete_session_available") {
+    if (event.availability_status !== "available_to_athlete") fail(`events[${index}].availability_status must be available_to_athlete.`);
+  }
+}
+
+const eventTypes = new Set(fixture.events.map((event) => event.event_type));
+for (const required of [
+  "coach_assignment_requested",
+  "coach_athlete_link_verified",
+  "coach_assignment_recorded",
+  "athlete_session_available"
+]) {
+  if (!eventTypes.has(required)) fail(`Required event missing: ${required}`);
+}
+
+if (!Array.isArray(fixture.blocked_cases)) fail("blocked_cases must be an array.");
+for (const blockedCase of fixture.blocked_cases) {
+  if (!blockedCase.case_id) fail("blocked case_id missing.");
+  if (!blockedLinkStatuses.has(blockedCase.link_status)) fail(`blocked case link_status invalid: ${blockedCase.link_status}`);
+  if (blockedCase.assignment_recorded !== false) fail(`blocked case ${blockedCase.case_id} must not record assignment.`);
+  if (!blockedCase.blocked_reason) fail(`blocked case ${blockedCase.case_id} missing blocked_reason.`);
+}
+
+console.log(JSON.stringify({ ok: true, slice: "S37", checked: [docPath, fixturePath] }, null, 2));

--- a/docs/pilot/S37_COACH_ASSIGNMENT_EXECUTION_PACK.md
+++ b/docs/pilot/S37_COACH_ASSIGNMENT_EXECUTION_PACK.md
@@ -1,0 +1,288 @@
+# S37 - Coach Assignment Execution Pack
+
+## Target
+
+Define the exact coach assignment flow from coach dashboard action to athlete session availability.
+
+## Invariant
+
+A coach may assign a session only to a linked athlete.
+
+Coach assignment is platform workflow only.
+
+Coach assignment must not:
+
+- create engine authority
+- alter Phase 1 declarations
+- re-run compilation
+- alter legality
+- override engine decisions
+- alter substitutions
+- alter progression
+- create recommendation language
+- create readiness language
+- create safety language
+
+## v0 Boundary
+
+This pack is limited to Kolosseum v0 Deterministic Execution Alpha.
+
+Included:
+
+- coach dashboard assignment action
+- linked athlete validation
+- session assignment record
+- athlete availability state
+- factual assignment events
+- coach authority boundary
+
+Excluded:
+
+- coach override
+- coach-authored engine decisions
+- Phase 1 editing
+- Phase 3 to Phase 5 re-entry
+- Phase 7 output
+- Phase 8 output
+- evidence envelope
+- export proof
+- readiness assessment
+- safety assessment
+- recommendation
+- optimisation
+- messaging
+- team runtime
+- organisation runtime
+
+## Required Coach Assignment Flow
+
+The coach assignment flow must follow this order.
+
+1. Coach account exists.
+2. Athlete account exists.
+3. Coach athlete link exists.
+4. Coach athlete link is accepted.
+5. Coach selects linked athlete.
+6. Coach selects existing session assignment target.
+7. Runtime records coach assignment.
+8. Athlete session availability is updated as factual platform state.
+9. Athlete can see assigned session as available.
+
+No other flow is part of S37.
+
+## Required Actor Scope
+
+Allowed actor:
+
+- coach
+
+Allowed target actor:
+
+- athlete
+
+Allowed execution scope:
+
+- coach_managed
+
+Coach assignment is invalid for unlinked athletes.
+
+Coach assignment is invalid for revoked links.
+
+Coach assignment is invalid for pending links.
+
+Coach assignment is invalid for individual execution scope unless a lawful coach-managed link exists.
+
+## Required Event Outputs
+
+S37 allows only the following event types:
+
+- coach_assignment_requested
+- coach_athlete_link_verified
+- coach_assignment_recorded
+- athlete_session_available
+
+Any other event type is outside this pack.
+
+## Event Shape
+
+Every coach assignment event must include:
+
+- event_id
+- coach_id
+- athlete_id
+- session_id
+- event_type
+- actor
+- occurred_at_utc
+
+Link verification events must also include:
+
+- link_id
+- link_status
+
+Assignment recorded events must also include:
+
+- assignment_id
+- assignment_scope
+
+Athlete availability events must also include:
+
+- availability_status
+
+## Event Meaning Lock
+
+coach_assignment_requested means the coach selected a linked athlete and requested assignment of an existing session target.
+
+coach_athlete_link_verified means the platform confirmed the coach athlete link was accepted and active.
+
+coach_assignment_recorded means the platform recorded assignment metadata.
+
+athlete_session_available means the assigned session became visible to the athlete as available platform state.
+
+These meanings must not be expanded.
+
+## Allowed Link Status Values
+
+Allowed link_status values:
+
+- accepted
+
+Blocked link_status values:
+
+- missing
+- pending
+- refused
+- revoked
+- expired
+
+## Allowed Assignment Scope Values
+
+Allowed assignment_scope values:
+
+- coach_managed
+
+No other assignment scope exists in S37.
+
+## Allowed Availability Status Values
+
+Allowed availability_status values:
+
+- available_to_athlete
+
+No other availability status exists in S37.
+
+## Coach Authority Boundary
+
+A coach may:
+
+- select a linked athlete
+- assign an existing lawful session target
+- create assignment metadata
+- make the assigned session available to the linked athlete
+- view factual assignment status
+
+A coach may not:
+
+- decide engine legality
+- override engine output
+- edit Phase 1 declarations
+- force compilation
+- alter substitutions
+- alter progression
+- mark athlete readiness
+- declare safety
+- recommend changes through assignment
+- assign sessions to unlinked athletes
+
+## Blocked Conditions
+
+The coach assignment flow must not continue when any of the following are true:
+
+| Condition | Required blocked_reason |
+|---|---|
+| coach_id is missing | missing_coach_id |
+| athlete_id is missing | missing_athlete_id |
+| session_id is missing | missing_session_id |
+| actor is not coach | invalid_actor |
+| coach athlete link is missing | link_missing |
+| coach athlete link is pending | link_pending |
+| coach athlete link is refused | link_refused |
+| coach athlete link is revoked | link_revoked |
+| coach athlete link is expired | link_expired |
+| assignment scope is not coach_managed | invalid_assignment_scope |
+| event_type is outside the allowed set | invalid_event_type |
+| event would mutate Phase 1 | phase1_mutation_attempt |
+| event would trigger recompilation | recompilation_attempt |
+| event would alter legality | legality_mutation_attempt |
+| event would override engine output | engine_override_attempt |
+| event would create readiness language | readiness_claim_attempt |
+| event would create safety language | safety_claim_attempt |
+| event would create recommendation | recommendation_attempt |
+
+No fallback is permitted.
+
+No automatic linking is permitted.
+
+No inferred coach authority is permitted.
+
+No assignment to unlinked athletes is permitted.
+
+No engine authority is created.
+
+## Operator Checklist
+
+S37 passes only if the operator can show:
+
+- coach exists
+- athlete exists
+- accepted coach athlete link exists
+- coach_assignment_requested exists
+- coach_athlete_link_verified exists
+- coach_assignment_recorded exists
+- athlete_session_available exists
+- assignment scope is coach_managed
+- linked athlete only is enforced
+- unlinked athlete assignment is blocked
+- revoked link assignment is blocked
+- pending link assignment is blocked
+- coach assignment does not mutate Phase 1
+- coach assignment does not re-run compilation
+- coach assignment does not alter legality
+- coach assignment does not override engine output
+- coach assignment does not create readiness, safety, recommendation, optimisation, or judgement language
+
+## Minimum Demonstration Record
+
+A valid S37 demonstration record must contain:
+
+- slice: S37
+- proof_name: coach_assignment_execution_pack
+- coach_id: coach_manual_v0_001
+- athlete_id: athlete_manual_v0_001
+- link_id: link_manual_v0_001
+- link_status: accepted
+- session_id: session_manual_v0_001
+- assignment_id: assignment_manual_v0_001
+- assignment_scope: coach_managed
+- availability_status: available_to_athlete
+- linked_athlete_only: true
+- unlinked_assignment_blocked: true
+- pending_link_assignment_blocked: true
+- revoked_link_assignment_blocked: true
+- engine_authority_created: false
+- phase1_mutated: false
+- recompilation_triggered: false
+- legality_changed: false
+- engine_output_overridden: false
+- readiness_claim_present: false
+- safety_claim_present: false
+- recommendation_present: false
+- event_count: 4
+
+## Final Operator Sentence
+
+"A coach can assign an existing lawful session target to an accepted linked athlete, making it available as factual platform state without creating engine authority."
+
+## Final Rule
+
+If coach assignment targets an unlinked athlete, mutates Phase 1, re-runs compilation, alters legality, overrides engine output, or creates readiness, safety, recommendation, optimisation, or judgement language, the S37 coach assignment flow does not exist.

--- a/docs/pilot/fixtures/s37_coach_assignment_execution_pack.valid.json
+++ b/docs/pilot/fixtures/s37_coach_assignment_execution_pack.valid.json
@@ -1,0 +1,88 @@
+{
+  "slice": "S37",
+  "proof_name": "coach_assignment_execution_pack",
+  "coach_id": "coach_manual_v0_001",
+  "athlete_id": "athlete_manual_v0_001",
+  "link_id": "link_manual_v0_001",
+  "link_status": "accepted",
+  "session_id": "session_manual_v0_001",
+  "assignment_id": "assignment_manual_v0_001",
+  "assignment_scope": "coach_managed",
+  "availability_status": "available_to_athlete",
+  "linked_athlete_only": true,
+  "unlinked_assignment_blocked": true,
+  "pending_link_assignment_blocked": true,
+  "revoked_link_assignment_blocked": true,
+  "engine_authority_created": false,
+  "phase1_mutated": false,
+  "recompilation_triggered": false,
+  "legality_changed": false,
+  "engine_output_overridden": false,
+  "readiness_claim_present": false,
+  "safety_claim_present": false,
+  "recommendation_present": false,
+  "event_count": 4,
+  "events": [
+    {
+      "event_id": "evt_s37_001",
+      "coach_id": "coach_manual_v0_001",
+      "athlete_id": "athlete_manual_v0_001",
+      "session_id": "session_manual_v0_001",
+      "event_type": "coach_assignment_requested",
+      "actor": "coach",
+      "occurred_at_utc": "2026-04-27T00:00:00Z"
+    },
+    {
+      "event_id": "evt_s37_002",
+      "coach_id": "coach_manual_v0_001",
+      "athlete_id": "athlete_manual_v0_001",
+      "session_id": "session_manual_v0_001",
+      "event_type": "coach_athlete_link_verified",
+      "actor": "coach",
+      "occurred_at_utc": "2026-04-27T00:01:00Z",
+      "link_id": "link_manual_v0_001",
+      "link_status": "accepted"
+    },
+    {
+      "event_id": "evt_s37_003",
+      "coach_id": "coach_manual_v0_001",
+      "athlete_id": "athlete_manual_v0_001",
+      "session_id": "session_manual_v0_001",
+      "event_type": "coach_assignment_recorded",
+      "actor": "coach",
+      "occurred_at_utc": "2026-04-27T00:02:00Z",
+      "assignment_id": "assignment_manual_v0_001",
+      "assignment_scope": "coach_managed"
+    },
+    {
+      "event_id": "evt_s37_004",
+      "coach_id": "coach_manual_v0_001",
+      "athlete_id": "athlete_manual_v0_001",
+      "session_id": "session_manual_v0_001",
+      "event_type": "athlete_session_available",
+      "actor": "coach",
+      "occurred_at_utc": "2026-04-27T00:03:00Z",
+      "availability_status": "available_to_athlete"
+    }
+  ],
+  "blocked_cases": [
+    {
+      "case_id": "s37_block_unlinked_athlete",
+      "link_status": "missing",
+      "blocked_reason": "link_missing",
+      "assignment_recorded": false
+    },
+    {
+      "case_id": "s37_block_pending_link",
+      "link_status": "pending",
+      "blocked_reason": "link_pending",
+      "assignment_recorded": false
+    },
+    {
+      "case_id": "s37_block_revoked_link",
+      "link_status": "revoked",
+      "blocked_reason": "link_revoked",
+      "assignment_recorded": false
+    }
+  ]
+}


### PR DESCRIPTION
Adds S37 operator proof for coach assignment from dashboard to athlete availability: linked athlete only, assign session only, and no engine authority.