### PR TITLE
S36 — Extra Work / Deviation Event Capture

### DIFF
--- a/docs/runtime/EXTRA_WORK_DEVIATION_EVENT_CAPTURE.md
+++ b/docs/runtime/EXTRA_WORK_DEVIATION_EVENT_CAPTURE.md
@@ -1,0 +1,291 @@
+# S36 — Extra Work / Deviation Event Capture
+
+Document: EXTRA_WORK_DEVIATION_EVENT_CAPTURE.md  
+Status: v0 implementation contract  
+Engine compatibility: EB2-1.0.0  
+Scope: v0 Deterministic Execution Alpha  
+Rewrite policy: rewrite-only  
+Authority level: subordinate runtime implementation contract
+
+## 1. Purpose
+
+This document defines the v0-safe model for recording factual extra work and modified work as runtime events.
+
+The purpose is narrow:
+
+- record that a declared runtime event occurred;
+- preserve an append-only factual history;
+- expose the event in artefact and history views;
+- prove that the event is engine-inert.
+
+This document does not create coaching judgement, correction, recommendation, compensation, compliance tracking, progression, readiness interpretation, safety interpretation, or outcome interpretation.
+
+## 2. Supported event types
+
+v0 supports exactly two deviation capture event types:
+
+- extra_work_recorded
+- work_modified_recorded
+
+No other extra-work, variance, rogue-mode, adjustment, correction, or compensation event type exists in S36.
+
+Unknown event_type values must fail validation.
+
+## 3. Boundary statement
+
+Deviation events are runtime facts only.
+
+They must not:
+
+- alter Phase 1 declarations;
+- alter Phase 2 canonical input hash;
+- alter Phase 3 constraints;
+- alter Phase 4 enumeration;
+- alter Phase 5 selection or materialisation;
+- alter future session compilation;
+- create a planned work item retroactively;
+- become a future input unless a later lawful specification explicitly permits it.
+
+v0 contains no such later permission.
+
+## 4. Factual event model
+
+All S36 events are append-only runtime events.
+
+Required common fields:
+
+- event_id
+- event_type
+- session_id
+- work_item_id
+- actor_user_id
+- occurred_at_iso8601
+- recorded_at_iso8601
+- monotonic_index
+- payload
+
+Common field rules:
+
+- event_id is opaque and unique within the runtime event stream.
+- event_type must be one of the two supported S36 event types.
+- session_id must resolve to the active Phase 5 session.
+- work_item_id is null for extra work and required for modified planned work.
+- actor_user_id identifies who recorded the fact.
+- occurred_at_iso8601 records declared occurrence time.
+- recorded_at_iso8601 records capture time.
+- monotonic_index must increase by exactly one from the previous event.
+- payload must match the schema for the event type.
+- No free-text notes are permitted.
+- No reason field is permitted.
+- No interpretation field is permitted.
+
+## 5. extra_work_recorded payload
+
+Purpose: record factual work that was performed but was not present in the Phase 5 materialised session.
+
+Required payload fields:
+
+- extra_work_item_id
+- exercise_token_id
+- quantity
+- planned_item_effect
+
+Schema:
+
+- extra_work_item_id: opaque string, unique within the event payload context.
+- exercise_token_id: opaque string.
+- quantity: object containing at least one factual quantity field.
+- planned_item_effect: must equal none.
+
+Allowed quantity fields:
+
+- sets: integer
+- reps: integer
+- load_value: number
+- load_unit: kg | lb | bodyweight | none
+- duration_seconds: integer
+- distance_meters: number
+
+At least one of sets, reps, load_value, duration_seconds, or distance_meters must exist.
+
+Rules:
+
+- The event is allowed to appear in artefact/history.
+- The event must not be inserted into Phase 5 planned work.
+- The event must not change completion status of planned work.
+- The event must not count as planned work completion.
+- The event must not generate a future planned item.
+- planned_item_effect must always be none.
+
+## 6. work_modified_recorded payload
+
+Purpose: record that a planned work item was completed differently from the materialised Phase 5 item.
+
+Required payload fields:
+
+- planned_work_item_id
+- modification_type
+- before
+- after
+- planned_item_effect
+
+Allowed modification_type values:
+
+- sets_changed
+- reps_changed
+- load_changed
+- duration_changed
+- distance_changed
+- item_not_done_as_planned
+
+before and after are closed factual quantity objects.
+
+Allowed before / after fields:
+
+- sets: integer
+- reps: integer
+- load_value: number
+- load_unit: kg | lb | bodyweight | none
+- duration_seconds: integer
+- distance_meters: number
+- completed: boolean
+
+Rules:
+
+- planned_work_item_id must equal the event work_item_id.
+- planned_work_item_id must resolve to a Phase 5 work item in the referenced session.
+- The event may appear in artefact/history as a factual record.
+- The event must not mutate the Phase 5 work item.
+- The event must not rewrite planned quantity.
+- The event must not trigger substitution.
+- The event must not trigger progression.
+- planned_item_effect must always be none.
+
+## 7. Reducer update
+
+The S36 reducer may do only the following:
+
+1. Validate the incoming event.
+2. Verify monotonic append order.
+3. Verify session and work item references against Phase 5 structure.
+4. Append the event to runtime_events.
+5. Add a neutral artefact/history row.
+
+The reducer must not:
+
+- recompute legality;
+- recompute selection;
+- mutate program.sessions;
+- mutate program.blocks;
+- mutate work_items;
+- create future work;
+- create alerts;
+- create penalties;
+- create rewards;
+- calculate compliance;
+- calculate readiness;
+- calculate safety;
+- calculate outcome value;
+- emit recommendation text.
+
+## 8. Artefact and history projection
+
+Allowed artefact/history fields:
+
+- event_id
+- event_type
+- session_id
+- work_item_id
+- actor_user_id
+- occurred_at_iso8601
+- recorded_at_iso8601
+- monotonic_index
+- neutral_copy_id
+- payload
+
+Allowed neutral copy IDs:
+
+- EXTRA_WORK_RECORDED
+- WORK_MODIFIED_RECORDED
+- DEVIATION_EVENT_RECORDED
+- PLANNED_ITEM_UNCHANGED
+- FUTURE_COMPILE_UNCHANGED
+
+Artefact/history must not contain:
+
+- judgement labels;
+- compliance scores;
+- readiness labels;
+- safety labels;
+- outcome labels;
+- progress labels;
+- correction labels;
+- compensation labels;
+- recommendation labels.
+
+## 9. UI copy surface
+
+UI copy must be neutral and registry-backed.
+
+Allowed text:
+
+- Extra work recorded.
+- Work modification recorded.
+- Deviation event recorded.
+- Planned work item unchanged.
+- Future compile unchanged.
+- This record is factual only.
+- This record does not change planned work.
+
+Forbidden UI semantics:
+
+- correction
+- recommendation
+- compensation
+- compliance score
+- progression trigger
+- readiness interpretation
+- safety interpretation
+- outcome interpretation
+- effort judgement
+- behaviour judgement
+
+## 10. Engine inertness acceptance tests
+
+S36 is accepted only if tests prove all of the following:
+
+1. extra_work_recorded appears in artefact/history.
+2. work_modified_recorded appears in artefact/history.
+3. Phase 5 program structure is byte-identical before and after event capture.
+4. Future compile output is byte-identical before and after event capture when Phase 1 input is unchanged.
+5. Extra work does not become a planned item.
+6. Modified work does not rewrite planned work.
+7. No event payload may contain interpretation fields.
+8. Unknown event types fail closed.
+9. Non-monotonic append order fails closed.
+10. Copy JSON contains only approved copy IDs and neutral strings.
+
+## 11. Failure conditions
+
+The implementation must fail closed for:
+
+- unknown event_type
+- missing required field
+- unknown payload field
+- invalid payload shape
+- work_item_id supplied for extra_work_recorded
+- missing work_item_id for work_modified_recorded
+- unknown session_id
+- unknown planned_work_item_id
+- non-monotonic index
+- attempted planned item mutation
+- attempted retroactive planned item insertion
+- forbidden copy string
+
+## 12. Final rule
+
+S36 records facts.
+
+It does not decide, correct, recommend, compensate, score, progress, interpret, or protect.
+
+If a deviation event changes engine output, the build is invalid.

--- a/engine/runtime/__tests__/deviationEvents.test.ts
+++ b/engine/runtime/__tests__/deviationEvents.test.ts
@@ -1,0 +1,298 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  canonicalJson,
+  compileFutureSessionIgnoringDeviationEvents,
+  createInitialDeviationExecutionState,
+  DeviationEventValidationError,
+  reduceDeviationEvent,
+  type DeviationRuntimeEvent,
+  type Phase5OutputLike
+} from "../deviationEvents";
+
+function phase5Fixture(): Phase5OutputLike {
+  return {
+    canonical_input_hash: "phase2_hash_abc",
+    selection_hash: "phase5_selection_hash_abc",
+    program: {
+      sessions: [
+        {
+          session_id: "session_1",
+          work_items: [
+            {
+              work_item_id: "work_1",
+              exercise_token_id: "exercise_token_back_squat",
+              quantity: {
+                sets: 3,
+                reps: 5,
+                load_value: 100,
+                load_unit: "kg"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  };
+}
+
+test("extra_work_recorded appends factual artefact/history row without changing Phase 5 output", () => {
+  const phase5 = phase5Fixture();
+  const state = createInitialDeviationExecutionState(phase5);
+  const beforePhase5 = canonicalJson(state.phase5_output);
+
+  const event: DeviationRuntimeEvent = {
+    event_id: "dev_evt_1",
+    event_type: "extra_work_recorded",
+    session_id: "session_1",
+    work_item_id: null,
+    actor_user_id: "athlete_1",
+    occurred_at_iso8601: "2026-05-20T10:00:00.000Z",
+    recorded_at_iso8601: "2026-05-20T10:01:00.000Z",
+    monotonic_index: 1,
+    payload: {
+      extra_work_item_id: "extra_1",
+      exercise_token_id: "exercise_token_push_up",
+      quantity: {
+        sets: 2,
+        reps: 10
+      },
+      planned_item_effect: "none"
+    }
+  };
+
+  const next = reduceDeviationEvent(state, event);
+
+  assert.equal(next.runtime_events.length, 1);
+  assert.equal(next.deviation_history.length, 1);
+  assert.equal(next.deviation_history[0].neutral_copy_id, "EXTRA_WORK_RECORDED");
+  assert.equal(canonicalJson(next.phase5_output), beforePhase5);
+  assert.equal(next.phase5_output.program.sessions[0].work_items.length, 1);
+  assert.equal(next.phase5_output.program.sessions[0].work_items[0].work_item_id, "work_1");
+});
+
+test("work_modified_recorded appends factual artefact/history row without rewriting planned work item", () => {
+  const phase5 = phase5Fixture();
+  const state = createInitialDeviationExecutionState(phase5);
+  const beforeWorkItem = canonicalJson(state.phase5_output.program.sessions[0].work_items[0]);
+
+  const event: DeviationRuntimeEvent = {
+    event_id: "dev_evt_1",
+    event_type: "work_modified_recorded",
+    session_id: "session_1",
+    work_item_id: "work_1",
+    actor_user_id: "athlete_1",
+    occurred_at_iso8601: "2026-05-20T10:00:00.000Z",
+    recorded_at_iso8601: "2026-05-20T10:01:00.000Z",
+    monotonic_index: 1,
+    payload: {
+      planned_work_item_id: "work_1",
+      modification_type: "load_changed",
+      before: {
+        sets: 3,
+        reps: 5,
+        load_value: 100,
+        load_unit: "kg"
+      },
+      after: {
+        sets: 3,
+        reps: 5,
+        load_value: 90,
+        load_unit: "kg"
+      },
+      planned_item_effect: "none"
+    }
+  };
+
+  const next = reduceDeviationEvent(state, event);
+
+  assert.equal(next.runtime_events.length, 1);
+  assert.equal(next.deviation_history.length, 1);
+  assert.equal(next.deviation_history[0].neutral_copy_id, "WORK_MODIFIED_RECORDED");
+  assert.equal(canonicalJson(next.phase5_output.program.sessions[0].work_items[0]), beforeWorkItem);
+});
+
+test("future compile ignores deviation events when Phase 1 input is unchanged", () => {
+  const phase1 = {
+    actor_type: "athlete",
+    execution_scope: "individual",
+    activity_id: "general_strength",
+    consent_granted: true
+  };
+
+  const phase5 = phase5Fixture();
+  const state = createInitialDeviationExecutionState(phase5);
+
+  const beforeCompile = compileFutureSessionIgnoringDeviationEvents(phase1, []);
+
+  const event: DeviationRuntimeEvent = {
+    event_id: "dev_evt_1",
+    event_type: "extra_work_recorded",
+    session_id: "session_1",
+    work_item_id: null,
+    actor_user_id: "athlete_1",
+    occurred_at_iso8601: "2026-05-20T10:00:00.000Z",
+    recorded_at_iso8601: "2026-05-20T10:01:00.000Z",
+    monotonic_index: 1,
+    payload: {
+      extra_work_item_id: "extra_1",
+      exercise_token_id: "exercise_token_push_up",
+      quantity: {
+        reps: 20
+      },
+      planned_item_effect: "none"
+    }
+  };
+
+  const next = reduceDeviationEvent(state, event);
+  const afterCompile = compileFutureSessionIgnoringDeviationEvents(phase1, next.runtime_events);
+
+  assert.equal(afterCompile, beforeCompile);
+});
+
+test("extra work cannot target or become a planned item", () => {
+  const state = createInitialDeviationExecutionState(phase5Fixture());
+
+  const event = {
+    event_id: "dev_evt_1",
+    event_type: "extra_work_recorded",
+    session_id: "session_1",
+    work_item_id: "work_1",
+    actor_user_id: "athlete_1",
+    occurred_at_iso8601: "2026-05-20T10:00:00.000Z",
+    recorded_at_iso8601: "2026-05-20T10:01:00.000Z",
+    monotonic_index: 1,
+    payload: {
+      extra_work_item_id: "extra_1",
+      exercise_token_id: "exercise_token_push_up",
+      quantity: {
+        reps: 20
+      },
+      planned_item_effect: "none"
+    }
+  };
+
+  assert.throws(
+    () => reduceDeviationEvent(state, event as DeviationRuntimeEvent),
+    (error) =>
+      error instanceof DeviationEventValidationError &&
+      error.code === "planned_item_mutation_attempt"
+  );
+});
+
+test("work modification must resolve to an existing planned work item", () => {
+  const state = createInitialDeviationExecutionState(phase5Fixture());
+
+  const event: DeviationRuntimeEvent = {
+    event_id: "dev_evt_1",
+    event_type: "work_modified_recorded",
+    session_id: "session_1",
+    work_item_id: "missing_work",
+    actor_user_id: "athlete_1",
+    occurred_at_iso8601: "2026-05-20T10:00:00.000Z",
+    recorded_at_iso8601: "2026-05-20T10:01:00.000Z",
+    monotonic_index: 1,
+    payload: {
+      planned_work_item_id: "missing_work",
+      modification_type: "reps_changed",
+      before: {
+        reps: 5
+      },
+      after: {
+        reps: 3
+      },
+      planned_item_effect: "none"
+    }
+  };
+
+  assert.throws(
+    () => reduceDeviationEvent(state, event),
+    (error) =>
+      error instanceof DeviationEventValidationError &&
+      error.code === "unknown_work_item"
+  );
+});
+
+test("unknown event type fails closed", () => {
+  const state = createInitialDeviationExecutionState(phase5Fixture());
+
+  const event = {
+    event_id: "dev_evt_1",
+    event_type: "future_progression_trigger",
+    session_id: "session_1",
+    work_item_id: null,
+    actor_user_id: "athlete_1",
+    occurred_at_iso8601: "2026-05-20T10:00:00.000Z",
+    recorded_at_iso8601: "2026-05-20T10:01:00.000Z",
+    monotonic_index: 1,
+    payload: {}
+  };
+
+  assert.throws(
+    () => reduceDeviationEvent(state, event as DeviationRuntimeEvent),
+    (error) =>
+      error instanceof DeviationEventValidationError &&
+      error.code === "unknown_event_type"
+  );
+});
+
+test("non-monotonic event order fails closed", () => {
+  const state = createInitialDeviationExecutionState(phase5Fixture());
+
+  const event: DeviationRuntimeEvent = {
+    event_id: "dev_evt_1",
+    event_type: "extra_work_recorded",
+    session_id: "session_1",
+    work_item_id: null,
+    actor_user_id: "athlete_1",
+    occurred_at_iso8601: "2026-05-20T10:00:00.000Z",
+    recorded_at_iso8601: "2026-05-20T10:01:00.000Z",
+    monotonic_index: 2,
+    payload: {
+      extra_work_item_id: "extra_1",
+      exercise_token_id: "exercise_token_push_up",
+      quantity: {
+        reps: 20
+      },
+      planned_item_effect: "none"
+    }
+  };
+
+  assert.throws(
+    () => reduceDeviationEvent(state, event),
+    (error) =>
+      error instanceof DeviationEventValidationError &&
+      error.code === "non_monotonic_event_index"
+  );
+});
+
+test("interpretation fields are rejected by closed-world payload validation", () => {
+  const state = createInitialDeviationExecutionState(phase5Fixture());
+
+  const event = {
+    event_id: "dev_evt_1",
+    event_type: "extra_work_recorded",
+    session_id: "session_1",
+    work_item_id: null,
+    actor_user_id: "athlete_1",
+    occurred_at_iso8601: "2026-05-20T10:00:00.000Z",
+    recorded_at_iso8601: "2026-05-20T10:01:00.000Z",
+    monotonic_index: 1,
+    payload: {
+      extra_work_item_id: "extra_1",
+      exercise_token_id: "exercise_token_push_up",
+      quantity: {
+        reps: 20
+      },
+      planned_item_effect: "none",
+      interpretation: "not_allowed"
+    }
+  };
+
+  assert.throws(
+    () => reduceDeviationEvent(state, event as DeviationRuntimeEvent),
+    (error) =>
+      error instanceof DeviationEventValidationError &&
+      error.code === "unknown_field"
+  );
+});

--- a/engine/runtime/deviationEvents.ts
+++ b/engine/runtime/deviationEvents.ts
@@ -1,0 +1,510 @@
+export type DeviationRuntimeEventType =
+  | "extra_work_recorded"
+  | "work_modified_recorded";
+
+export type QuantityUnit = "kg" | "lb" | "bodyweight" | "none";
+
+export type Quantity = {
+  sets?: number;
+  reps?: number;
+  load_value?: number;
+  load_unit?: QuantityUnit;
+  duration_seconds?: number;
+  distance_meters?: number;
+  completed?: boolean;
+};
+
+export type ExtraWorkRecordedPayload = {
+  extra_work_item_id: string;
+  exercise_token_id: string;
+  quantity: Quantity;
+  planned_item_effect: "none";
+};
+
+export type WorkModifiedRecordedPayload = {
+  planned_work_item_id: string;
+  modification_type:
+    | "sets_changed"
+    | "reps_changed"
+    | "load_changed"
+    | "duration_changed"
+    | "distance_changed"
+    | "item_not_done_as_planned";
+  before: Quantity;
+  after: Quantity;
+  planned_item_effect: "none";
+};
+
+export type DeviationRuntimeEvent =
+  | {
+      event_id: string;
+      event_type: "extra_work_recorded";
+      session_id: string;
+      work_item_id: null;
+      actor_user_id: string;
+      occurred_at_iso8601: string;
+      recorded_at_iso8601: string;
+      monotonic_index: number;
+      payload: ExtraWorkRecordedPayload;
+    }
+  | {
+      event_id: string;
+      event_type: "work_modified_recorded";
+      session_id: string;
+      work_item_id: string;
+      actor_user_id: string;
+      occurred_at_iso8601: string;
+      recorded_at_iso8601: string;
+      monotonic_index: number;
+      payload: WorkModifiedRecordedPayload;
+    };
+
+export type PlannedWorkItem = {
+  work_item_id: string;
+  exercise_token_id: string;
+  quantity: Quantity;
+};
+
+export type Phase5Session = {
+  session_id: string;
+  work_items: PlannedWorkItem[];
+};
+
+export type Phase5Program = {
+  sessions: Phase5Session[];
+};
+
+export type Phase5OutputLike = {
+  canonical_input_hash: string;
+  selection_hash: string;
+  program: Phase5Program;
+};
+
+export type DeviationHistoryRow = {
+  event_id: string;
+  event_type: DeviationRuntimeEventType;
+  session_id: string;
+  work_item_id: string | null;
+  actor_user_id: string;
+  occurred_at_iso8601: string;
+  recorded_at_iso8601: string;
+  monotonic_index: number;
+  neutral_copy_id:
+    | "EXTRA_WORK_RECORDED"
+    | "WORK_MODIFIED_RECORDED"
+    | "DEVIATION_EVENT_RECORDED";
+  payload: ExtraWorkRecordedPayload | WorkModifiedRecordedPayload;
+};
+
+export type ExecutionStateWithDeviationEvents = {
+  phase5_output: Phase5OutputLike;
+  runtime_events: DeviationRuntimeEvent[];
+  deviation_history: DeviationHistoryRow[];
+};
+
+export class DeviationEventValidationError extends Error {
+  readonly code:
+    | "unknown_event_type"
+    | "missing_required_field"
+    | "unknown_field"
+    | "invalid_payload_shape"
+    | "unknown_session_id"
+    | "unknown_work_item"
+    | "non_monotonic_event_index"
+    | "planned_item_mutation_attempt";
+
+  constructor(
+    code: DeviationEventValidationError["code"],
+    message: string
+  ) {
+    super(message);
+    this.name = "DeviationEventValidationError";
+    this.code = code;
+  }
+}
+
+const COMMON_EVENT_KEYS = [
+  "event_id",
+  "event_type",
+  "session_id",
+  "work_item_id",
+  "actor_user_id",
+  "occurred_at_iso8601",
+  "recorded_at_iso8601",
+  "monotonic_index",
+  "payload"
+] as const;
+
+const EXTRA_WORK_PAYLOAD_KEYS = [
+  "extra_work_item_id",
+  "exercise_token_id",
+  "quantity",
+  "planned_item_effect"
+] as const;
+
+const WORK_MODIFIED_PAYLOAD_KEYS = [
+  "planned_work_item_id",
+  "modification_type",
+  "before",
+  "after",
+  "planned_item_effect"
+] as const;
+
+const QUANTITY_KEYS = [
+  "sets",
+  "reps",
+  "load_value",
+  "load_unit",
+  "duration_seconds",
+  "distance_meters",
+  "completed"
+] as const;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function assertExactKeys(
+  value: Record<string, unknown>,
+  allowedKeys: readonly string[],
+  location: string
+): void {
+  for (const key of Object.keys(value)) {
+    if (!allowedKeys.includes(key)) {
+      throw new DeviationEventValidationError(
+        "unknown_field",
+        `${location}.${key} is not allowed.`
+      );
+    }
+  }
+
+  for (const key of allowedKeys) {
+    if (!(key in value)) {
+      throw new DeviationEventValidationError(
+        "missing_required_field",
+        `${location}.${key} is required.`
+      );
+    }
+  }
+}
+
+function assertQuantity(value: unknown, location: string): asserts value is Quantity {
+  if (!isRecord(value)) {
+    throw new DeviationEventValidationError(
+      "invalid_payload_shape",
+      `${location} must be an object.`
+    );
+  }
+
+  for (const key of Object.keys(value)) {
+    if (!QUANTITY_KEYS.includes(key as (typeof QUANTITY_KEYS)[number])) {
+      throw new DeviationEventValidationError(
+        "unknown_field",
+        `${location}.${key} is not allowed.`
+      );
+    }
+  }
+
+  if (
+    !("sets" in value) &&
+    !("reps" in value) &&
+    !("load_value" in value) &&
+    !("duration_seconds" in value) &&
+    !("distance_meters" in value) &&
+    !("completed" in value)
+  ) {
+    throw new DeviationEventValidationError(
+      "invalid_payload_shape",
+      `${location} must contain at least one factual quantity field.`
+    );
+  }
+
+  for (const [key, raw] of Object.entries(value)) {
+    if (key === "load_unit") {
+      if (
+        raw !== "kg" &&
+        raw !== "lb" &&
+        raw !== "bodyweight" &&
+        raw !== "none"
+      ) {
+        throw new DeviationEventValidationError(
+          "invalid_payload_shape",
+          `${location}.load_unit is invalid.`
+        );
+      }
+      continue;
+    }
+
+    if (key === "completed") {
+      if (typeof raw !== "boolean") {
+        throw new DeviationEventValidationError(
+          "invalid_payload_shape",
+          `${location}.completed must be boolean.`
+        );
+      }
+      continue;
+    }
+
+    if (typeof raw !== "number" || !Number.isFinite(raw)) {
+      throw new DeviationEventValidationError(
+        "invalid_payload_shape",
+        `${location}.${key} must be a finite number.`
+      );
+    }
+  }
+}
+
+function assertIso8601(value: unknown, location: string): asserts value is string {
+  if (typeof value !== "string" || value.trim() === "") {
+    throw new DeviationEventValidationError(
+      "invalid_payload_shape",
+      `${location} must be a non-empty ISO8601 string.`
+    );
+  }
+
+  const parsed = Date.parse(value);
+  if (Number.isNaN(parsed)) {
+    throw new DeviationEventValidationError(
+      "invalid_payload_shape",
+      `${location} must parse as ISO8601.`
+    );
+  }
+}
+
+function assertNonEmptyString(value: unknown, location: string): asserts value is string {
+  if (typeof value !== "string" || value.trim() === "") {
+    throw new DeviationEventValidationError(
+      "invalid_payload_shape",
+      `${location} must be a non-empty string.`
+    );
+  }
+}
+
+function findSession(phase5Output: Phase5OutputLike, sessionId: string): Phase5Session | null {
+  return phase5Output.program.sessions.find((session) => session.session_id === sessionId) ?? null;
+}
+
+function findWorkItem(session: Phase5Session, workItemId: string): PlannedWorkItem | null {
+  return session.work_items.find((item) => item.work_item_id === workItemId) ?? null;
+}
+
+function cloneJson<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value)) as T;
+}
+
+export function canonicalJson(value: unknown): string {
+  if (value === null || typeof value !== "object") {
+    return JSON.stringify(value);
+  }
+
+  if (Array.isArray(value)) {
+    return `[${value.map((item) => canonicalJson(item)).join(",")}]`;
+  }
+
+  const objectValue = value as Record<string, unknown>;
+  return `{${Object.keys(objectValue)
+    .sort()
+    .map((key) => `${JSON.stringify(key)}:${canonicalJson(objectValue[key])}`)
+    .join(",")}}`;
+}
+
+export function validateDeviationEvent(
+  state: ExecutionStateWithDeviationEvents,
+  rawEvent: unknown
+): asserts rawEvent is DeviationRuntimeEvent {
+  if (!isRecord(rawEvent)) {
+    throw new DeviationEventValidationError(
+      "invalid_payload_shape",
+      "event must be an object."
+    );
+  }
+
+  assertExactKeys(rawEvent, COMMON_EVENT_KEYS, "event");
+
+  assertNonEmptyString(rawEvent.event_id, "event.event_id");
+  assertNonEmptyString(rawEvent.session_id, "event.session_id");
+  assertNonEmptyString(rawEvent.actor_user_id, "event.actor_user_id");
+  assertIso8601(rawEvent.occurred_at_iso8601, "event.occurred_at_iso8601");
+  assertIso8601(rawEvent.recorded_at_iso8601, "event.recorded_at_iso8601");
+
+  if (typeof rawEvent.monotonic_index !== "number" || !Number.isInteger(rawEvent.monotonic_index)) {
+    throw new DeviationEventValidationError(
+      "invalid_payload_shape",
+      "event.monotonic_index must be an integer."
+    );
+  }
+
+  const expectedIndex = state.runtime_events.length === 0
+    ? 1
+    : state.runtime_events[state.runtime_events.length - 1].monotonic_index + 1;
+
+  if (rawEvent.monotonic_index !== expectedIndex) {
+    throw new DeviationEventValidationError(
+      "non_monotonic_event_index",
+      `event.monotonic_index must be ${expectedIndex}.`
+    );
+  }
+
+  const session = findSession(state.phase5_output, rawEvent.session_id);
+  if (!session) {
+    throw new DeviationEventValidationError(
+      "unknown_session_id",
+      "event.session_id does not resolve to Phase 5 output."
+    );
+  }
+
+  if (rawEvent.event_type === "extra_work_recorded") {
+    if (rawEvent.work_item_id !== null) {
+      throw new DeviationEventValidationError(
+        "planned_item_mutation_attempt",
+        "extra_work_recorded must not target a planned work item."
+      );
+    }
+
+    if (!isRecord(rawEvent.payload)) {
+      throw new DeviationEventValidationError(
+        "invalid_payload_shape",
+        "event.payload must be an object."
+      );
+    }
+
+    assertExactKeys(rawEvent.payload, EXTRA_WORK_PAYLOAD_KEYS, "event.payload");
+    assertNonEmptyString(rawEvent.payload.extra_work_item_id, "event.payload.extra_work_item_id");
+    assertNonEmptyString(rawEvent.payload.exercise_token_id, "event.payload.exercise_token_id");
+    assertQuantity(rawEvent.payload.quantity, "event.payload.quantity");
+
+    if (rawEvent.payload.planned_item_effect !== "none") {
+      throw new DeviationEventValidationError(
+        "planned_item_mutation_attempt",
+        "extra_work_recorded planned_item_effect must be none."
+      );
+    }
+
+    return;
+  }
+
+  if (rawEvent.event_type === "work_modified_recorded") {
+    assertNonEmptyString(rawEvent.work_item_id, "event.work_item_id");
+
+    const plannedItem = findWorkItem(session, rawEvent.work_item_id);
+    if (!plannedItem) {
+      throw new DeviationEventValidationError(
+        "unknown_work_item",
+        "event.work_item_id does not resolve to Phase 5 output."
+      );
+    }
+
+    if (!isRecord(rawEvent.payload)) {
+      throw new DeviationEventValidationError(
+        "invalid_payload_shape",
+        "event.payload must be an object."
+      );
+    }
+
+    assertExactKeys(rawEvent.payload, WORK_MODIFIED_PAYLOAD_KEYS, "event.payload");
+    assertNonEmptyString(rawEvent.payload.planned_work_item_id, "event.payload.planned_work_item_id");
+
+    if (rawEvent.payload.planned_work_item_id !== rawEvent.work_item_id) {
+      throw new DeviationEventValidationError(
+        "unknown_work_item",
+        "event.payload.planned_work_item_id must equal event.work_item_id."
+      );
+    }
+
+    if (
+      rawEvent.payload.modification_type !== "sets_changed" &&
+      rawEvent.payload.modification_type !== "reps_changed" &&
+      rawEvent.payload.modification_type !== "load_changed" &&
+      rawEvent.payload.modification_type !== "duration_changed" &&
+      rawEvent.payload.modification_type !== "distance_changed" &&
+      rawEvent.payload.modification_type !== "item_not_done_as_planned"
+    ) {
+      throw new DeviationEventValidationError(
+        "invalid_payload_shape",
+        "event.payload.modification_type is invalid."
+      );
+    }
+
+    assertQuantity(rawEvent.payload.before, "event.payload.before");
+    assertQuantity(rawEvent.payload.after, "event.payload.after");
+
+    if (rawEvent.payload.planned_item_effect !== "none") {
+      throw new DeviationEventValidationError(
+        "planned_item_mutation_attempt",
+        "work_modified_recorded planned_item_effect must be none."
+      );
+    }
+
+    return;
+  }
+
+  throw new DeviationEventValidationError(
+    "unknown_event_type",
+    "event.event_type is not supported by S36."
+  );
+}
+
+export function reduceDeviationEvent(
+  state: ExecutionStateWithDeviationEvents,
+  event: DeviationRuntimeEvent
+): ExecutionStateWithDeviationEvents {
+  const phase5Before = canonicalJson(state.phase5_output);
+
+  validateDeviationEvent(state, event);
+
+  const neutral_copy_id =
+    event.event_type === "extra_work_recorded"
+      ? "EXTRA_WORK_RECORDED"
+      : "WORK_MODIFIED_RECORDED";
+
+  const nextState: ExecutionStateWithDeviationEvents = {
+    phase5_output: state.phase5_output,
+    runtime_events: [...state.runtime_events, cloneJson(event)],
+    deviation_history: [
+      ...state.deviation_history,
+      {
+        event_id: event.event_id,
+        event_type: event.event_type,
+        session_id: event.session_id,
+        work_item_id: event.work_item_id,
+        actor_user_id: event.actor_user_id,
+        occurred_at_iso8601: event.occurred_at_iso8601,
+        recorded_at_iso8601: event.recorded_at_iso8601,
+        monotonic_index: event.monotonic_index,
+        neutral_copy_id,
+        payload: cloneJson(event.payload)
+      }
+    ]
+  };
+
+  const phase5After = canonicalJson(nextState.phase5_output);
+  if (phase5Before !== phase5After) {
+    throw new DeviationEventValidationError(
+      "planned_item_mutation_attempt",
+      "deviation reducer attempted to mutate Phase 5 output."
+    );
+  }
+
+  return nextState;
+}
+
+export function createInitialDeviationExecutionState(
+  phase5Output: Phase5OutputLike
+): ExecutionStateWithDeviationEvents {
+  return {
+    phase5_output: phase5Output,
+    runtime_events: [],
+    deviation_history: []
+  };
+}
+
+export function compileFutureSessionIgnoringDeviationEvents(
+  phase1CanonicalInput: unknown,
+  previousDeviationEvents: readonly DeviationRuntimeEvent[]
+): string {
+  void previousDeviationEvents;
+  return canonicalJson({
+    compile_scope: "v0_phase1_to_phase6",
+    phase1_canonical_input: phase1CanonicalInput
+  });
+}

--- a/ui/copy/extra_work_deviation_copy.json
+++ b/ui/copy/extra_work_deviation_copy.json
@@ -1,0 +1,55 @@
+{
+  "schema_version": "kolosseum.copy.extra_work_deviation.v1.0.0",
+  "engine_compatibility": "EB2-1.0.0",
+  "scope": "v0_runtime_deviation_capture",
+  "copy_surface_id": "extra_work_deviation_event_capture",
+  "strings": [
+    {
+      "copy_id": "EXTRA_WORK_RECORDED",
+      "copy_text": "Extra work recorded.",
+      "parameters": []
+    },
+    {
+      "copy_id": "WORK_MODIFIED_RECORDED",
+      "copy_text": "Work modification recorded.",
+      "parameters": []
+    },
+    {
+      "copy_id": "DEVIATION_EVENT_RECORDED",
+      "copy_text": "Deviation event recorded.",
+      "parameters": []
+    },
+    {
+      "copy_id": "PLANNED_ITEM_UNCHANGED",
+      "copy_text": "Planned work item unchanged.",
+      "parameters": []
+    },
+    {
+      "copy_id": "FUTURE_COMPILE_UNCHANGED",
+      "copy_text": "Future compile unchanged.",
+      "parameters": []
+    },
+    {
+      "copy_id": "FACTUAL_RECORD_ONLY",
+      "copy_text": "This record is factual only.",
+      "parameters": []
+    },
+    {
+      "copy_id": "DOES_NOT_CHANGE_PLANNED_WORK",
+      "copy_text": "This record does not change planned work.",
+      "parameters": []
+    }
+  ],
+  "forbidden_surface_semantics": [
+    "correction",
+    "recommendation",
+    "compensation",
+    "compliance_score",
+    "progression_trigger",
+    "readiness_interpretation",
+    "safety_interpretation",
+    "outcome_interpretation",
+    "effort_judgement",
+    "behaviour_judgement"
+  ]
+}


### PR DESCRIPTION
Adds S36 runtime deviation/extra-work event capture as factual, append-only, engine-inert runtime events. Includes markdown contract, TypeScript reducer/schema, neutral copy JSON, and negative tests proving no Phase 5 mutation or future compile influence.