### PR TITLE
S37 — Session Artefact Viewer

### DIFF
--- a/docs/runtime/SESSION_ARTEFACT_VIEWER.md
+++ b/docs/runtime/SESSION_ARTEFACT_VIEWER.md
@@ -1,0 +1,340 @@
+# S37 — Session Artefact Viewer
+
+Document: SESSION_ARTEFACT_VIEWER.md  
+Status: v0 implementation contract  
+Engine compatibility: EB2-1.0.0  
+Scope: v0 Deterministic Execution Alpha  
+Rewrite policy: rewrite-only  
+Authority level: subordinate product/runtime implementation contract
+
+## 1. Purpose
+
+This document defines the v0 session artefact viewer.
+
+The viewer allows authorised users to inspect factual session artefacts. It is read-only. It does not allow editing, event override, Phase 1 editing, coaching judgement, hidden progression logic, or any interpretation layer.
+
+The viewer exists only to show what was recorded.
+
+## 2. Viewer scope
+
+The viewer may show only the following artefact fields:
+
+- session status
+- work item list
+- completed factual events
+- skipped factual events
+- partial factual events
+- event timestamps
+- source declaration hash
+- activity_id
+- execution_scope
+
+The viewer must not show or calculate:
+
+- analytics
+- trends
+- rankings
+- readiness labels
+- optimisation language
+- safety language
+- compliance language
+- outcome interpretation
+- comparison between athletes
+- future session implications
+- coaching instruction
+- correction
+- recommendation
+- progression trigger
+
+## 3. Actors
+
+Supported viewer actors in v0:
+
+- athlete
+- coach
+
+Unsupported actors must be denied.
+
+## 4. Permission matrix
+
+| Actor | Relationship to artefact athlete | Link status | May view artefact | May edit artefact | May override events | May edit Phase 1 |
+| --- | --- | --- | --- | --- | --- | --- |
+| athlete | own artefact | not required | yes | no | no | no |
+| athlete | another athlete | not applicable | no | no | no | no |
+| coach | linked athlete | accepted | yes | no | no | no |
+| coach | unlinked athlete | none | no | no | no | no |
+| coach | linked athlete | invited | no | no | no | no |
+| coach | linked athlete | rejected | no | no | no | no |
+| coach | linked athlete | expired | no | no | no | no |
+| coach | linked athlete | revoked | no | no | no | no |
+| unknown actor | any | any | no | no | no | no |
+
+## 5. Revoked link rule
+
+A revoked coach-athlete link denies viewer access.
+
+Historical visibility is also denied unless a separate historical visibility rule is explicitly defined by a later lawful v0 contract. S37 defines no such rule.
+
+If the visibility period is unclear, the viewer must fail closed.
+
+## 6. Artefact record contract
+
+A session artefact record must contain:
+
+- artefact_id
+- session_id
+- athlete_user_id
+- session_status
+- work_items
+- factual_events
+- source_declaration_hash
+- activity_id
+- execution_scope
+- created_at_iso8601
+- updated_at_iso8601
+
+Allowed session_status values:
+
+- planned
+- in_progress
+- completed
+- stopped
+- partial
+
+Allowed factual event types:
+
+- work_completed
+- work_skipped
+- work_partial
+
+No other event type may be projected by this viewer.
+
+## 7. Work item list
+
+Each work item shown by the viewer must contain:
+
+- work_item_id
+- display_order
+- exercise_token_id
+- planned_quantity
+
+Allowed planned_quantity fields:
+
+- sets
+- reps
+- load_value
+- load_unit
+- duration_seconds
+- distance_meters
+
+The viewer must not rewrite planned_quantity.
+
+## 8. Factual event list
+
+Each factual event shown by the viewer must contain:
+
+- event_id
+- event_type
+- work_item_id
+- occurred_at_iso8601
+- recorded_at_iso8601
+- factual_quantity
+
+The viewer must not add event interpretation.
+
+## 9. API contract
+
+### 9.1 Read session artefact
+
+Method:
+
+GET
+
+Path:
+
+/v0/session-artefacts/:artefact_id
+
+Required actor context:
+
+- actor_type
+- user_id
+
+Response 200:
+
+- artefact_id
+- session_id
+- athlete_user_id
+- session_status
+- work_items
+- factual_events
+- source_declaration_hash
+- activity_id
+- execution_scope
+- copy_ids
+- read_only
+
+Response 403:
+
+- error: access_denied
+- copy_id: ARTEFACT_ACCESS_DENIED
+
+Response 404:
+
+- error: artefact_not_found
+- copy_id: ARTEFACT_NOT_FOUND
+
+### 9.2 Mutating requests
+
+All non-GET methods against the viewer path must be rejected.
+
+Rejected methods include:
+
+- POST
+- PUT
+- PATCH
+- DELETE
+
+Response 405:
+
+- error: viewer_read_only
+- copy_id: VIEWER_READ_ONLY
+
+### 9.3 Event override requests
+
+Event override requests must not exist in v0.
+
+Any attempted route such as:
+
+/v0/session-artefacts/:artefact_id/events/:event_id/override
+
+must be rejected as read-only.
+
+Response 405:
+
+- error: viewer_read_only
+- copy_id: VIEWER_READ_ONLY
+
+### 9.4 Phase 1 edit requests
+
+Phase 1 edit requests must not exist in the viewer.
+
+Any attempted route such as:
+
+/v0/session-artefacts/:artefact_id/phase1
+
+with a mutating method must be rejected.
+
+Response 405:
+
+- error: viewer_read_only
+- copy_id: VIEWER_READ_ONLY
+
+## 10. UI states
+
+### 10.1 Loading
+
+Copy ID:
+
+- SESSION_ARTEFACT_LOADING
+
+### 10.2 Loaded
+
+The loaded state shows only factual fields.
+
+Copy IDs:
+
+- SESSION_ARTEFACT_VIEWER_TITLE
+- SESSION_STATUS_LABEL
+- WORK_ITEMS_LABEL
+- FACTUAL_EVENTS_LABEL
+- TIMESTAMPS_LABEL
+- SOURCE_DECLARATION_HASH_LABEL
+- ACTIVITY_ID_LABEL
+- EXECUTION_SCOPE_LABEL
+- VIEWER_READ_ONLY
+
+### 10.3 Empty factual events
+
+Copy ID:
+
+- NO_FACTUAL_EVENTS_RECORDED
+
+### 10.4 Access denied
+
+Copy ID:
+
+- ARTEFACT_ACCESS_DENIED
+
+### 10.5 Not found
+
+Copy ID:
+
+- ARTEFACT_NOT_FOUND
+
+### 10.6 Read-only rejection
+
+Copy ID:
+
+- VIEWER_READ_ONLY
+
+## 11. Copy rules
+
+All viewer copy must be registry-backed.
+
+Copy must be:
+
+- neutral
+- factual
+- non-advisory
+- non-comparative
+- non-directional
+- non-judgemental
+
+Copy must not imply:
+
+- athlete quality
+- coach approval
+- event correction
+- future program change
+- athlete state
+- session value
+- hidden scoring
+- hidden analysis
+
+## 12. Reducer and API separation
+
+The viewer must read already-created artefacts.
+
+The viewer must not:
+
+- call engine compilation
+- call substitution logic
+- write runtime events
+- write Phase 1
+- write coach notes
+- write declaration records
+- write link records
+- mutate artefacts
+
+## 13. Acceptance criteria
+
+S37 is accepted only if tests prove:
+
+1. Athlete can view own artefact.
+2. Athlete cannot view another athlete artefact.
+3. Accepted linked coach can view linked athlete artefact.
+4. Unlinked coach access is denied.
+5. Revoked link access is denied.
+6. Invited, rejected, and expired link access is denied.
+7. Coach cannot edit artefacts.
+8. Coach cannot override events.
+9. Coach cannot edit Phase 1 through the viewer.
+10. Viewer response contains only factual fields.
+11. Viewer response includes session status, work items, factual events, timestamps, source declaration hash, activity_id, and execution_scope.
+12. Copy JSON contains neutral registered strings only.
+
+## 14. Final rule
+
+The S37 viewer is a read-only factual projection.
+
+If it edits, overrides, interprets, scores, ranks, recommends, compares, or changes engine behaviour, the build is invalid.

--- a/server/api/__tests__/sessionArtefactViewer.test.ts
+++ b/server/api/__tests__/sessionArtefactViewer.test.ts
@@ -1,0 +1,346 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  assertViewerResponseFactualOnly,
+  getSessionArtefactViewer,
+  handleSessionArtefactViewerRequest,
+  type CoachAthleteLink,
+  type SessionArtefactRecord,
+  type SessionArtefactViewerStore
+} from "../sessionArtefactViewer";
+
+function artefactFixture(): SessionArtefactRecord {
+  return {
+    artefact_id: "artefact_1",
+    session_id: "session_1",
+    athlete_user_id: "athlete_1",
+    session_status: "partial",
+    work_items: [
+      {
+        work_item_id: "work_1",
+        display_order: 1,
+        exercise_token_id: "exercise_token_back_squat",
+        planned_quantity: {
+          sets: 3,
+          reps: 5,
+          load_value: 100,
+          load_unit: "kg"
+        }
+      },
+      {
+        work_item_id: "work_2",
+        display_order: 2,
+        exercise_token_id: "exercise_token_bench_press",
+        planned_quantity: {
+          sets: 3,
+          reps: 5,
+          load_value: 80,
+          load_unit: "kg"
+        }
+      }
+    ],
+    factual_events: [
+      {
+        event_id: "event_1",
+        event_type: "work_completed",
+        work_item_id: "work_1",
+        occurred_at_iso8601: "2026-05-20T10:00:00.000Z",
+        recorded_at_iso8601: "2026-05-20T10:01:00.000Z",
+        factual_quantity: {
+          sets: 3,
+          reps: 5,
+          load_value: 100,
+          load_unit: "kg"
+        }
+      },
+      {
+        event_id: "event_2",
+        event_type: "work_partial",
+        work_item_id: "work_2",
+        occurred_at_iso8601: "2026-05-20T10:10:00.000Z",
+        recorded_at_iso8601: "2026-05-20T10:11:00.000Z",
+        factual_quantity: {
+          sets: 1,
+          reps: 5,
+          load_value: 80,
+          load_unit: "kg"
+        }
+      }
+    ],
+    source_declaration_hash: "sha256_phase1_source_hash",
+    activity_id: "powerlifting",
+    execution_scope: "coach_managed",
+    created_at_iso8601: "2026-05-20T09:00:00.000Z",
+    updated_at_iso8601: "2026-05-20T10:11:00.000Z"
+  };
+}
+
+function storeFixture(links: CoachAthleteLink[] = []): SessionArtefactViewerStore {
+  return {
+    artefacts: [artefactFixture()],
+    coach_athlete_links: links
+  };
+}
+
+test("athlete can view own session artefact", () => {
+  const result = getSessionArtefactViewer(
+    { actor_type: "athlete", user_id: "athlete_1" },
+    "artefact_1",
+    storeFixture()
+  );
+
+  assert.equal(result.status, 200);
+  if (result.status !== 200) return;
+
+  assert.equal(result.body.artefact_id, "artefact_1");
+  assert.equal(result.body.athlete_user_id, "athlete_1");
+  assert.equal(result.body.session_status, "partial");
+  assert.equal(result.body.source_declaration_hash, "sha256_phase1_source_hash");
+  assert.equal(result.body.activity_id, "powerlifting");
+  assert.equal(result.body.execution_scope, "coach_managed");
+  assert.equal(result.body.read_only, true);
+  assert.equal(result.body.work_items.length, 2);
+  assert.equal(result.body.factual_events.length, 2);
+  assertViewerResponseFactualOnly(result.body);
+});
+
+test("athlete cannot view another athlete artefact", () => {
+  const result = getSessionArtefactViewer(
+    { actor_type: "athlete", user_id: "athlete_2" },
+    "artefact_1",
+    storeFixture()
+  );
+
+  assert.equal(result.status, 403);
+  if (result.status !== 403) return;
+
+  assert.equal(result.body.error, "access_denied");
+  assert.equal(result.body.copy_id, "ARTEFACT_ACCESS_DENIED");
+});
+
+test("accepted linked coach can view linked athlete artefact", () => {
+  const result = getSessionArtefactViewer(
+    { actor_type: "coach", user_id: "coach_1" },
+    "artefact_1",
+    storeFixture([
+      {
+        link_id: "link_1",
+        coach_user_id: "coach_1",
+        athlete_user_id: "athlete_1",
+        status: "accepted"
+      }
+    ])
+  );
+
+  assert.equal(result.status, 200);
+  if (result.status !== 200) return;
+
+  assert.equal(result.body.athlete_user_id, "athlete_1");
+  assert.equal(result.body.read_only, true);
+  assertViewerResponseFactualOnly(result.body);
+});
+
+test("unlinked coach access denied", () => {
+  const result = getSessionArtefactViewer(
+    { actor_type: "coach", user_id: "coach_2" },
+    "artefact_1",
+    storeFixture([
+      {
+        link_id: "link_1",
+        coach_user_id: "coach_1",
+        athlete_user_id: "athlete_1",
+        status: "accepted"
+      }
+    ])
+  );
+
+  assert.equal(result.status, 403);
+  if (result.status !== 403) return;
+
+  assert.equal(result.body.error, "access_denied");
+});
+
+test("revoked link access denied and fails closed", () => {
+  const result = getSessionArtefactViewer(
+    { actor_type: "coach", user_id: "coach_1" },
+    "artefact_1",
+    storeFixture([
+      {
+        link_id: "link_1",
+        coach_user_id: "coach_1",
+        athlete_user_id: "athlete_1",
+        status: "revoked"
+      }
+    ])
+  );
+
+  assert.equal(result.status, 403);
+  if (result.status !== 403) return;
+
+  assert.equal(result.body.error, "access_denied");
+});
+
+test("non-accepted coach link states are denied", () => {
+  const deniedStatuses = ["invited", "rejected", "expired"] as const;
+
+  for (const status of deniedStatuses) {
+    const result = getSessionArtefactViewer(
+      { actor_type: "coach", user_id: "coach_1" },
+      "artefact_1",
+      storeFixture([
+        {
+          link_id: `link_${status}`,
+          coach_user_id: "coach_1",
+          athlete_user_id: "athlete_1",
+          status
+        }
+      ])
+    );
+
+    assert.equal(result.status, 403);
+  }
+});
+
+test("missing artefact returns not found", () => {
+  const result = getSessionArtefactViewer(
+    { actor_type: "athlete", user_id: "athlete_1" },
+    "missing_artefact",
+    storeFixture()
+  );
+
+  assert.equal(result.status, 404);
+  if (result.status !== 404) return;
+
+  assert.equal(result.body.error, "artefact_not_found");
+  assert.equal(result.body.copy_id, "ARTEFACT_NOT_FOUND");
+});
+
+test("coach cannot edit artefact through viewer endpoint", () => {
+  const result = handleSessionArtefactViewerRequest(
+    {
+      method: "PATCH",
+      path: "/v0/session-artefacts/artefact_1",
+      actor: { actor_type: "coach", user_id: "coach_1" }
+    },
+    storeFixture([
+      {
+        link_id: "link_1",
+        coach_user_id: "coach_1",
+        athlete_user_id: "athlete_1",
+        status: "accepted"
+      }
+    ])
+  );
+
+  assert.equal(result.status, 405);
+  if (result.status !== 405) return;
+
+  assert.equal(result.body.error, "viewer_read_only");
+  assert.equal(result.body.copy_id, "VIEWER_READ_ONLY");
+});
+
+test("coach cannot override events through viewer endpoint", () => {
+  const result = handleSessionArtefactViewerRequest(
+    {
+      method: "POST",
+      path: "/v0/session-artefacts/artefact_1/events/event_1/override",
+      actor: { actor_type: "coach", user_id: "coach_1" }
+    },
+    storeFixture([
+      {
+        link_id: "link_1",
+        coach_user_id: "coach_1",
+        athlete_user_id: "athlete_1",
+        status: "accepted"
+      }
+    ])
+  );
+
+  assert.equal(result.status, 405);
+  if (result.status !== 405) return;
+
+  assert.equal(result.body.error, "viewer_read_only");
+  assert.equal(result.body.copy_id, "VIEWER_READ_ONLY");
+});
+
+test("coach cannot edit Phase 1 through viewer endpoint", () => {
+  const result = handleSessionArtefactViewerRequest(
+    {
+      method: "PUT",
+      path: "/v0/session-artefacts/artefact_1/phase1",
+      actor: { actor_type: "coach", user_id: "coach_1" }
+    },
+    storeFixture([
+      {
+        link_id: "link_1",
+        coach_user_id: "coach_1",
+        athlete_user_id: "athlete_1",
+        status: "accepted"
+      }
+    ])
+  );
+
+  assert.equal(result.status, 405);
+  if (result.status !== 405) return;
+
+  assert.equal(result.body.error, "viewer_read_only");
+});
+
+test("GET request returns factual fields required by S37", () => {
+  const result = handleSessionArtefactViewerRequest(
+    {
+      method: "GET",
+      path: "/v0/session-artefacts/artefact_1",
+      actor: { actor_type: "athlete", user_id: "athlete_1" }
+    },
+    storeFixture()
+  );
+
+  assert.equal(result.status, 200);
+  if (result.status !== 200) return;
+
+  assert.ok("session_status" in result.body);
+  assert.ok("work_items" in result.body);
+  assert.ok("factual_events" in result.body);
+  assert.ok("created_at_iso8601" in result.body);
+  assert.ok("updated_at_iso8601" in result.body);
+  assert.ok("source_declaration_hash" in result.body);
+  assert.ok("activity_id" in result.body);
+  assert.ok("execution_scope" in result.body);
+  assert.equal(result.body.read_only, true);
+  assertViewerResponseFactualOnly(result.body);
+});
+
+test("viewer response does not expose interpretation fields", () => {
+  const result = getSessionArtefactViewer(
+    { actor_type: "athlete", user_id: "athlete_1" },
+    "artefact_1",
+    storeFixture()
+  );
+
+  assert.equal(result.status, 200);
+  if (result.status !== 200) return;
+
+  const serialised = JSON.stringify(result.body).toLowerCase();
+
+  const forbiddenFragments = [
+    "analytics",
+    "trend",
+    "ranking",
+    "readiness",
+    "optimisation",
+    "safety",
+    "compliance",
+    "outcome",
+    "recommendation",
+    "override"
+  ];
+
+  for (const fragment of forbiddenFragments) {
+    assert.equal(
+      serialised.includes(fragment),
+      false,
+      `viewer response must not contain ${fragment}`
+    );
+  }
+});

--- a/server/api/sessionArtefactViewer.ts
+++ b/server/api/sessionArtefactViewer.ts
@@ -1,0 +1,305 @@
+export type ViewerActorType = "athlete" | "coach";
+
+export type ViewerActorContext = {
+  actor_type: ViewerActorType;
+  user_id: string;
+};
+
+export type CoachAthleteLinkStatus =
+  | "invited"
+  | "accepted"
+  | "revoked"
+  | "expired"
+  | "rejected";
+
+export type CoachAthleteLink = {
+  link_id: string;
+  coach_user_id: string;
+  athlete_user_id: string;
+  status: CoachAthleteLinkStatus;
+};
+
+export type SessionStatus =
+  | "planned"
+  | "in_progress"
+  | "completed"
+  | "stopped"
+  | "partial";
+
+export type ExecutionScope = "individual" | "coach_managed";
+
+export type QuantityUnit = "kg" | "lb" | "bodyweight" | "none";
+
+export type FactualQuantity = {
+  sets?: number;
+  reps?: number;
+  load_value?: number;
+  load_unit?: QuantityUnit;
+  duration_seconds?: number;
+  distance_meters?: number;
+};
+
+export type SessionArtefactWorkItem = {
+  work_item_id: string;
+  display_order: number;
+  exercise_token_id: string;
+  planned_quantity: FactualQuantity;
+};
+
+export type SessionArtefactFactualEventType =
+  | "work_completed"
+  | "work_skipped"
+  | "work_partial";
+
+export type SessionArtefactFactualEvent = {
+  event_id: string;
+  event_type: SessionArtefactFactualEventType;
+  work_item_id: string;
+  occurred_at_iso8601: string;
+  recorded_at_iso8601: string;
+  factual_quantity: FactualQuantity;
+};
+
+export type SessionArtefactRecord = {
+  artefact_id: string;
+  session_id: string;
+  athlete_user_id: string;
+  session_status: SessionStatus;
+  work_items: SessionArtefactWorkItem[];
+  factual_events: SessionArtefactFactualEvent[];
+  source_declaration_hash: string;
+  activity_id: string;
+  execution_scope: ExecutionScope;
+  created_at_iso8601: string;
+  updated_at_iso8601: string;
+};
+
+export type SessionArtefactViewerCopyId =
+  | "SESSION_ARTEFACT_VIEWER_TITLE"
+  | "SESSION_STATUS_LABEL"
+  | "WORK_ITEMS_LABEL"
+  | "FACTUAL_EVENTS_LABEL"
+  | "TIMESTAMPS_LABEL"
+  | "SOURCE_DECLARATION_HASH_LABEL"
+  | "ACTIVITY_ID_LABEL"
+  | "EXECUTION_SCOPE_LABEL"
+  | "VIEWER_READ_ONLY";
+
+export type SessionArtefactViewerResponse = {
+  artefact_id: string;
+  session_id: string;
+  athlete_user_id: string;
+  session_status: SessionStatus;
+  work_items: SessionArtefactWorkItem[];
+  factual_events: SessionArtefactFactualEvent[];
+  source_declaration_hash: string;
+  activity_id: string;
+  execution_scope: ExecutionScope;
+  created_at_iso8601: string;
+  updated_at_iso8601: string;
+  read_only: true;
+  copy_ids: SessionArtefactViewerCopyId[];
+};
+
+export type SessionArtefactApiError =
+  | {
+      error: "access_denied";
+      copy_id: "ARTEFACT_ACCESS_DENIED";
+    }
+  | {
+      error: "artefact_not_found";
+      copy_id: "ARTEFACT_NOT_FOUND";
+    }
+  | {
+      error: "viewer_read_only";
+      copy_id: "VIEWER_READ_ONLY";
+    }
+  | {
+      error: "invalid_request";
+      copy_id: "ARTEFACT_ACCESS_DENIED";
+    };
+
+export type ApiResult<T> =
+  | {
+      status: 200;
+      body: T;
+    }
+  | {
+      status: 403 | 404 | 405 | 400;
+      body: SessionArtefactApiError;
+    };
+
+export type SessionArtefactViewerStore = {
+  artefacts: readonly SessionArtefactRecord[];
+  coach_athlete_links: readonly CoachAthleteLink[];
+};
+
+export type SessionArtefactApiRequest = {
+  method: "GET" | "POST" | "PUT" | "PATCH" | "DELETE";
+  path: string;
+  actor: ViewerActorContext;
+};
+
+const VIEWER_COPY_IDS: SessionArtefactViewerCopyId[] = [
+  "SESSION_ARTEFACT_VIEWER_TITLE",
+  "SESSION_STATUS_LABEL",
+  "WORK_ITEMS_LABEL",
+  "FACTUAL_EVENTS_LABEL",
+  "TIMESTAMPS_LABEL",
+  "SOURCE_DECLARATION_HASH_LABEL",
+  "ACTIVITY_ID_LABEL",
+  "EXECUTION_SCOPE_LABEL",
+  "VIEWER_READ_ONLY"
+];
+
+const ALLOWED_VIEWER_RESPONSE_KEYS = [
+  "artefact_id",
+  "session_id",
+  "athlete_user_id",
+  "session_status",
+  "work_items",
+  "factual_events",
+  "source_declaration_hash",
+  "activity_id",
+  "execution_scope",
+  "created_at_iso8601",
+  "updated_at_iso8601",
+  "read_only",
+  "copy_ids"
+];
+
+export function canViewSessionArtefact(
+  actor: ViewerActorContext,
+  artefact: SessionArtefactRecord,
+  links: readonly CoachAthleteLink[]
+): boolean {
+  if (actor.actor_type === "athlete") {
+    return actor.user_id === artefact.athlete_user_id;
+  }
+
+  if (actor.actor_type === "coach") {
+    return links.some((link) =>
+      link.coach_user_id === actor.user_id &&
+      link.athlete_user_id === artefact.athlete_user_id &&
+      link.status === "accepted"
+    );
+  }
+
+  return false;
+}
+
+export function getSessionArtefactViewer(
+  actor: ViewerActorContext,
+  artefact_id: string,
+  store: SessionArtefactViewerStore
+): ApiResult<SessionArtefactViewerResponse> {
+  const artefact = store.artefacts.find((candidate) => candidate.artefact_id === artefact_id);
+
+  if (!artefact) {
+    return {
+      status: 404,
+      body: {
+        error: "artefact_not_found",
+        copy_id: "ARTEFACT_NOT_FOUND"
+      }
+    };
+  }
+
+  if (!canViewSessionArtefact(actor, artefact, store.coach_athlete_links)) {
+    return {
+      status: 403,
+      body: {
+        error: "access_denied",
+        copy_id: "ARTEFACT_ACCESS_DENIED"
+      }
+    };
+  }
+
+  return {
+    status: 200,
+    body: toViewerResponse(artefact)
+  };
+}
+
+export function handleSessionArtefactViewerRequest(
+  request: SessionArtefactApiRequest,
+  store: SessionArtefactViewerStore
+): ApiResult<SessionArtefactViewerResponse> {
+  const artefactId = parseArtefactIdFromPath(request.path);
+
+  if (!artefactId) {
+    return {
+      status: 400,
+      body: {
+        error: "invalid_request",
+        copy_id: "ARTEFACT_ACCESS_DENIED"
+      }
+    };
+  }
+
+  if (request.method !== "GET") {
+    return {
+      status: 405,
+      body: {
+        error: "viewer_read_only",
+        copy_id: "VIEWER_READ_ONLY"
+      }
+    };
+  }
+
+  return getSessionArtefactViewer(request.actor, artefactId, store);
+}
+
+export function parseArtefactIdFromPath(path: string): string | null {
+  const match = /^\/v0\/session-artefacts\/([^/]+)(?:\/.*)?$/.exec(path);
+  if (!match) return null;
+  return decodeURIComponent(match[1]);
+}
+
+export function toViewerResponse(
+  artefact: SessionArtefactRecord
+): SessionArtefactViewerResponse {
+  return {
+    artefact_id: artefact.artefact_id,
+    session_id: artefact.session_id,
+    athlete_user_id: artefact.athlete_user_id,
+    session_status: artefact.session_status,
+    work_items: artefact.work_items.map((item) => ({
+      work_item_id: item.work_item_id,
+      display_order: item.display_order,
+      exercise_token_id: item.exercise_token_id,
+      planned_quantity: { ...item.planned_quantity }
+    })),
+    factual_events: artefact.factual_events.map((event) => ({
+      event_id: event.event_id,
+      event_type: event.event_type,
+      work_item_id: event.work_item_id,
+      occurred_at_iso8601: event.occurred_at_iso8601,
+      recorded_at_iso8601: event.recorded_at_iso8601,
+      factual_quantity: { ...event.factual_quantity }
+    })),
+    source_declaration_hash: artefact.source_declaration_hash,
+    activity_id: artefact.activity_id,
+    execution_scope: artefact.execution_scope,
+    created_at_iso8601: artefact.created_at_iso8601,
+    updated_at_iso8601: artefact.updated_at_iso8601,
+    read_only: true,
+    copy_ids: [...VIEWER_COPY_IDS]
+  };
+}
+
+export function assertViewerResponseFactualOnly(
+  response: SessionArtefactViewerResponse
+): true {
+  for (const key of Object.keys(response)) {
+    if (!ALLOWED_VIEWER_RESPONSE_KEYS.includes(key)) {
+      throw new Error(`Unexpected viewer response key: ${key}`);
+    }
+  }
+
+  if (response.read_only !== true) {
+    throw new Error("Viewer response must be read-only.");
+  }
+
+  return true;
+}

--- a/ui/copy/session_artefact_viewer_copy.json
+++ b/ui/copy/session_artefact_viewer_copy.json
@@ -1,0 +1,73 @@
+{
+  "schema_version": "kolosseum.copy.session_artefact_viewer.v1.0.0",
+  "engine_compatibility": "EB2-1.0.0",
+  "scope": "v0_session_artefact_viewer",
+  "copy_surface_id": "session_artefact_viewer",
+  "strings": [
+    {
+      "copy_id": "SESSION_ARTEFACT_VIEWER_TITLE",
+      "copy_text": "Session artefact",
+      "parameters": []
+    },
+    {
+      "copy_id": "SESSION_ARTEFACT_LOADING",
+      "copy_text": "Loading session artefact.",
+      "parameters": []
+    },
+    {
+      "copy_id": "SESSION_STATUS_LABEL",
+      "copy_text": "Session status",
+      "parameters": []
+    },
+    {
+      "copy_id": "WORK_ITEMS_LABEL",
+      "copy_text": "Work items",
+      "parameters": []
+    },
+    {
+      "copy_id": "FACTUAL_EVENTS_LABEL",
+      "copy_text": "Recorded events",
+      "parameters": []
+    },
+    {
+      "copy_id": "TIMESTAMPS_LABEL",
+      "copy_text": "Timestamps",
+      "parameters": []
+    },
+    {
+      "copy_id": "SOURCE_DECLARATION_HASH_LABEL",
+      "copy_text": "Source declaration hash",
+      "parameters": []
+    },
+    {
+      "copy_id": "ACTIVITY_ID_LABEL",
+      "copy_text": "Activity ID",
+      "parameters": []
+    },
+    {
+      "copy_id": "EXECUTION_SCOPE_LABEL",
+      "copy_text": "Execution scope",
+      "parameters": []
+    },
+    {
+      "copy_id": "NO_FACTUAL_EVENTS_RECORDED",
+      "copy_text": "No recorded events.",
+      "parameters": []
+    },
+    {
+      "copy_id": "ARTEFACT_ACCESS_DENIED",
+      "copy_text": "This artefact is not available.",
+      "parameters": []
+    },
+    {
+      "copy_id": "ARTEFACT_NOT_FOUND",
+      "copy_text": "Artefact not found.",
+      "parameters": []
+    },
+    {
+      "copy_id": "VIEWER_READ_ONLY",
+      "copy_text": "Viewer is read-only.",
+      "parameters": []
+    }
+  ]
+}


### PR DESCRIPTION
Adds S37 session artefact viewer as a read-only factual projection. Includes viewer contract, permission matrix, API contract, neutral copy JSON, and tests for athlete access, linked coach access, denied unlinked/revoked access, and blocked edit/override/Phase 1 mutation routes.