### PR TITLE
S40 blocked state support pack

### DIFF
--- a/ci/scripts/guards/s40_blocked_state_support_pack_guard.mjs
+++ b/ci/scripts/guards/s40_blocked_state_support_pack_guard.mjs
@@ -1,0 +1,146 @@
+import fs from "node:fs";
+
+const docPath = "docs/pilot/S40_BLOCKED_STATE_SUPPORT_PACK.md";
+const fixturePath = "docs/pilot/fixtures/s40_blocked_state_support_pack.valid.json";
+
+const allowedEvents = new Set([
+  "blocked_state_checked",
+  "blocked_state_recorded",
+  "blocked_action_refused"
+]);
+
+const allowedBlockedStates = new Set([
+  "phase1_missing",
+  "no_session",
+  "no_link",
+  "revoked_link",
+  "return_missing"
+]);
+
+const allowedBlockedReasons = new Set([
+  "phase1_missing",
+  "session_missing",
+  "coach_athlete_link_missing",
+  "coach_athlete_link_revoked",
+  "return_choice_missing",
+  "return_point_missing"
+]);
+
+const requiredCopy = new Map([
+  ["phase1_missing", "Blocked: Phase 1 declaration is missing. The pilot cannot continue until Phase 1 is accepted."],
+  ["no_session", "Blocked: no live session exists for this action."],
+  ["no_link", "Blocked: no accepted coach athlete link exists."],
+  ["revoked_link", "Blocked: coach athlete link is revoked."],
+  ["return_missing", "Blocked: return data is missing."]
+]);
+
+const requiredDocStrings = [
+  "S40 - Blocked-State Support Pack",
+  "phase1_missing",
+  "no_session",
+  "no_link",
+  "revoked_link",
+  "return_missing",
+  "blocked_state_recorded",
+  "blocked_action_refused",
+  "hidden_continuation_present: false",
+  "inferred_phase1_present: false",
+  "inferred_link_present: false",
+  "inferred_return_choice_present: false",
+  "phase1_mutated: false",
+  "recompilation_triggered: false",
+  "legality_changed: false",
+  "Live pilot blocked states are recorded factually, refuse only the requested action, and never infer missing truth, mutate Phase 1, re-run compilation, alter legality, or create advice."
+];
+
+function fail(message) {
+  console.error(JSON.stringify({ ok: false, slice: "S40", message }, null, 2));
+  process.exit(1);
+}
+
+if (!fs.existsSync(docPath)) fail(`Missing ${docPath}`);
+if (!fs.existsSync(fixturePath)) fail(`Missing ${fixturePath}`);
+
+const doc = fs.readFileSync(docPath, "utf8");
+const fixture = JSON.parse(fs.readFileSync(fixturePath, "utf8"));
+
+for (const value of requiredDocStrings) {
+  if (!doc.includes(value)) fail(`Missing required S40 doc string: ${value}`);
+}
+
+for (const copy of requiredCopy.values()) {
+  if (!doc.includes(copy)) fail(`Missing required S40 operator copy: ${copy}`);
+}
+
+if (fixture.slice !== "S40") fail("Fixture slice must be S40.");
+if (fixture.proof_name !== "blocked_state_support_pack") fail("Fixture proof_name mismatch.");
+if (fixture.phase1_missing_blocked !== true) fail("phase1_missing_blocked must be true.");
+if (fixture.no_session_blocked !== true) fail("no_session_blocked must be true.");
+if (fixture.no_link_blocked !== true) fail("no_link_blocked must be true.");
+if (fixture.revoked_link_blocked !== true) fail("revoked_link_blocked must be true.");
+if (fixture.return_missing_blocked !== true) fail("return_missing_blocked must be true.");
+if (fixture.exact_operator_copy_present !== true) fail("exact_operator_copy_present must be true.");
+if (fixture.blocked_action_refused !== true) fail("blocked_action_refused must be true.");
+if (fixture.hidden_continuation_present !== false) fail("hidden_continuation_present must be false.");
+if (fixture.inferred_phase1_present !== false) fail("inferred_phase1_present must be false.");
+if (fixture.inferred_link_present !== false) fail("inferred_link_present must be false.");
+if (fixture.inferred_return_choice_present !== false) fail("inferred_return_choice_present must be false.");
+if (fixture.engine_authority_created !== false) fail("engine_authority_created must be false.");
+if (fixture.phase1_mutated !== false) fail("phase1_mutated must be false.");
+if (fixture.recompilation_triggered !== false) fail("recompilation_triggered must be false.");
+if (fixture.legality_changed !== false) fail("legality_changed must be false.");
+if (fixture.engine_output_overridden !== false) fail("engine_output_overridden must be false.");
+if (fixture.readiness_claim_present !== false) fail("readiness_claim_present must be false.");
+if (fixture.advice_present !== false) fail("advice_present must be false.");
+if (fixture.recommendation_present !== false) fail("recommendation_present must be false.");
+if (fixture.judgement_present !== false) fail("judgement_present must be false.");
+if (fixture.future_effect !== false) fail("future_effect must be false.");
+
+if (!Array.isArray(fixture.blocked_cases)) fail("blocked_cases must be an array.");
+if (fixture.blocked_cases.length !== fixture.blocked_case_count) fail("blocked_case_count must match blocked_cases length.");
+
+const seenBlockedStates = new Set();
+for (const blockedCase of fixture.blocked_cases) {
+  if (!blockedCase.case_id) fail("blocked case_id missing.");
+  if (!allowedBlockedStates.has(blockedCase.blocked_state)) fail(`blocked_state invalid: ${blockedCase.blocked_state}`);
+  if (!allowedBlockedReasons.has(blockedCase.blocked_reason)) fail(`blocked_reason invalid: ${blockedCase.blocked_reason}`);
+  if (blockedCase.requested_action_continued !== false) fail(`${blockedCase.case_id} must refuse requested action.`);
+  if (blockedCase.operator_copy !== requiredCopy.get(blockedCase.blocked_state)) {
+    fail(`${blockedCase.case_id} operator copy mismatch.`);
+  }
+  seenBlockedStates.add(blockedCase.blocked_state);
+}
+
+for (const requiredState of allowedBlockedStates) {
+  if (!seenBlockedStates.has(requiredState)) fail(`Required blocked state missing: ${requiredState}`);
+}
+
+if (!Array.isArray(fixture.events)) fail("events must be an array.");
+if (fixture.events.length !== fixture.event_count) fail("event_count must match events length.");
+
+const ids = new Set();
+for (const [index, event] of fixture.events.entries()) {
+  if (!event.event_id) fail(`events[${index}].event_id missing.`);
+  if (ids.has(event.event_id)) fail(`Duplicate event_id ${event.event_id}.`);
+  ids.add(event.event_id);
+
+  if (!event.pilot_id) fail(`events[${index}].pilot_id missing.`);
+  if (event.actor !== "platform") fail(`events[${index}].actor must be platform.`);
+  if (!allowedEvents.has(event.event_type)) fail(`events[${index}].event_type is not allowed: ${event.event_type}`);
+  if (!allowedBlockedStates.has(event.blocked_state)) fail(`events[${index}].blocked_state invalid.`);
+  if (!allowedBlockedReasons.has(event.blocked_reason)) fail(`events[${index}].blocked_reason invalid.`);
+  if (!event.occurred_at_utc) fail(`events[${index}].occurred_at_utc missing.`);
+}
+
+for (const requiredState of allowedBlockedStates) {
+  const stateEvents = fixture.events.filter((event) => event.blocked_state === requiredState);
+  const stateEventTypes = new Set(stateEvents.map((event) => event.event_type));
+
+  for (const requiredEvent of allowedEvents) {
+    if (!stateEventTypes.has(requiredEvent)) {
+      fail(`${requiredState} missing required event ${requiredEvent}.`);
+    }
+  }
+}
+
+console.log(JSON.stringify({ ok: true, slice: "S40", checked: [docPath, fixturePath] }, null, 2));

--- a/docs/pilot/S40_BLOCKED_STATE_SUPPORT_PACK.md
+++ b/docs/pilot/S40_BLOCKED_STATE_SUPPORT_PACK.md
@@ -1,0 +1,277 @@
+# S40 - Blocked-State Support Pack
+
+## Target
+
+Define all live pilot blocked states in one place.
+
+## Invariant
+
+A blocked state is factual platform/runtime refusal only.
+
+A blocked state must not:
+
+- infer missing truth
+- auto-correct missing truth
+- bypass Phase 1
+- bypass coach athlete link rules
+- create a session where none exists
+- continue a return flow without required return data
+- create advice
+- create recommendation
+- create readiness language
+- create judgement
+- mutate Phase 1
+- re-run compilation
+- alter legality
+- override engine output
+
+## v0 Boundary
+
+This pack is limited to Kolosseum v0 Deterministic Execution Alpha.
+
+Included:
+
+- Phase 1 missing blocked state
+- no session blocked state
+- no link blocked state
+- revoked link blocked state
+- return missing blocked state
+- factual blocked reason records
+- operator-facing blocked state copy
+- athlete/coach-safe blocked state copy
+
+Excluded:
+
+- automatic correction
+- fallback session creation
+- inferred link creation
+- Phase 1 editing
+- Phase 3 to Phase 5 re-entry
+- Phase 7 output
+- Phase 8 output
+- evidence envelope
+- export proof
+- readiness assessment
+- advice
+- recommendation
+- optimisation
+- judgement
+- scoring
+- ranking
+- messaging
+- team runtime
+- organisation runtime
+
+## Required Blocked States
+
+S40 defines these blocked_state values:
+
+- phase1_missing
+- no_session
+- no_link
+- revoked_link
+- return_missing
+
+No other blocked state exists in S40.
+
+## Required Blocked Reasons
+
+Allowed blocked_reason values:
+
+- phase1_missing
+- session_missing
+- coach_athlete_link_missing
+- coach_athlete_link_revoked
+- return_choice_missing
+- return_point_missing
+
+No other blocked reason exists in S40.
+
+## Required Blocked Flow
+
+The blocked-state flow must follow this order.
+
+1. A live pilot action is requested.
+2. Platform/runtime checks required factual prerequisites.
+3. Required prerequisite is missing, invalid, or revoked.
+4. Platform/runtime appends blocked_state_recorded.
+5. Action is refused.
+6. No engine truth is changed.
+7. No compilation is triggered.
+8. No legality is changed.
+9. No advisory copy is displayed.
+
+No other flow is part of S40.
+
+## Required Event Outputs
+
+S40 allows only the following event types:
+
+- blocked_state_checked
+- blocked_state_recorded
+- blocked_action_refused
+
+Any other event type is outside this pack.
+
+## Event Shape
+
+Every blocked-state event must include:
+
+- event_id
+- pilot_id
+- event_type
+- actor
+- occurred_at_utc
+- blocked_state
+- blocked_reason
+
+Where known, the event may also include:
+
+- coach_id
+- athlete_id
+- session_id
+- link_id
+- requested_action
+
+The payload is factual data only.
+
+## Event Meaning Lock
+
+blocked_state_checked means the platform/runtime checked required prerequisites for a requested live pilot action.
+
+blocked_state_recorded means the platform/runtime recorded a factual blocked state.
+
+blocked_action_refused means the requested action did not continue.
+
+These meanings must not be expanded.
+
+## Required Operator Copy
+
+phase1_missing:
+
+"Blocked: Phase 1 declaration is missing. The pilot cannot continue until Phase 1 is accepted."
+
+no_session:
+
+"Blocked: no live session exists for this action."
+
+no_link:
+
+"Blocked: no accepted coach athlete link exists."
+
+revoked_link:
+
+"Blocked: coach athlete link is revoked."
+
+return_missing:
+
+"Blocked: return data is missing."
+
+No alternative wording is part of S40.
+
+## State Rules
+
+phase1_missing applies when a live pilot action requires accepted Phase 1 and no accepted Phase 1 exists.
+
+no_session applies when a live pilot action requires an existing live or assigned session and none exists.
+
+no_link applies when a coach-managed action requires an accepted coach athlete link and no accepted link exists.
+
+revoked_link applies when a coach-managed action has a link record but that link is revoked.
+
+return_missing applies when split/return flow requires return choice or return point data and the required return data is missing.
+
+A blocked state must be terminal for the requested action.
+
+A blocked state must not terminate the pilot globally.
+
+A blocked state must not change Phase 1.
+
+A blocked state must not trigger recompilation.
+
+A blocked state must not alter legality.
+
+A blocked state must not create future-session effects.
+
+## Blocked Conditions
+
+The blocked-state flow must refuse the requested action when any of the following are true:
+
+| Condition | Required blocked_state | Required blocked_reason |
+|---|---|---|
+| Phase 1 accepted record is missing | phase1_missing | phase1_missing |
+| required session is missing | no_session | session_missing |
+| accepted coach athlete link is missing | no_link | coach_athlete_link_missing |
+| coach athlete link is revoked | revoked_link | coach_athlete_link_revoked |
+| return choice is missing | return_missing | return_choice_missing |
+| return point is missing | return_missing | return_point_missing |
+
+No fallback is permitted.
+
+No automatic correction is permitted.
+
+No hidden continuation is permitted.
+
+No inferred link is permitted.
+
+No inferred Phase 1 is permitted.
+
+No inferred return choice is permitted.
+
+## Operator Checklist
+
+S40 passes only if the operator can show:
+
+- phase1_missing blocked state exists
+- no_session blocked state exists
+- no_link blocked state exists
+- revoked_link blocked state exists
+- return_missing blocked state exists
+- each blocked state has exact required copy
+- each blocked state has exact blocked_reason
+- blocked_state_recorded exists
+- blocked_action_refused exists
+- requested action does not continue
+- no blocked state mutates Phase 1
+- no blocked state re-runs compilation
+- no blocked state alters legality
+- no blocked state overrides engine output
+- no blocked state creates readiness, advice, recommendation, judgement, score, ranking, or future-session effect
+
+## Minimum Demonstration Record
+
+A valid S40 demonstration record must contain:
+
+- slice: S40
+- proof_name: blocked_state_support_pack
+- phase1_missing_blocked: true
+- no_session_blocked: true
+- no_link_blocked: true
+- revoked_link_blocked: true
+- return_missing_blocked: true
+- exact_operator_copy_present: true
+- blocked_action_refused: true
+- hidden_continuation_present: false
+- inferred_phase1_present: false
+- inferred_link_present: false
+- inferred_return_choice_present: false
+- engine_authority_created: false
+- phase1_mutated: false
+- recompilation_triggered: false
+- legality_changed: false
+- engine_output_overridden: false
+- readiness_claim_present: false
+- advice_present: false
+- recommendation_present: false
+- judgement_present: false
+- future_effect: false
+- blocked_case_count: 5
+- event_count: 15
+
+## Final Operator Sentence
+
+"Live pilot blocked states are recorded factually, refuse only the requested action, and never infer missing truth, mutate Phase 1, re-run compilation, alter legality, or create advice."
+
+## Final Rule
+
+If a blocked state infers missing truth, allows hidden continuation, mutates Phase 1, re-runs compilation, alters legality, overrides engine output, or creates readiness, advice, recommendation, judgement, or future-session effect, the S40 blocked-state support flow does not exist.

--- a/docs/pilot/fixtures/s40_blocked_state_support_pack.valid.json
+++ b/docs/pilot/fixtures/s40_blocked_state_support_pack.valid.json
@@ -1,0 +1,216 @@
+{
+  "slice": "S40",
+  "proof_name": "blocked_state_support_pack",
+  "phase1_missing_blocked": true,
+  "no_session_blocked": true,
+  "no_link_blocked": true,
+  "revoked_link_blocked": true,
+  "return_missing_blocked": true,
+  "exact_operator_copy_present": true,
+  "blocked_action_refused": true,
+  "hidden_continuation_present": false,
+  "inferred_phase1_present": false,
+  "inferred_link_present": false,
+  "inferred_return_choice_present": false,
+  "engine_authority_created": false,
+  "phase1_mutated": false,
+  "recompilation_triggered": false,
+  "legality_changed": false,
+  "engine_output_overridden": false,
+  "readiness_claim_present": false,
+  "advice_present": false,
+  "recommendation_present": false,
+  "judgement_present": false,
+  "future_effect": false,
+  "blocked_case_count": 5,
+  "event_count": 15,
+  "blocked_cases": [
+    {
+      "case_id": "s40_phase1_missing",
+      "blocked_state": "phase1_missing",
+      "blocked_reason": "phase1_missing",
+      "operator_copy": "Blocked: Phase 1 declaration is missing. The pilot cannot continue until Phase 1 is accepted.",
+      "requested_action_continued": false
+    },
+    {
+      "case_id": "s40_no_session",
+      "blocked_state": "no_session",
+      "blocked_reason": "session_missing",
+      "operator_copy": "Blocked: no live session exists for this action.",
+      "requested_action_continued": false
+    },
+    {
+      "case_id": "s40_no_link",
+      "blocked_state": "no_link",
+      "blocked_reason": "coach_athlete_link_missing",
+      "operator_copy": "Blocked: no accepted coach athlete link exists.",
+      "requested_action_continued": false
+    },
+    {
+      "case_id": "s40_revoked_link",
+      "blocked_state": "revoked_link",
+      "blocked_reason": "coach_athlete_link_revoked",
+      "operator_copy": "Blocked: coach athlete link is revoked.",
+      "requested_action_continued": false
+    },
+    {
+      "case_id": "s40_return_missing",
+      "blocked_state": "return_missing",
+      "blocked_reason": "return_choice_missing",
+      "operator_copy": "Blocked: return data is missing.",
+      "requested_action_continued": false
+    }
+  ],
+  "events": [
+    {
+      "event_id": "evt_s40_001",
+      "pilot_id": "pilot_manual_v0_001",
+      "event_type": "blocked_state_checked",
+      "actor": "platform",
+      "occurred_at_utc": "2026-04-27T00:00:00Z",
+      "blocked_state": "phase1_missing",
+      "blocked_reason": "phase1_missing",
+      "requested_action": "start_live_session"
+    },
+    {
+      "event_id": "evt_s40_002",
+      "pilot_id": "pilot_manual_v0_001",
+      "event_type": "blocked_state_recorded",
+      "actor": "platform",
+      "occurred_at_utc": "2026-04-27T00:00:01Z",
+      "blocked_state": "phase1_missing",
+      "blocked_reason": "phase1_missing",
+      "requested_action": "start_live_session"
+    },
+    {
+      "event_id": "evt_s40_003",
+      "pilot_id": "pilot_manual_v0_001",
+      "event_type": "blocked_action_refused",
+      "actor": "platform",
+      "occurred_at_utc": "2026-04-27T00:00:02Z",
+      "blocked_state": "phase1_missing",
+      "blocked_reason": "phase1_missing",
+      "requested_action": "start_live_session"
+    },
+    {
+      "event_id": "evt_s40_004",
+      "pilot_id": "pilot_manual_v0_001",
+      "event_type": "blocked_state_checked",
+      "actor": "platform",
+      "occurred_at_utc": "2026-04-27T00:01:00Z",
+      "blocked_state": "no_session",
+      "blocked_reason": "session_missing",
+      "requested_action": "open_live_session"
+    },
+    {
+      "event_id": "evt_s40_005",
+      "pilot_id": "pilot_manual_v0_001",
+      "event_type": "blocked_state_recorded",
+      "actor": "platform",
+      "occurred_at_utc": "2026-04-27T00:01:01Z",
+      "blocked_state": "no_session",
+      "blocked_reason": "session_missing",
+      "requested_action": "open_live_session"
+    },
+    {
+      "event_id": "evt_s40_006",
+      "pilot_id": "pilot_manual_v0_001",
+      "event_type": "blocked_action_refused",
+      "actor": "platform",
+      "occurred_at_utc": "2026-04-27T00:01:02Z",
+      "blocked_state": "no_session",
+      "blocked_reason": "session_missing",
+      "requested_action": "open_live_session"
+    },
+    {
+      "event_id": "evt_s40_007",
+      "pilot_id": "pilot_manual_v0_001",
+      "event_type": "blocked_state_checked",
+      "actor": "platform",
+      "occurred_at_utc": "2026-04-27T00:02:00Z",
+      "blocked_state": "no_link",
+      "blocked_reason": "coach_athlete_link_missing",
+      "requested_action": "coach_assign_session"
+    },
+    {
+      "event_id": "evt_s40_008",
+      "pilot_id": "pilot_manual_v0_001",
+      "event_type": "blocked_state_recorded",
+      "actor": "platform",
+      "occurred_at_utc": "2026-04-27T00:02:01Z",
+      "blocked_state": "no_link",
+      "blocked_reason": "coach_athlete_link_missing",
+      "requested_action": "coach_assign_session"
+    },
+    {
+      "event_id": "evt_s40_009",
+      "pilot_id": "pilot_manual_v0_001",
+      "event_type": "blocked_action_refused",
+      "actor": "platform",
+      "occurred_at_utc": "2026-04-27T00:02:02Z",
+      "blocked_state": "no_link",
+      "blocked_reason": "coach_athlete_link_missing",
+      "requested_action": "coach_assign_session"
+    },
+    {
+      "event_id": "evt_s40_010",
+      "pilot_id": "pilot_manual_v0_001",
+      "event_type": "blocked_state_checked",
+      "actor": "platform",
+      "occurred_at_utc": "2026-04-27T00:03:00Z",
+      "blocked_state": "revoked_link",
+      "blocked_reason": "coach_athlete_link_revoked",
+      "requested_action": "coach_view_artefact"
+    },
+    {
+      "event_id": "evt_s40_011",
+      "pilot_id": "pilot_manual_v0_001",
+      "event_type": "blocked_state_recorded",
+      "actor": "platform",
+      "occurred_at_utc": "2026-04-27T00:03:01Z",
+      "blocked_state": "revoked_link",
+      "blocked_reason": "coach_athlete_link_revoked",
+      "requested_action": "coach_view_artefact"
+    },
+    {
+      "event_id": "evt_s40_012",
+      "pilot_id": "pilot_manual_v0_001",
+      "event_type": "blocked_action_refused",
+      "actor": "platform",
+      "occurred_at_utc": "2026-04-27T00:03:02Z",
+      "blocked_state": "revoked_link",
+      "blocked_reason": "coach_athlete_link_revoked",
+      "requested_action": "coach_view_artefact"
+    },
+    {
+      "event_id": "evt_s40_013",
+      "pilot_id": "pilot_manual_v0_001",
+      "event_type": "blocked_state_checked",
+      "actor": "platform",
+      "occurred_at_utc": "2026-04-27T00:04:00Z",
+      "blocked_state": "return_missing",
+      "blocked_reason": "return_choice_missing",
+      "requested_action": "return_to_split_session"
+    },
+    {
+      "event_id": "evt_s40_014",
+      "pilot_id": "pilot_manual_v0_001",
+      "event_type": "blocked_state_recorded",
+      "actor": "platform",
+      "occurred_at_utc": "2026-04-27T00:04:01Z",
+      "blocked_state": "return_missing",
+      "blocked_reason": "return_choice_missing",
+      "requested_action": "return_to_split_session"
+    },
+    {
+      "event_id": "evt_s40_015",
+      "pilot_id": "pilot_manual_v0_001",
+      "event_type": "blocked_action_refused",
+      "actor": "platform",
+      "occurred_at_utc": "2026-04-27T00:04:02Z",
+      "blocked_state": "return_missing",
+      "blocked_reason": "return_choice_missing",
+      "requested_action": "return_to_split_session"
+    }
+  ]
+}


### PR DESCRIPTION
Adds S40 operator proof for all live pilot blocked states: Phase 1 missing, no session, no link, revoked link, and return missing.