### PR TITLE
Fence public UI diagnostics

### DIFF
--- a/docs/diagnostics/PUBLIC_UI_DIAGNOSTIC_SURFACES.md
+++ b/docs/diagnostics/PUBLIC_UI_DIAGNOSTIC_SURFACES.md
@@ -1,0 +1,34 @@
+# PUBLIC UI DIAGNOSTIC SURFACES
+
+## Status
+
+Diagnostic-only.
+
+The files listed here are retained for explicit local inspection of factual API and runtime behaviour. They are not part of the active v0 application flow and do not define engine, API, registry, CI, or commercial authority.
+
+## Covered files
+
+- `public/session.html`
+- `public/session.js`
+- `public/session.css`
+- `public/decision-summary.html`
+- `public/decision-summary.js`
+- `public/decision-summary.css`
+- `public/v0-session-runner.html`
+- `public/v0-session-runner.js`
+
+## Route boundary
+
+The `/ui/*` routes are disabled by default.
+
+They may only be enabled locally with:
+
+`KOLOSSEUM_ENABLE_DIAGNOSTIC_UI=true`
+
+This flag controls only whether the diagnostic files are reachable over HTTP. It must not affect engine inputs, engine outputs, compilation, session execution, registry loading, or CI checks.
+
+## Handling rule
+
+Do not expand these files during engine, schema, registry, API, or CI slices.
+
+Future work may either keep them fenced for local inspection or remove them once no local workflow depends on them.

--- a/public/decision-summary.html
+++ b/public/decision-summary.html
@@ -11,7 +11,7 @@
       <header class="top">
         <div>
           <div class="h1">Decision Summary</div>
-          <div class="sub">Consumer-facing read surface for one engine run</div>
+          <div class="sub">Diagnostic read surface for one engine run</div>
         </div>
         <div class="top-right">
           <div class="pill">API: <span id="apiBaseText"></span></div>

--- a/src/server.ts
+++ b/src/server.ts
@@ -31,6 +31,18 @@ app.use(express.json({ limit: "1mb" }));
  * - /ui/decision-summary/:run_id (redirect convenience)
  */
 const publicDir = path.resolve(process.cwd(), "public");
+/**
+ * Local diagnostic UI gate.
+ *
+ * The /ui files are retained for explicit local inspection only.
+ * They are disabled unless KOLOSSEUM_ENABLE_DIAGNOSTIC_UI=true.
+ */
+const diagnosticUiEnabled = process.env.KOLOSSEUM_ENABLE_DIAGNOSTIC_UI === "true";
+
+app.use("/ui", (req, res, next) => {
+  if (diagnosticUiEnabled) return next();
+  return res.status(404).json({ error: "diagnostic_ui_disabled" });
+});
 app.use("/ui", express.static(publicDir));
 
 app.get("/ui/session/:session_id", (req, res) => {

--- a/test/public_ui_diagnostic_route_fence_contract.test.mjs
+++ b/test/public_ui_diagnostic_route_fence_contract.test.mjs
@@ -1,0 +1,41 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+
+const repo = process.cwd();
+const serverPath = path.join(repo, "src", "server.ts");
+const serverSrc = fs.readFileSync(serverPath, "utf8");
+
+const gateConst = 'const diagnosticUiEnabled = process.env.KOLOSSEUM_ENABLE_DIAGNOSTIC_UI === "true";';
+const gateMiddleware = 'app.use("/ui", (req, res, next) => {';
+
+assert.ok(
+  serverSrc.includes(gateConst),
+  "expected diagnostic UI env gate constant"
+);
+
+assert.ok(
+  serverSrc.includes(gateMiddleware),
+  "expected /ui middleware gate"
+);
+
+assert.match(
+  serverSrc,
+  /return res\.status\(404\)\.json\(\{ error: "diagnostic_ui_disabled" \}\);/,
+  "expected disabled diagnostic UI to return deterministic 404"
+);
+
+const gateIndex = serverSrc.indexOf(gateMiddleware);
+const uiRegistrations = [
+  serverSrc.indexOf('app.use("/ui", express.static'),
+  serverSrc.indexOf('app.get("/ui/session/:session_id"'),
+  serverSrc.indexOf('app.get("/ui/decision-summary/:run_id"'),
+].filter((n) => n >= 0);
+
+assert.ok(uiRegistrations.length > 0, "expected existing /ui registrations to remain present");
+assert.ok(
+  uiRegistrations.every((idx) => gateIndex < idx),
+  "expected diagnostic /ui gate to appear before all /ui static and redirect registrations"
+);
+
+console.log("public UI diagnostic route fence contract passed");


### PR DESCRIPTION
Fences legacy public UI files as diagnostics-only. Adds a default-disabled /ui middleware gate behind KOLOSSEUM_ENABLE_DIAGNOSTIC_UI=true and documents the boundary without changing engine, API, registry, or CI behaviour.