### PR TITLE
S39 coach non-binding note pack

### DIFF
--- a/ci/scripts/guards/s39_coach_non_binding_note_pack_guard.mjs
+++ b/ci/scripts/guards/s39_coach_non_binding_note_pack_guard.mjs
@@ -1,0 +1,146 @@
+import fs from "node:fs";
+
+const docPath = "docs/pilot/S39_COACH_NON_BINDING_NOTE_PACK.md";
+const fixturePath = "docs/pilot/fixtures/s39_coach_non_binding_note_pack.valid.json";
+
+const allowedEvents = new Set([
+  "coach_note_surface_opened",
+  "coach_athlete_link_verified",
+  "coach_note_saved",
+  "coach_note_visibility_recorded"
+]);
+
+const allowedVisibilityStatuses = new Set([
+  "visible_to_authoring_coach",
+  "visible_to_linked_athlete",
+  "visible_to_authoring_coach_and_linked_athlete"
+]);
+
+const blockedLinkStatuses = new Set(["missing", "pending", "refused", "revoked", "expired"]);
+
+const requiredCoachUiCopy =
+  "Coach notes are non-binding. They are stored outside engine truth and do not change session legality, compilation, substitutions, progression, or future sessions.";
+
+const requiredAthleteUiCopy =
+  "This coach note is non-binding. It does not change your engine-generated session or future sessions.";
+
+const requiredDocStrings = [
+  "S39 - Coach Non-Binding Note Pack",
+  "Coach notes are non-binding",
+  "stored outside engine truth",
+  "not read by the engine",
+  "no effect on future sessions",
+  "coach_note_surface_opened",
+  "coach_athlete_link_verified",
+  "coach_note_saved",
+  "coach_note_visibility_recorded",
+  "note_storage_scope: platform_metadata_only",
+  "engine_readable: false",
+  "engine_truth_mutated: false",
+  "future_effect: false",
+  "A coach can save a non-binding note for an accepted linked athlete, stored outside engine truth, not read by the engine, and with no effect on future sessions."
+];
+
+function fail(message) {
+  console.error(JSON.stringify({ ok: false, slice: "S39", message }, null, 2));
+  process.exit(1);
+}
+
+if (!fs.existsSync(docPath)) fail(`Missing ${docPath}`);
+if (!fs.existsSync(fixturePath)) fail(`Missing ${fixturePath}`);
+
+const doc = fs.readFileSync(docPath, "utf8");
+const fixture = JSON.parse(fs.readFileSync(fixturePath, "utf8"));
+
+for (const value of requiredDocStrings) {
+  if (!doc.includes(value)) fail(`Missing required S39 doc string: ${value}`);
+}
+
+if (!doc.includes(requiredCoachUiCopy)) fail("Required coach UI copy missing from doc.");
+if (!doc.includes(requiredAthleteUiCopy)) fail("Required athlete UI copy missing from doc.");
+
+if (fixture.slice !== "S39") fail("Fixture slice must be S39.");
+if (fixture.proof_name !== "coach_non_binding_note_pack") fail("Fixture proof_name mismatch.");
+if (!fixture.coach_id) fail("coach_id missing.");
+if (!fixture.athlete_id) fail("athlete_id missing.");
+if (!fixture.link_id) fail("link_id missing.");
+if (!fixture.note_id) fail("note_id missing.");
+if (fixture.link_status !== "accepted") fail("link_status must be accepted.");
+if (fixture.note_storage_scope !== "platform_metadata_only") fail("note_storage_scope must be platform_metadata_only.");
+if (fixture.engine_readable !== false) fail("engine_readable must be false.");
+if (fixture.engine_truth_mutated !== false) fail("engine_truth_mutated must be false.");
+if (fixture.future_effect !== false) fail("future_effect must be false.");
+if (fixture.required_coach_ui_copy_present !== true) fail("required_coach_ui_copy_present must be true.");
+if (fixture.required_athlete_ui_copy_present !== true) fail("required_athlete_ui_copy_present must be true.");
+if (fixture.coach_ui_copy !== requiredCoachUiCopy) fail("coach_ui_copy must match exact required copy.");
+if (fixture.athlete_ui_copy !== requiredAthleteUiCopy) fail("athlete_ui_copy must match exact required copy.");
+if (fixture.unlinked_note_blocked !== true) fail("unlinked_note_blocked must be true.");
+if (fixture.pending_link_note_blocked !== true) fail("pending_link_note_blocked must be true.");
+if (fixture.revoked_link_note_blocked !== true) fail("revoked_link_note_blocked must be true.");
+if (fixture.engine_authority_created !== false) fail("engine_authority_created must be false.");
+if (fixture.phase1_mutated !== false) fail("phase1_mutated must be false.");
+if (fixture.recompilation_triggered !== false) fail("recompilation_triggered must be false.");
+if (fixture.legality_changed !== false) fail("legality_changed must be false.");
+if (fixture.engine_output_overridden !== false) fail("engine_output_overridden must be false.");
+if (fixture.readiness_claim_present !== false) fail("readiness_claim_present must be false.");
+if (fixture.safety_claim_present !== false) fail("safety_claim_present must be false.");
+if (fixture.recommendation_present !== false) fail("recommendation_present must be false.");
+if (fixture.judgement_present !== false) fail("judgement_present must be false.");
+if (fixture.score_present !== false) fail("score_present must be false.");
+if (fixture.ranking_present !== false) fail("ranking_present must be false.");
+
+if (!Array.isArray(fixture.events)) fail("events must be an array.");
+if (fixture.events.length !== fixture.event_count) fail("event_count must match events length.");
+
+const ids = new Set();
+for (const [index, event] of fixture.events.entries()) {
+  if (!event.event_id) fail(`events[${index}].event_id missing.`);
+  if (ids.has(event.event_id)) fail(`Duplicate event_id ${event.event_id}.`);
+  ids.add(event.event_id);
+
+  if (event.coach_id !== fixture.coach_id) fail(`events[${index}].coach_id mismatch.`);
+  if (event.athlete_id !== fixture.athlete_id) fail(`events[${index}].athlete_id mismatch.`);
+  if (event.note_id !== fixture.note_id) fail(`events[${index}].note_id mismatch.`);
+  if (event.actor !== "coach") fail(`events[${index}].actor must be coach.`);
+  if (!allowedEvents.has(event.event_type)) fail(`events[${index}].event_type is not allowed: ${event.event_type}`);
+  if (!event.occurred_at_utc) fail(`events[${index}].occurred_at_utc missing.`);
+
+  if (event.event_type === "coach_athlete_link_verified") {
+    if (event.link_id !== fixture.link_id) fail(`events[${index}].link_id mismatch.`);
+    if (event.link_status !== "accepted") fail(`events[${index}].link_status must be accepted.`);
+  }
+
+  if (event.event_type === "coach_note_saved") {
+    if (event.note_storage_scope !== "platform_metadata_only") fail(`events[${index}].note_storage_scope must be platform_metadata_only.`);
+    if (event.engine_readable !== false) fail(`events[${index}].engine_readable must be false.`);
+    if (event.engine_truth_mutated !== false) fail(`events[${index}].engine_truth_mutated must be false.`);
+    if (event.future_effect !== false) fail(`events[${index}].future_effect must be false.`);
+  }
+
+  if (event.event_type === "coach_note_visibility_recorded") {
+    if (!allowedVisibilityStatuses.has(event.visibility_status)) fail(`events[${index}].visibility_status invalid.`);
+    if (event.ui_copy_id !== "s39_non_binding_note_copy") fail(`events[${index}].ui_copy_id mismatch.`);
+  }
+}
+
+const eventTypes = new Set(fixture.events.map((event) => event.event_type));
+for (const required of [
+  "coach_note_surface_opened",
+  "coach_athlete_link_verified",
+  "coach_note_saved",
+  "coach_note_visibility_recorded"
+]) {
+  if (!eventTypes.has(required)) fail(`Required event missing: ${required}`);
+}
+
+if (!Array.isArray(fixture.blocked_cases)) fail("blocked_cases must be an array.");
+for (const blockedCase of fixture.blocked_cases) {
+  if (!blockedCase.case_id) fail("blocked case_id missing.");
+  if (blockedCase.link_status && !blockedLinkStatuses.has(blockedCase.link_status)) {
+    fail(`blocked case link_status invalid: ${blockedCase.link_status}`);
+  }
+  if (blockedCase.note_saved !== false) fail(`blocked case ${blockedCase.case_id} must not save note.`);
+  if (!blockedCase.blocked_reason) fail(`blocked case ${blockedCase.case_id} missing blocked_reason.`);
+}
+
+console.log(JSON.stringify({ ok: true, slice: "S39", checked: [docPath, fixturePath] }, null, 2));

--- a/docs/pilot/S39_COACH_NON_BINDING_NOTE_PACK.md
+++ b/docs/pilot/S39_COACH_NON_BINDING_NOTE_PACK.md
@@ -1,0 +1,355 @@
+# S39 - Coach Non-Binding Note Pack
+
+## Target
+
+Define exact coach note rules and UI copy.
+
+## Invariant
+
+Coach notes are non-binding platform records only.
+
+Coach notes must be stored outside engine truth.
+
+Coach notes must not:
+
+- be read by the engine
+- change Phase 1 declarations
+- re-run compilation
+- alter legality
+- alter session selection
+- alter substitutions
+- alter progression
+- alter future sessions
+- create readiness language
+- create safety language
+- create recommendation language
+- create judgement
+- create score
+- create ranking
+
+## v0 Boundary
+
+This pack is limited to Kolosseum v0 Deterministic Execution Alpha.
+
+Included:
+
+- linked athlete note access
+- coach-authored non-binding note creation
+- factual note storage
+- note visibility to coach
+- note visibility to linked athlete when surfaced
+- explicit non-binding UI copy
+- proof that note is outside engine truth
+
+Excluded:
+
+- engine-readable note input
+- engine authority
+- advice generation
+- recommendation generation
+- readiness assessment
+- safety assessment
+- medical or rehabilitation language
+- scoring
+- ranking
+- judgement
+- Phase 1 editing
+- Phase 3 to Phase 5 re-entry
+- Phase 7 output
+- Phase 8 output
+- evidence envelope
+- export proof
+- messaging
+- team runtime
+- organisation runtime
+
+## Required Coach Note Flow
+
+The coach note flow must follow this order.
+
+1. Coach account exists.
+2. Athlete account exists.
+3. Coach athlete link exists.
+4. Coach athlete link is accepted.
+5. Coach opens linked athlete note surface.
+6. Coach writes note text.
+7. Platform displays non-binding note copy.
+8. Coach saves note.
+9. Platform stores note outside engine truth.
+10. Engine input remains unchanged.
+11. Future engine output remains unaffected.
+
+No other flow is part of S39.
+
+## Required Actor Scope
+
+Allowed actor:
+
+- coach
+
+Allowed target actor:
+
+- athlete
+
+Allowed execution scope:
+
+- coach_managed
+
+Coach notes are invalid for unlinked athletes.
+
+Coach notes are invalid for revoked links.
+
+Coach notes are invalid for pending links.
+
+Coach notes are invalid if submitted as engine input.
+
+## Required UI Copy
+
+The coach note surface must display this exact copy:
+
+"Coach notes are non-binding. They are stored outside engine truth and do not change session legality, compilation, substitutions, progression, or future sessions."
+
+The athlete-facing note surface, where shown, must display this exact copy:
+
+"This coach note is non-binding. It does not change your engine-generated session or future sessions."
+
+No alternative wording is part of S39.
+
+## Required Event Outputs
+
+S39 allows only the following event types:
+
+- coach_note_surface_opened
+- coach_athlete_link_verified
+- coach_note_saved
+- coach_note_visibility_recorded
+
+Any other event type is outside this pack.
+
+## Event Shape
+
+Every coach note event must include:
+
+- event_id
+- coach_id
+- athlete_id
+- note_id
+- event_type
+- actor
+- occurred_at_utc
+
+Link verification events must also include:
+
+- link_id
+- link_status
+
+Note saved events must also include:
+
+- note_storage_scope
+- engine_readable
+- engine_truth_mutated
+- future_effect
+
+Visibility events must also include:
+
+- visibility_status
+- ui_copy_id
+
+## Event Meaning Lock
+
+coach_note_surface_opened means the coach opened the note surface for a linked athlete.
+
+coach_athlete_link_verified means the platform confirmed the coach athlete link was accepted and active.
+
+coach_note_saved means the platform stored the coach note outside engine truth.
+
+coach_note_visibility_recorded means the platform recorded note visibility and required non-binding UI copy.
+
+These meanings must not be expanded.
+
+## Required Storage Rules
+
+Allowed note_storage_scope values:
+
+- platform_metadata_only
+
+Required engine_readable value:
+
+- false
+
+Required engine_truth_mutated value:
+
+- false
+
+Required future_effect value:
+
+- false
+
+No other storage behaviour exists in S39.
+
+## Allowed Visibility Status Values
+
+Allowed visibility_status values:
+
+- visible_to_authoring_coach
+- visible_to_linked_athlete
+- visible_to_authoring_coach_and_linked_athlete
+
+No other visibility status exists in S39.
+
+## Coach Note Boundary
+
+A coach may:
+
+- write a non-binding note
+- save a note outside engine truth
+- view their saved note
+- expose a note to the linked athlete where the UI permits
+- comment on observed factual artefacts
+
+A coach may not:
+
+- create engine input through a note
+- create future-session changes through a note
+- alter substitutions through a note
+- alter progression through a note
+- alter legality through a note
+- mark readiness through a note
+- declare safety through a note
+- issue binding advice through a note
+- create judgement through a note
+- create score or ranking through a note
+- write notes for unlinked athletes
+
+## Blocked Conditions
+
+The coach note flow must not continue when any of the following are true:
+
+| Condition | Required blocked_reason |
+|---|---|
+| coach_id is missing | missing_coach_id |
+| athlete_id is missing | missing_athlete_id |
+| note_id is missing | missing_note_id |
+| actor is not coach | invalid_actor |
+| coach athlete link is missing | link_missing |
+| coach athlete link is pending | link_pending |
+| coach athlete link is refused | link_refused |
+| coach athlete link is revoked | link_revoked |
+| coach athlete link is expired | link_expired |
+| note storage scope is not platform_metadata_only | invalid_note_storage_scope |
+| note is engine-readable | engine_readable_note_attempt |
+| note would mutate engine truth | engine_truth_mutation_attempt |
+| note would affect future sessions | future_effect_attempt |
+| note would mutate Phase 1 | phase1_mutation_attempt |
+| note would trigger recompilation | recompilation_attempt |
+| note would alter legality | legality_mutation_attempt |
+| note would override engine output | engine_override_attempt |
+| note would create readiness language | readiness_claim_attempt |
+| note would create safety language | safety_claim_attempt |
+| note would create recommendation | recommendation_attempt |
+| note would create judgement | judgement_attempt |
+| note would create score | score_attempt |
+| note would create ranking | ranking_attempt |
+| required UI copy is missing | missing_non_binding_ui_copy |
+| event_type is outside allowed set | invalid_event_type |
+
+No fallback is permitted.
+
+No automatic linking is permitted.
+
+No inferred coach authority is permitted.
+
+No note may become engine truth.
+
+No note may be read by the engine.
+
+No note may affect future sessions.
+
+## Forbidden Note Semantics
+
+The following note semantics are forbidden:
+
+- must do
+- should do
+- needs to do
+- ready for
+- not ready for
+- safe to
+- unsafe to
+- recommended
+- recommendation
+- increase next session
+- reduce next session
+- progression changed
+- substitute this
+- catch up
+- failed
+- poor adherence
+- non-compliant
+- underperformed
+
+## Operator Checklist
+
+S39 passes only if the operator can show:
+
+- coach exists
+- athlete exists
+- accepted coach athlete link exists
+- coach_note_surface_opened exists
+- coach_athlete_link_verified exists
+- coach_note_saved exists
+- coach_note_visibility_recorded exists
+- required non-binding UI copy is present
+- note_storage_scope is platform_metadata_only
+- engine_readable is false
+- engine_truth_mutated is false
+- future_effect is false
+- unlinked athlete note is blocked
+- pending link note is blocked
+- revoked link note is blocked
+- coach note does not mutate Phase 1
+- coach note does not re-run compilation
+- coach note does not alter legality
+- coach note does not override engine output
+- coach note does not create readiness, safety, recommendation, judgement, score, ranking, or future-session effect
+
+## Minimum Demonstration Record
+
+A valid S39 demonstration record must contain:
+
+- slice: S39
+- proof_name: coach_non_binding_note_pack
+- coach_id: coach_manual_v0_001
+- athlete_id: athlete_manual_v0_001
+- link_id: link_manual_v0_001
+- link_status: accepted
+- note_id: note_manual_v0_001
+- note_storage_scope: platform_metadata_only
+- engine_readable: false
+- engine_truth_mutated: false
+- future_effect: false
+- required_coach_ui_copy_present: true
+- required_athlete_ui_copy_present: true
+- unlinked_note_blocked: true
+- pending_link_note_blocked: true
+- revoked_link_note_blocked: true
+- engine_authority_created: false
+- phase1_mutated: false
+- recompilation_triggered: false
+- legality_changed: false
+- engine_output_overridden: false
+- readiness_claim_present: false
+- safety_claim_present: false
+- recommendation_present: false
+- judgement_present: false
+- score_present: false
+- ranking_present: false
+- event_count: 4
+
+## Final Operator Sentence
+
+"A coach can save a non-binding note for an accepted linked athlete, stored outside engine truth, not read by the engine, and with no effect on future sessions."
+
+## Final Rule
+
+If a coach note becomes engine-readable, mutates engine truth, affects future sessions, changes Phase 1, re-runs compilation, alters legality, overrides engine output, or creates readiness, safety, recommendation, judgement, score, or ranking language, the S39 coach note flow does not exist.

--- a/docs/pilot/fixtures/s39_coach_non_binding_note_pack.valid.json
+++ b/docs/pilot/fixtures/s39_coach_non_binding_note_pack.valid.json
@@ -1,0 +1,103 @@
+{
+  "slice": "S39",
+  "proof_name": "coach_non_binding_note_pack",
+  "coach_id": "coach_manual_v0_001",
+  "athlete_id": "athlete_manual_v0_001",
+  "link_id": "link_manual_v0_001",
+  "link_status": "accepted",
+  "note_id": "note_manual_v0_001",
+  "note_storage_scope": "platform_metadata_only",
+  "engine_readable": false,
+  "engine_truth_mutated": false,
+  "future_effect": false,
+  "required_coach_ui_copy_present": true,
+  "required_athlete_ui_copy_present": true,
+  "unlinked_note_blocked": true,
+  "pending_link_note_blocked": true,
+  "revoked_link_note_blocked": true,
+  "engine_authority_created": false,
+  "phase1_mutated": false,
+  "recompilation_triggered": false,
+  "legality_changed": false,
+  "engine_output_overridden": false,
+  "readiness_claim_present": false,
+  "safety_claim_present": false,
+  "recommendation_present": false,
+  "judgement_present": false,
+  "score_present": false,
+  "ranking_present": false,
+  "coach_ui_copy": "Coach notes are non-binding. They are stored outside engine truth and do not change session legality, compilation, substitutions, progression, or future sessions.",
+  "athlete_ui_copy": "This coach note is non-binding. It does not change your engine-generated session or future sessions.",
+  "event_count": 4,
+  "events": [
+    {
+      "event_id": "evt_s39_001",
+      "coach_id": "coach_manual_v0_001",
+      "athlete_id": "athlete_manual_v0_001",
+      "note_id": "note_manual_v0_001",
+      "event_type": "coach_note_surface_opened",
+      "actor": "coach",
+      "occurred_at_utc": "2026-04-27T00:00:00Z"
+    },
+    {
+      "event_id": "evt_s39_002",
+      "coach_id": "coach_manual_v0_001",
+      "athlete_id": "athlete_manual_v0_001",
+      "note_id": "note_manual_v0_001",
+      "event_type": "coach_athlete_link_verified",
+      "actor": "coach",
+      "occurred_at_utc": "2026-04-27T00:01:00Z",
+      "link_id": "link_manual_v0_001",
+      "link_status": "accepted"
+    },
+    {
+      "event_id": "evt_s39_003",
+      "coach_id": "coach_manual_v0_001",
+      "athlete_id": "athlete_manual_v0_001",
+      "note_id": "note_manual_v0_001",
+      "event_type": "coach_note_saved",
+      "actor": "coach",
+      "occurred_at_utc": "2026-04-27T00:02:00Z",
+      "note_storage_scope": "platform_metadata_only",
+      "engine_readable": false,
+      "engine_truth_mutated": false,
+      "future_effect": false
+    },
+    {
+      "event_id": "evt_s39_004",
+      "coach_id": "coach_manual_v0_001",
+      "athlete_id": "athlete_manual_v0_001",
+      "note_id": "note_manual_v0_001",
+      "event_type": "coach_note_visibility_recorded",
+      "actor": "coach",
+      "occurred_at_utc": "2026-04-27T00:03:00Z",
+      "visibility_status": "visible_to_authoring_coach_and_linked_athlete",
+      "ui_copy_id": "s39_non_binding_note_copy"
+    }
+  ],
+  "blocked_cases": [
+    {
+      "case_id": "s39_block_unlinked_athlete",
+      "link_status": "missing",
+      "blocked_reason": "link_missing",
+      "note_saved": false
+    },
+    {
+      "case_id": "s39_block_pending_link",
+      "link_status": "pending",
+      "blocked_reason": "link_pending",
+      "note_saved": false
+    },
+    {
+      "case_id": "s39_block_revoked_link",
+      "link_status": "revoked",
+      "blocked_reason": "link_revoked",
+      "note_saved": false
+    },
+    {
+      "case_id": "s39_block_engine_readable_note",
+      "blocked_reason": "engine_readable_note_attempt",
+      "note_saved": false
+    }
+  ]
+}


### PR DESCRIPTION
Adds S39 operator proof for coach non-binding notes: exact note rules, required UI copy, storage outside engine truth, not read by engine, and no future effect.