### PR TITLE
S38 coach artefact viewing pack

### DIFF
--- a/ci/scripts/guards/s38_coach_artefact_viewing_pack_guard.mjs
+++ b/ci/scripts/guards/s38_coach_artefact_viewing_pack_guard.mjs
@@ -1,0 +1,159 @@
+import fs from "node:fs";
+
+const docPath = "docs/pilot/S38_COACH_ARTEFACT_VIEWING_PACK.md";
+const fixturePath = "docs/pilot/fixtures/s38_coach_artefact_viewing_pack.valid.json";
+
+const allowedEvents = new Set([
+  "coach_artefact_view_requested",
+  "coach_athlete_link_verified",
+  "coach_artefact_view_rendered"
+]);
+
+const allowedArtefactTypes = new Set([
+  "phase1_acceptance_summary",
+  "session_assignment_record",
+  "session_availability_record",
+  "session_started_event",
+  "work_item_event",
+  "session_partially_completed_event",
+  "session_completed_event",
+  "session_stopped_event",
+  "split_return_event"
+]);
+
+const allowedDisplayedFields = new Set([
+  "artefact_id",
+  "artefact_type",
+  "coach_id",
+  "athlete_id",
+  "link_id",
+  "session_id",
+  "event_id",
+  "event_type",
+  "occurred_at_utc",
+  "created_at_utc",
+  "status",
+  "factual_payload",
+  "source_record_id"
+]);
+
+const blockedLinkStatuses = new Set(["missing", "pending", "refused", "revoked", "expired"]);
+
+const requiredDocStrings = [
+  "S38 - Coach Artefact Viewing Pack",
+  "factual artefacts",
+  "no analytics",
+  "no readiness",
+  "no advice",
+  "coach_artefact_view_requested",
+  "coach_athlete_link_verified",
+  "coach_artefact_view_rendered",
+  "view_mode: read_only",
+  "visibility_status: visible_to_linked_coach",
+  "factual_artefacts_only: true",
+  "analytics_present: false",
+  "readiness_claim_present: false",
+  "advice_present: false",
+  "recommendation_present: false",
+  "judgement_present: false",
+  "A coach can view factual artefacts for an accepted linked athlete in read-only mode only, with no analytics, readiness, advice, recommendation, judgement, or engine authority."
+];
+
+function fail(message) {
+  console.error(JSON.stringify({ ok: false, slice: "S38", message }, null, 2));
+  process.exit(1);
+}
+
+if (!fs.existsSync(docPath)) fail(`Missing ${docPath}`);
+if (!fs.existsSync(fixturePath)) fail(`Missing ${fixturePath}`);
+
+const doc = fs.readFileSync(docPath, "utf8");
+const fixture = JSON.parse(fs.readFileSync(fixturePath, "utf8"));
+
+for (const value of requiredDocStrings) {
+  if (!doc.includes(value)) fail(`Missing required S38 doc string: ${value}`);
+}
+
+if (fixture.slice !== "S38") fail("Fixture slice must be S38.");
+if (fixture.proof_name !== "coach_artefact_viewing_pack") fail("Fixture proof_name mismatch.");
+if (!fixture.coach_id) fail("coach_id missing.");
+if (!fixture.athlete_id) fail("athlete_id missing.");
+if (!fixture.link_id) fail("link_id missing.");
+if (!fixture.artefact_id) fail("artefact_id missing.");
+if (!allowedArtefactTypes.has(fixture.artefact_type)) fail("artefact_type invalid.");
+if (fixture.link_status !== "accepted") fail("link_status must be accepted.");
+if (fixture.view_mode !== "read_only") fail("view_mode must be read_only.");
+if (fixture.visibility_status !== "visible_to_linked_coach") fail("visibility_status must be visible_to_linked_coach.");
+if (fixture.factual_artefacts_only !== true) fail("factual_artefacts_only must be true.");
+if (fixture.analytics_present !== false) fail("analytics_present must be false.");
+if (fixture.readiness_claim_present !== false) fail("readiness_claim_present must be false.");
+if (fixture.advice_present !== false) fail("advice_present must be false.");
+if (fixture.recommendation_present !== false) fail("recommendation_present must be false.");
+if (fixture.judgement_present !== false) fail("judgement_present must be false.");
+if (fixture.score_present !== false) fail("score_present must be false.");
+if (fixture.ranking_present !== false) fail("ranking_present must be false.");
+if (fixture.safety_claim_present !== false) fail("safety_claim_present must be false.");
+if (fixture.medical_claim_present !== false) fail("medical_claim_present must be false.");
+if (fixture.unlinked_artefact_view_blocked !== true) fail("unlinked_artefact_view_blocked must be true.");
+if (fixture.pending_link_view_blocked !== true) fail("pending_link_view_blocked must be true.");
+if (fixture.revoked_link_view_blocked !== true) fail("revoked_link_view_blocked must be true.");
+if (fixture.engine_authority_created !== false) fail("engine_authority_created must be false.");
+if (fixture.phase1_mutated !== false) fail("phase1_mutated must be false.");
+if (fixture.recompilation_triggered !== false) fail("recompilation_triggered must be false.");
+if (fixture.legality_changed !== false) fail("legality_changed must be false.");
+if (fixture.engine_output_overridden !== false) fail("engine_output_overridden must be false.");
+
+if (!Array.isArray(fixture.events)) fail("events must be an array.");
+if (fixture.events.length !== fixture.event_count) fail("event_count must match events length.");
+
+const ids = new Set();
+for (const [index, event] of fixture.events.entries()) {
+  if (!event.event_id) fail(`events[${index}].event_id missing.`);
+  if (ids.has(event.event_id)) fail(`Duplicate event_id ${event.event_id}.`);
+  ids.add(event.event_id);
+
+  if (event.coach_id !== fixture.coach_id) fail(`events[${index}].coach_id mismatch.`);
+  if (event.athlete_id !== fixture.athlete_id) fail(`events[${index}].athlete_id mismatch.`);
+  if (event.artefact_id !== fixture.artefact_id) fail(`events[${index}].artefact_id mismatch.`);
+  if (event.artefact_type !== fixture.artefact_type) fail(`events[${index}].artefact_type mismatch.`);
+  if (event.actor !== "coach") fail(`events[${index}].actor must be coach.`);
+  if (!allowedEvents.has(event.event_type)) fail(`events[${index}].event_type is not allowed: ${event.event_type}`);
+  if (!event.occurred_at_utc) fail(`events[${index}].occurred_at_utc missing.`);
+
+  if (event.event_type === "coach_athlete_link_verified") {
+    if (event.link_id !== fixture.link_id) fail(`events[${index}].link_id mismatch.`);
+    if (event.link_status !== "accepted") fail(`events[${index}].link_status must be accepted.`);
+  }
+
+  if (event.event_type === "coach_artefact_view_rendered") {
+    if (event.view_mode !== "read_only") fail(`events[${index}].view_mode must be read_only.`);
+    if (event.visibility_status !== "visible_to_linked_coach") fail(`events[${index}].visibility_status must be visible_to_linked_coach.`);
+    if (!Number.isInteger(event.displayed_field_count) || event.displayed_field_count < 1) fail(`events[${index}].displayed_field_count invalid.`);
+    if (!Array.isArray(event.displayed_fields)) fail(`events[${index}].displayed_fields must be an array.`);
+    if (event.displayed_fields.length !== event.displayed_field_count) fail(`events[${index}].displayed_field_count mismatch.`);
+    for (const field of event.displayed_fields) {
+      if (!allowedDisplayedFields.has(field)) fail(`events[${index}].displayed field not allowed: ${field}`);
+    }
+  }
+}
+
+const eventTypes = new Set(fixture.events.map((event) => event.event_type));
+for (const required of [
+  "coach_artefact_view_requested",
+  "coach_athlete_link_verified",
+  "coach_artefact_view_rendered"
+]) {
+  if (!eventTypes.has(required)) fail(`Required event missing: ${required}`);
+}
+
+if (!Array.isArray(fixture.blocked_cases)) fail("blocked_cases must be an array.");
+for (const blockedCase of fixture.blocked_cases) {
+  if (!blockedCase.case_id) fail("blocked case_id missing.");
+  if (blockedCase.link_status && !blockedLinkStatuses.has(blockedCase.link_status)) {
+    fail(`blocked case link_status invalid: ${blockedCase.link_status}`);
+  }
+  if (blockedCase.view_rendered !== false) fail(`blocked case ${blockedCase.case_id} must not render view.`);
+  if (!blockedCase.blocked_reason) fail(`blocked case ${blockedCase.case_id} missing blocked_reason.`);
+}
+
+console.log(JSON.stringify({ ok: true, slice: "S38", checked: [docPath, fixturePath] }, null, 2));

--- a/docs/pilot/S38_COACH_ARTEFACT_VIEWING_PACK.md
+++ b/docs/pilot/S38_COACH_ARTEFACT_VIEWING_PACK.md
@@ -1,0 +1,334 @@
+# S38 - Coach Artefact Viewing Pack
+
+## Target
+
+Define the exact coach view-only artefact surface.
+
+## Invariant
+
+A coach may view factual athlete artefacts only when the athlete is linked to the coach.
+
+Coach artefact viewing is observational only.
+
+Coach artefact viewing must not:
+
+- create analytics
+- create readiness language
+- create advice
+- create recommendations
+- create judgement
+- create scores
+- create rankings
+- create safety language
+- create medical language
+- mutate Phase 1
+- re-run compilation
+- alter legality
+- override engine output
+
+## v0 Boundary
+
+This pack is limited to Kolosseum v0 Deterministic Execution Alpha.
+
+Included:
+
+- linked athlete artefact access
+- view-only factual artefact surface
+- factual session artefacts
+- factual assignment artefacts
+- factual Phase 6 runtime event artefacts
+- factual coach visibility state
+
+Excluded:
+
+- analytics
+- readiness
+- advice
+- recommendations
+- optimisation
+- scoring
+- ranking
+- judgement
+- safety assessment
+- medical or rehabilitation language
+- coach override
+- Phase 1 editing
+- Phase 3 to Phase 5 re-entry
+- Phase 7 output
+- Phase 8 output
+- evidence envelope
+- export proof
+- messaging
+- team runtime
+- organisation runtime
+
+## Required Coach Artefact Viewing Flow
+
+The coach artefact viewing flow must follow this order.
+
+1. Coach account exists.
+2. Athlete account exists.
+3. Coach athlete link exists.
+4. Coach athlete link is accepted.
+5. Coach opens linked athlete artefact view.
+6. Platform verifies link.
+7. Platform displays allowed factual artefacts only.
+8. Coach remains view-only.
+9. No analytics, readiness, advice, recommendation, judgement, score, ranking, safety, or medical language is displayed.
+
+No other flow is part of S38.
+
+## Required Actor Scope
+
+Allowed actor:
+
+- coach
+
+Allowed target actor:
+
+- athlete
+
+Allowed execution scope:
+
+- coach_managed
+
+Coach artefact viewing is invalid for unlinked athletes.
+
+Coach artefact viewing is invalid for revoked links.
+
+Coach artefact viewing is invalid for pending links.
+
+Coach artefact viewing is invalid if the artefact is not inside the linked athlete surface.
+
+## Allowed Artefact Types
+
+S38 allows only the following artefact_type values:
+
+- phase1_acceptance_summary
+- session_assignment_record
+- session_availability_record
+- session_started_event
+- work_item_event
+- session_partially_completed_event
+- session_completed_event
+- session_stopped_event
+- split_return_event
+
+Any other artefact type is outside this pack.
+
+## Allowed View Fields
+
+The coach artefact view may show only factual fields:
+
+- artefact_id
+- artefact_type
+- coach_id
+- athlete_id
+- link_id
+- session_id
+- event_id
+- event_type
+- occurred_at_utc
+- created_at_utc
+- status
+- factual_payload
+- source_record_id
+
+No other field is part of S38.
+
+## Required View State
+
+Allowed view_mode values:
+
+- read_only
+
+Allowed visibility_status values:
+
+- visible_to_linked_coach
+
+No other view mode or visibility status exists in S38.
+
+## Required Event Outputs
+
+S38 allows only the following event types:
+
+- coach_artefact_view_requested
+- coach_athlete_link_verified
+- coach_artefact_view_rendered
+
+Any other event type is outside this pack.
+
+## Event Shape
+
+Every coach artefact viewing event must include:
+
+- event_id
+- coach_id
+- athlete_id
+- artefact_id
+- artefact_type
+- event_type
+- actor
+- occurred_at_utc
+
+Link verification events must also include:
+
+- link_id
+- link_status
+
+View rendered events must also include:
+
+- view_mode
+- visibility_status
+- displayed_field_count
+
+## Event Meaning Lock
+
+coach_artefact_view_requested means the coach opened a factual artefact view for a linked athlete.
+
+coach_athlete_link_verified means the platform confirmed the coach athlete link was accepted and active.
+
+coach_artefact_view_rendered means the platform displayed a view-only factual artefact surface.
+
+These meanings must not be expanded.
+
+## Coach View Boundary
+
+A coach may view:
+
+- factual Phase 1 acceptance summary
+- factual session assignment records
+- factual session availability records
+- factual session start event
+- factual work item events
+- factual partial completion event
+- factual completion event
+- factual stopped event
+- factual split return event
+
+A coach may not view or generate:
+
+- analytics
+- readiness
+- advice
+- recommendation
+- optimisation
+- score
+- ranking
+- judgement
+- safety assessment
+- medical assessment
+- hidden engine authority
+- unlinked athlete artefacts
+
+## Blocked Conditions
+
+The coach artefact viewing flow must not continue when any of the following are true:
+
+| Condition | Required blocked_reason |
+|---|---|
+| coach_id is missing | missing_coach_id |
+| athlete_id is missing | missing_athlete_id |
+| artefact_id is missing | missing_artefact_id |
+| actor is not coach | invalid_actor |
+| coach athlete link is missing | link_missing |
+| coach athlete link is pending | link_pending |
+| coach athlete link is refused | link_refused |
+| coach athlete link is revoked | link_revoked |
+| coach athlete link is expired | link_expired |
+| artefact type is outside allowed set | invalid_artefact_type |
+| view mode is not read_only | invalid_view_mode |
+| visibility status is not visible_to_linked_coach | invalid_visibility_status |
+| event_type is outside allowed set | invalid_event_type |
+| view would show analytics | analytics_surface_attempt |
+| view would show readiness | readiness_surface_attempt |
+| view would show advice | advice_surface_attempt |
+| view would show recommendation | recommendation_surface_attempt |
+| view would show judgement | judgement_surface_attempt |
+| view would show score | score_surface_attempt |
+| view would show ranking | ranking_surface_attempt |
+| view would show safety language | safety_surface_attempt |
+| view would show medical language | medical_surface_attempt |
+| view would mutate Phase 1 | phase1_mutation_attempt |
+| view would trigger recompilation | recompilation_attempt |
+| view would alter legality | legality_mutation_attempt |
+| view would override engine output | engine_override_attempt |
+
+No fallback is permitted.
+
+No automatic linking is permitted.
+
+No inferred coach authority is permitted.
+
+No artefact access for unlinked athletes is permitted.
+
+No analytics are permitted.
+
+No readiness surface is permitted.
+
+No advice is permitted.
+
+## Operator Checklist
+
+S38 passes only if the operator can show:
+
+- coach exists
+- athlete exists
+- accepted coach athlete link exists
+- coach_artefact_view_requested exists
+- coach_athlete_link_verified exists
+- coach_artefact_view_rendered exists
+- view_mode is read_only
+- visibility_status is visible_to_linked_coach
+- only allowed artefact types are visible
+- only allowed factual fields are visible
+- unlinked athlete artefact view is blocked
+- revoked link artefact view is blocked
+- pending link artefact view is blocked
+- coach artefact viewing does not mutate Phase 1
+- coach artefact viewing does not re-run compilation
+- coach artefact viewing does not alter legality
+- coach artefact viewing does not override engine output
+- coach artefact viewing does not create analytics, readiness, advice, recommendation, judgement, score, ranking, safety, or medical language
+
+## Minimum Demonstration Record
+
+A valid S38 demonstration record must contain:
+
+- slice: S38
+- proof_name: coach_artefact_viewing_pack
+- coach_id: coach_manual_v0_001
+- athlete_id: athlete_manual_v0_001
+- link_id: link_manual_v0_001
+- link_status: accepted
+- artefact_id: artefact_manual_v0_001
+- artefact_type: session_started_event
+- view_mode: read_only
+- visibility_status: visible_to_linked_coach
+- factual_artefacts_only: true
+- analytics_present: false
+- readiness_claim_present: false
+- advice_present: false
+- recommendation_present: false
+- judgement_present: false
+- score_present: false
+- ranking_present: false
+- safety_claim_present: false
+- medical_claim_present: false
+- unlinked_artefact_view_blocked: true
+- pending_link_view_blocked: true
+- revoked_link_view_blocked: true
+- engine_authority_created: false
+- phase1_mutated: false
+- recompilation_triggered: false
+- legality_changed: false
+- engine_output_overridden: false
+- event_count: 3
+
+## Final Operator Sentence
+
+"A coach can view factual artefacts for an accepted linked athlete in read-only mode only, with no analytics, readiness, advice, recommendation, judgement, or engine authority."
+
+## Final Rule
+
+If coach artefact viewing exposes analytics, readiness, advice, recommendation, judgement, score, ranking, safety, medical language, unlinked athlete data, Phase 1 mutation, recompilation, legality change, or engine override, the S38 coach artefact viewing flow does not exist.

--- a/docs/pilot/fixtures/s38_coach_artefact_viewing_pack.valid.json
+++ b/docs/pilot/fixtures/s38_coach_artefact_viewing_pack.valid.json
@@ -1,0 +1,106 @@
+{
+  "slice": "S38",
+  "proof_name": "coach_artefact_viewing_pack",
+  "coach_id": "coach_manual_v0_001",
+  "athlete_id": "athlete_manual_v0_001",
+  "link_id": "link_manual_v0_001",
+  "link_status": "accepted",
+  "artefact_id": "artefact_manual_v0_001",
+  "artefact_type": "session_started_event",
+  "view_mode": "read_only",
+  "visibility_status": "visible_to_linked_coach",
+  "factual_artefacts_only": true,
+  "analytics_present": false,
+  "readiness_claim_present": false,
+  "advice_present": false,
+  "recommendation_present": false,
+  "judgement_present": false,
+  "score_present": false,
+  "ranking_present": false,
+  "safety_claim_present": false,
+  "medical_claim_present": false,
+  "unlinked_artefact_view_blocked": true,
+  "pending_link_view_blocked": true,
+  "revoked_link_view_blocked": true,
+  "engine_authority_created": false,
+  "phase1_mutated": false,
+  "recompilation_triggered": false,
+  "legality_changed": false,
+  "engine_output_overridden": false,
+  "event_count": 3,
+  "events": [
+    {
+      "event_id": "evt_s38_001",
+      "coach_id": "coach_manual_v0_001",
+      "athlete_id": "athlete_manual_v0_001",
+      "artefact_id": "artefact_manual_v0_001",
+      "artefact_type": "session_started_event",
+      "event_type": "coach_artefact_view_requested",
+      "actor": "coach",
+      "occurred_at_utc": "2026-04-27T00:00:00Z"
+    },
+    {
+      "event_id": "evt_s38_002",
+      "coach_id": "coach_manual_v0_001",
+      "athlete_id": "athlete_manual_v0_001",
+      "artefact_id": "artefact_manual_v0_001",
+      "artefact_type": "session_started_event",
+      "event_type": "coach_athlete_link_verified",
+      "actor": "coach",
+      "occurred_at_utc": "2026-04-27T00:01:00Z",
+      "link_id": "link_manual_v0_001",
+      "link_status": "accepted"
+    },
+    {
+      "event_id": "evt_s38_003",
+      "coach_id": "coach_manual_v0_001",
+      "athlete_id": "athlete_manual_v0_001",
+      "artefact_id": "artefact_manual_v0_001",
+      "artefact_type": "session_started_event",
+      "event_type": "coach_artefact_view_rendered",
+      "actor": "coach",
+      "occurred_at_utc": "2026-04-27T00:02:00Z",
+      "view_mode": "read_only",
+      "visibility_status": "visible_to_linked_coach",
+      "displayed_field_count": 11,
+      "displayed_fields": [
+        "artefact_id",
+        "artefact_type",
+        "coach_id",
+        "athlete_id",
+        "link_id",
+        "session_id",
+        "event_id",
+        "event_type",
+        "occurred_at_utc",
+        "status",
+        "source_record_id"
+      ]
+    }
+  ],
+  "blocked_cases": [
+    {
+      "case_id": "s38_block_unlinked_athlete",
+      "link_status": "missing",
+      "blocked_reason": "link_missing",
+      "view_rendered": false
+    },
+    {
+      "case_id": "s38_block_pending_link",
+      "link_status": "pending",
+      "blocked_reason": "link_pending",
+      "view_rendered": false
+    },
+    {
+      "case_id": "s38_block_revoked_link",
+      "link_status": "revoked",
+      "blocked_reason": "link_revoked",
+      "view_rendered": false
+    },
+    {
+      "case_id": "s38_block_analytics_surface",
+      "blocked_reason": "analytics_surface_attempt",
+      "view_rendered": false
+    }
+  ]
+}


### PR DESCRIPTION
Adds S38 operator proof for coach view-only artefact surface: factual artefacts only, no analytics, no readiness, and no advice.