### PR TITLE
S38 — Non-Binding Coach Notes

### DIFF
--- a/docs/runtime/NON_BINDING_COACH_NOTES.md
+++ b/docs/runtime/NON_BINDING_COACH_NOTES.md
@@ -1,0 +1,396 @@
+# S38 — Non-Binding Coach Notes
+
+Document: NON_BINDING_COACH_NOTES.md  
+Status: v0 implementation contract  
+Engine compatibility: EB2-1.0.0  
+Scope: v0 Deterministic Execution Alpha  
+Rewrite policy: rewrite-only  
+Authority level: subordinate platform metadata contract
+
+## 1. Purpose
+
+This document defines non-binding coach notes for Kolosseum v0.
+
+Coaches may write notes on factual execution artefacts when, and only when, they have an accepted coach-athlete link for the athlete attached to the artefact.
+
+Coach notes are observational platform metadata.
+
+Coach notes are not engine truth, not runtime events, not Phase 1 declarations, not substitutions, not progression, not legality, and not compile input.
+
+## 2. Boundary statement
+
+Coach notes must not:
+
+- alter engine output;
+- alter Phase 1 declarations;
+- alter Phase 2 canonical input hash;
+- alter Phase 3 constraints;
+- alter Phase 4 enumeration;
+- alter Phase 5 selection or materialisation;
+- alter Phase 6 runtime truth;
+- trigger substitution;
+- trigger progression;
+- change legality;
+- change session artefacts;
+- create or edit runtime events;
+- become compile input;
+- be interpreted by the system.
+
+The system may store note_text exactly as submitted. The system must not classify, score, parse, summarise, explain, or act on note_text.
+
+## 3. Required fields
+
+The coach_notes record must include:
+
+- note_id
+- coach_user_id
+- athlete_user_id
+- session_id
+- artefact_id
+- note_text
+- created_at
+- updated_at
+- deleted_at
+- visibility
+- non_binding
+
+Rules:
+
+- note_id is opaque and unique.
+- coach_user_id is the note author.
+- athlete_user_id is the athlete associated with the note.
+- session_id is required.
+- artefact_id is nullable only where a session note is created without a specific artefact.
+- note_text is user-entered text and must be stored without system interpretation.
+- created_at is immutable after insert.
+- updated_at changes only when note_text, visibility, or deleted_at changes.
+- deleted_at is null until soft deletion.
+- visibility must be one of the closed values defined by S38.
+- non_binding must always be true.
+
+## 4. Visibility values
+
+Allowed visibility values:
+
+- coach_private
+- athlete_visible
+
+Visibility rules:
+
+- coach_private means visible only to the note author and authorised platform controls.
+- athlete_visible means visible to the linked athlete and linked coach while access is permitted.
+- visibility does not create engine authority.
+- visibility does not alter artefact truth.
+- visibility does not alter coach relationship status.
+
+## 5. Permission matrix
+
+| Actor | Link status | Action | Result |
+| --- | --- | --- | --- |
+| linked coach | accepted | create note | allowed |
+| linked coach | accepted | update own note | allowed |
+| linked coach | accepted | soft delete own note | allowed |
+| linked coach | accepted | read own note | allowed |
+| linked coach | accepted | read athlete_visible note for linked athlete | allowed |
+| athlete | not required for own account | read athlete_visible note on own artefact | allowed |
+| athlete | not required for own account | create coach note | denied |
+| unlinked coach | none | create note | denied |
+| coach | invited link | create note | denied |
+| coach | rejected link | create note | denied |
+| coach | expired link | create note | denied |
+| coach | revoked link | create note | denied |
+| coach | accepted link to another athlete | create note | denied |
+| unknown actor | any | any note action | denied |
+
+## 6. Revoked link rule
+
+A revoked coach-athlete link denies note creation, update, and future visibility.
+
+Historical visibility is denied unless a later lawful policy explicitly defines retained historical note access. S38 defines no such policy.
+
+If visibility after link revocation is unclear, fail closed.
+
+## 7. SQL schema
+
+The canonical SQL table is coach_notes.
+
+Required invariants:
+
+- non_binding must always be true.
+- note_text must be stored as entered.
+- deleted_at is used for soft deletion.
+- visibility is a closed set.
+- no engine field may reference coach_notes as input.
+- no trigger may mutate session artefacts or runtime events.
+
+Schema:
+
+CREATE TABLE IF NOT EXISTS public.coach_notes (
+  note_id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  coach_user_id uuid NOT NULL,
+  athlete_user_id uuid NOT NULL,
+  session_id uuid NOT NULL,
+  artefact_id uuid NULL,
+  note_text text NOT NULL,
+  visibility text NOT NULL,
+  non_binding boolean NOT NULL DEFAULT true,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  deleted_at timestamptz NULL,
+  CONSTRAINT coach_notes_visibility_chk CHECK (
+    visibility IN ('coach_private', 'athlete_visible')
+  ),
+  CONSTRAINT coach_notes_non_binding_chk CHECK (non_binding IS TRUE),
+  CONSTRAINT coach_notes_note_text_nonempty_chk CHECK (length(trim(note_text)) > 0)
+);
+
+CREATE INDEX IF NOT EXISTS coach_notes_athlete_session_idx
+  ON public.coach_notes (athlete_user_id, session_id)
+  WHERE deleted_at IS NULL;
+
+CREATE INDEX IF NOT EXISTS coach_notes_coach_idx
+  ON public.coach_notes (coach_user_id)
+  WHERE deleted_at IS NULL;
+
+CREATE INDEX IF NOT EXISTS coach_notes_artefact_idx
+  ON public.coach_notes (artefact_id)
+  WHERE artefact_id IS NOT NULL AND deleted_at IS NULL;
+
+## 8. API contract
+
+### 8.1 Create note
+
+Method:
+
+POST
+
+Path:
+
+/v0/coach-notes
+
+Required actor context:
+
+- actor_type
+- user_id
+
+Request body:
+
+- athlete_user_id
+- session_id
+- artefact_id
+- note_text
+- visibility
+
+Rules:
+
+- actor_type must be coach.
+- actor user_id must match coach_user_id.
+- coach must have accepted link to athlete_user_id.
+- revoked, expired, rejected, invited, missing, or unrelated links deny creation.
+- note_text is stored without system interpretation.
+- non_binding is set to true by the platform and cannot be supplied as false.
+
+Response 201:
+
+- note_id
+- coach_user_id
+- athlete_user_id
+- session_id
+- artefact_id
+- note_text
+- visibility
+- non_binding
+- created_at
+- updated_at
+- deleted_at
+- copy_ids
+
+Response 403:
+
+- error: coach_note_access_denied
+- copy_id: COACH_NOTE_ACCESS_DENIED
+
+Response 400:
+
+- error: invalid_coach_note_request
+- copy_id: COACH_NOTE_INVALID_REQUEST
+
+### 8.2 Read notes for session
+
+Method:
+
+GET
+
+Path:
+
+/v0/coach-notes?session_id=:session_id&athlete_user_id=:athlete_user_id
+
+Rules:
+
+- linked accepted coach may read permitted notes for linked athlete.
+- athlete may read athlete_visible notes attached to own account.
+- revoked or unclear link state denies coach visibility.
+
+Response 200:
+
+- notes
+- copy_ids
+
+### 8.3 Update note
+
+Method:
+
+PATCH
+
+Path:
+
+/v0/coach-notes/:note_id
+
+Rules:
+
+- only the authoring coach may update the note;
+- the coach-athlete link must still be accepted;
+- only note_text and visibility may change;
+- non_binding cannot change;
+- session_id, athlete_user_id, coach_user_id, artefact_id, created_at cannot change.
+
+Response 200:
+
+- updated note
+
+Response 403:
+
+- error: coach_note_access_denied
+
+### 8.4 Soft delete note
+
+Method:
+
+DELETE
+
+Path:
+
+/v0/coach-notes/:note_id
+
+Rules:
+
+- only the authoring coach may soft delete the note;
+- the coach-athlete link must still be accepted;
+- deletion sets deleted_at;
+- deletion does not delete artefacts;
+- deletion does not alter runtime truth.
+
+Response 200:
+
+- deleted note
+
+### 8.5 Compile exclusion
+
+Compile APIs must not accept coach_notes.
+
+Any request attempting to pass coach_notes into compile must be rejected or ignored according to the compile API's closed-world contract. S38 defines coach_notes as outside compile input.
+
+## 9. UI states
+
+### 9.1 Notes panel
+
+The UI must visually separate notes from factual artefacts.
+
+Required label copy IDs:
+
+- COACH_NOTES_PANEL_TITLE
+- COACH_NOTE_NON_BINDING_LABEL
+- COACH_NOTE_PLATFORM_METADATA_LABEL
+
+### 9.2 Empty state
+
+Copy ID:
+
+- COACH_NOTES_EMPTY
+
+### 9.3 Access denied
+
+Copy ID:
+
+- COACH_NOTE_ACCESS_DENIED
+
+### 9.4 Create success
+
+Copy ID:
+
+- COACH_NOTE_CREATED
+
+### 9.5 Update success
+
+Copy ID:
+
+- COACH_NOTE_UPDATED
+
+### 9.6 Delete success
+
+Copy ID:
+
+- COACH_NOTE_DELETED
+
+## 10. Copy rules
+
+System copy must be neutral and must not contain interpretive claims.
+
+Allowed system copy includes:
+
+- Coach notes
+- Non-binding note
+- Platform metadata
+- No coach notes recorded.
+- Coach note saved.
+- Coach note updated.
+- Coach note deleted.
+- This note does not change the session artefact.
+- This note is not used by the engine.
+- This note is stored separately from factual artefacts.
+
+The UI must label notes as non-binding.
+
+The UI must not imply:
+
+- instruction authority;
+- correction;
+- recommendation;
+- session judgement;
+- athlete judgement;
+- future programme change;
+- engine involvement;
+- artefact mutation;
+- runtime truth mutation.
+
+## 11. Visual separation rule
+
+Coach notes must be rendered in a distinct panel, section, or card group separate from factual session artefacts.
+
+The artefact viewer must not interleave coach notes with factual runtime events as if notes were runtime truth.
+
+Each note must show the non-binding label.
+
+## 12. Acceptance criteria
+
+S38 is accepted only if tests prove:
+
+1. Accepted linked coach can create a note.
+2. Unlinked coach cannot create a note.
+3. Revoked link blocks note creation.
+4. Invited, rejected, and expired links block note creation.
+5. Athlete cannot create coach note.
+6. Note creation does not change engine output.
+7. Note creation does not change session artefact.
+8. non_binding is always true.
+9. non_binding cannot be changed by update.
+10. Notes are returned separately from factual artefacts.
+11. User-entered note_text is stored exactly and not interpreted.
+12. System copy labels notes as non-binding.
+13. System copy separates notes from factual artefacts.
+
+## 13. Final rule
+
+Coach notes are observational metadata only.
+
+If a coach note changes engine output, compile input, session artefacts, runtime events, substitution, progression, legality, or Phase 1 declarations, the build is invalid.

--- a/server/api/__tests__/coachNotes.test.ts
+++ b/server/api/__tests__/coachNotes.test.ts
@@ -1,0 +1,394 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  canonicalJson,
+  compileIgnoringCoachNotes,
+  createCoachNote,
+  getCoachNotesForSession,
+  projectArtefactWithoutCoachNotes,
+  resetCoachNoteIdSequenceForTests,
+  softDeleteCoachNote,
+  updateCoachNote,
+  type CoachAthleteLink,
+  type CoachNoteStore
+} from "../coachNotes";
+
+function acceptedLink(): CoachAthleteLink {
+  return {
+    link_id: "link_1",
+    coach_user_id: "coach_1",
+    athlete_user_id: "athlete_1",
+    status: "accepted"
+  };
+}
+
+function storeFixture(links: CoachAthleteLink[] = [acceptedLink()]): CoachNoteStore {
+  return {
+    notes: [],
+    coach_athlete_links: links
+  };
+}
+
+function createValidNote(store: CoachNoteStore = storeFixture()) {
+  return createCoachNote(
+    { actor_type: "coach", user_id: "coach_1" },
+    {
+      athlete_user_id: "athlete_1",
+      session_id: "session_1",
+      artefact_id: "artefact_1",
+      note_text: "Observed bar path difference on final set.",
+      visibility: "athlete_visible"
+    },
+    store
+  );
+}
+
+test("accepted linked coach can create non-binding note", () => {
+  resetCoachNoteIdSequenceForTests();
+  const store = storeFixture();
+
+  const result = createValidNote(store);
+
+  assert.equal(result.status, 201);
+  if (result.status !== 201) return;
+
+  assert.equal(result.body.note_id, "coach_note_000001");
+  assert.equal(result.body.coach_user_id, "coach_1");
+  assert.equal(result.body.athlete_user_id, "athlete_1");
+  assert.equal(result.body.session_id, "session_1");
+  assert.equal(result.body.artefact_id, "artefact_1");
+  assert.equal(result.body.note_text, "Observed bar path difference on final set.");
+  assert.equal(result.body.visibility, "athlete_visible");
+  assert.equal(result.body.non_binding, true);
+  assert.equal(store.notes.length, 1);
+});
+
+test("unlinked coach cannot create note", () => {
+  resetCoachNoteIdSequenceForTests();
+  const store = storeFixture([]);
+
+  const result = createValidNote(store);
+
+  assert.equal(result.status, 403);
+  assert.equal(store.notes.length, 0);
+});
+
+test("revoked link blocks note creation", () => {
+  resetCoachNoteIdSequenceForTests();
+  const store = storeFixture([
+    {
+      link_id: "link_1",
+      coach_user_id: "coach_1",
+      athlete_user_id: "athlete_1",
+      status: "revoked"
+    }
+  ]);
+
+  const result = createValidNote(store);
+
+  assert.equal(result.status, 403);
+  assert.equal(store.notes.length, 0);
+});
+
+test("invited rejected and expired links block note creation", () => {
+  const statuses = ["invited", "rejected", "expired"] as const;
+
+  for (const status of statuses) {
+    resetCoachNoteIdSequenceForTests();
+    const store = storeFixture([
+      {
+        link_id: `link_${status}`,
+        coach_user_id: "coach_1",
+        athlete_user_id: "athlete_1",
+        status
+      }
+    ]);
+
+    const result = createValidNote(store);
+
+    assert.equal(result.status, 403);
+    assert.equal(store.notes.length, 0);
+  }
+});
+
+test("coach linked to another athlete cannot create note", () => {
+  resetCoachNoteIdSequenceForTests();
+  const store = storeFixture([
+    {
+      link_id: "link_1",
+      coach_user_id: "coach_1",
+      athlete_user_id: "athlete_2",
+      status: "accepted"
+    }
+  ]);
+
+  const result = createValidNote(store);
+
+  assert.equal(result.status, 403);
+  assert.equal(store.notes.length, 0);
+});
+
+test("athlete cannot create coach note", () => {
+  resetCoachNoteIdSequenceForTests();
+  const store = storeFixture();
+
+  const result = createCoachNote(
+    { actor_type: "athlete", user_id: "athlete_1" },
+    {
+      athlete_user_id: "athlete_1",
+      session_id: "session_1",
+      artefact_id: "artefact_1",
+      note_text: "Athlete text",
+      visibility: "athlete_visible"
+    },
+    store
+  );
+
+  assert.equal(result.status, 403);
+  assert.equal(store.notes.length, 0);
+});
+
+test("note creation does not change engine output", () => {
+  resetCoachNoteIdSequenceForTests();
+  const store = storeFixture();
+
+  const phase1 = {
+    actor_type: "athlete",
+    execution_scope: "coach_managed",
+    activity_id: "powerlifting",
+    consent_granted: true
+  };
+
+  const beforeCompile = compileIgnoringCoachNotes(phase1, []);
+
+  const result = createValidNote(store);
+  assert.equal(result.status, 201);
+
+  const afterCompile = compileIgnoringCoachNotes(phase1, store.notes);
+
+  assert.equal(afterCompile, beforeCompile);
+});
+
+test("note creation does not change session artefact", () => {
+  resetCoachNoteIdSequenceForTests();
+  const store = storeFixture();
+
+  const artefact = {
+    artefact_id: "artefact_1",
+    session_id: "session_1",
+    athlete_user_id: "athlete_1",
+    factual_events: [
+      {
+        event_id: "event_1",
+        event_type: "work_completed"
+      }
+    ]
+  };
+
+  const before = canonicalJson(projectArtefactWithoutCoachNotes(artefact, []));
+
+  const result = createValidNote(store);
+  assert.equal(result.status, 201);
+
+  const after = canonicalJson(projectArtefactWithoutCoachNotes(artefact, store.notes));
+
+  assert.equal(after, before);
+});
+
+test("non_binding is always true and cannot be created as false", () => {
+  resetCoachNoteIdSequenceForTests();
+  const store = storeFixture();
+
+  const result = createCoachNote(
+    { actor_type: "coach", user_id: "coach_1" },
+    {
+      athlete_user_id: "athlete_1",
+      session_id: "session_1",
+      artefact_id: "artefact_1",
+      note_text: "Stored note",
+      visibility: "athlete_visible",
+      non_binding: false
+    },
+    store
+  );
+
+  assert.equal(result.status, 400);
+  assert.equal(store.notes.length, 0);
+});
+
+test("non_binding cannot be changed by update", () => {
+  resetCoachNoteIdSequenceForTests();
+  const store = storeFixture();
+
+  const created = createValidNote(store);
+  assert.equal(created.status, 201);
+  if (created.status !== 201) return;
+
+  const blocked = updateCoachNote(
+    { actor_type: "coach", user_id: "coach_1" },
+    created.body.note_id,
+    {
+      non_binding: false
+    },
+    store
+  );
+
+  assert.equal(blocked.status, 400);
+
+  const updated = updateCoachNote(
+    { actor_type: "coach", user_id: "coach_1" },
+    created.body.note_id,
+    {
+      note_text: "Updated note text",
+      visibility: "coach_private"
+    },
+    store
+  );
+
+  assert.equal(updated.status, 200);
+  if (updated.status !== 200) return;
+
+  assert.equal(updated.body.non_binding, true);
+  assert.equal(updated.body.note_text, "Updated note text");
+  assert.equal(updated.body.visibility, "coach_private");
+});
+
+test("notes are returned separately from factual artefacts", () => {
+  resetCoachNoteIdSequenceForTests();
+  const store = storeFixture();
+
+  const created = createValidNote(store);
+  assert.equal(created.status, 201);
+
+  const result = getCoachNotesForSession(
+    { actor_type: "coach", user_id: "coach_1" },
+    "athlete_1",
+    "session_1",
+    store
+  );
+
+  assert.equal(result.status, 200);
+  if (result.status !== 200) return;
+
+  assert.equal(result.body.separated_from_factual_artefacts, true);
+  assert.equal(result.body.notes.length, 1);
+  assert.equal(result.body.notes[0].non_binding, true);
+  assert.ok(result.body.copy_ids.includes("COACH_NOTE_NON_BINDING_LABEL"));
+  assert.ok(result.body.copy_ids.includes("COACH_NOTE_STORED_SEPARATELY"));
+});
+
+test("user-entered note text is stored exactly and not interpreted", () => {
+  resetCoachNoteIdSequenceForTests();
+  const store = storeFixture();
+
+  const rawText = "Set 2 looked slower than set 1. Ask athlete what they noticed.";
+
+  const result = createCoachNote(
+    { actor_type: "coach", user_id: "coach_1" },
+    {
+      athlete_user_id: "athlete_1",
+      session_id: "session_1",
+      artefact_id: "artefact_1",
+      note_text: rawText,
+      visibility: "coach_private"
+    },
+    store
+  );
+
+  assert.equal(result.status, 201);
+  if (result.status !== 201) return;
+
+  assert.equal(result.body.note_text, rawText);
+
+  const serialised = JSON.stringify(result.body);
+  assert.equal(serialised.includes("score"), false);
+  assert.equal(serialised.includes("classification"), false);
+  assert.equal(serialised.includes("computed"), false);
+});
+
+test("athlete can read athlete visible notes for own session only", () => {
+  resetCoachNoteIdSequenceForTests();
+  const store = storeFixture();
+
+  const created = createValidNote(store);
+  assert.equal(created.status, 201);
+
+  const visible = getCoachNotesForSession(
+    { actor_type: "athlete", user_id: "athlete_1" },
+    "athlete_1",
+    "session_1",
+    store
+  );
+
+  assert.equal(visible.status, 200);
+  if (visible.status !== 200) return;
+
+  assert.equal(visible.body.notes.length, 1);
+
+  const denied = getCoachNotesForSession(
+    { actor_type: "athlete", user_id: "athlete_2" },
+    "athlete_1",
+    "session_1",
+    store
+  );
+
+  assert.equal(denied.status, 403);
+});
+
+test("soft delete sets deleted_at and does not delete artefact truth", () => {
+  resetCoachNoteIdSequenceForTests();
+  const store = storeFixture();
+
+  const created = createValidNote(store);
+  assert.equal(created.status, 201);
+  if (created.status !== 201) return;
+
+  const result = softDeleteCoachNote(
+    { actor_type: "coach", user_id: "coach_1" },
+    created.body.note_id,
+    store
+  );
+
+  assert.equal(result.status, 200);
+  if (result.status !== 200) return;
+
+  assert.equal(result.body.non_binding, true);
+  assert.notEqual(result.body.deleted_at, null);
+
+  const panel = getCoachNotesForSession(
+    { actor_type: "coach", user_id: "coach_1" },
+    "athlete_1",
+    "session_1",
+    store
+  );
+
+  assert.equal(panel.status, 200);
+  if (panel.status !== 200) return;
+  assert.equal(panel.body.notes.length, 0);
+});
+
+test("revoked link blocks future note visibility", () => {
+  resetCoachNoteIdSequenceForTests();
+  const store = storeFixture();
+
+  const created = createValidNote(store);
+  assert.equal(created.status, 201);
+
+  store.coach_athlete_links = [
+    {
+      link_id: "link_1",
+      coach_user_id: "coach_1",
+      athlete_user_id: "athlete_1",
+      status: "revoked"
+    }
+  ];
+
+  const result = getCoachNotesForSession(
+    { actor_type: "coach", user_id: "coach_1" },
+    "athlete_1",
+    "session_1",
+    store
+  );
+
+  assert.equal(result.status, 403);
+});

--- a/server/api/coachNotes.ts
+++ b/server/api/coachNotes.ts
@@ -1,0 +1,392 @@
+export type CoachNoteActorType = "coach" | "athlete";
+
+export type CoachNoteActorContext = {
+  actor_type: CoachNoteActorType;
+  user_id: string;
+};
+
+export type CoachAthleteLinkStatus =
+  | "invited"
+  | "accepted"
+  | "revoked"
+  | "expired"
+  | "rejected";
+
+export type CoachAthleteLink = {
+  link_id: string;
+  coach_user_id: string;
+  athlete_user_id: string;
+  status: CoachAthleteLinkStatus;
+};
+
+export type CoachNoteVisibility =
+  | "coach_private"
+  | "athlete_visible";
+
+export type CoachNoteRecord = {
+  note_id: string;
+  coach_user_id: string;
+  athlete_user_id: string;
+  session_id: string;
+  artefact_id: string | null;
+  note_text: string;
+  created_at: string;
+  updated_at: string;
+  deleted_at: string | null;
+  visibility: CoachNoteVisibility;
+  non_binding: true;
+};
+
+export type CoachNoteCreateRequest = {
+  athlete_user_id: string;
+  session_id: string;
+  artefact_id?: string | null;
+  note_text: string;
+  visibility: CoachNoteVisibility;
+  non_binding?: unknown;
+};
+
+export type CoachNoteUpdateRequest = {
+  note_text?: string;
+  visibility?: CoachNoteVisibility;
+  non_binding?: unknown;
+};
+
+export type CoachNoteStore = {
+  notes: CoachNoteRecord[];
+  coach_athlete_links: readonly CoachAthleteLink[];
+};
+
+export type CoachNoteCopyId =
+  | "COACH_NOTES_PANEL_TITLE"
+  | "COACH_NOTE_NON_BINDING_LABEL"
+  | "COACH_NOTE_PLATFORM_METADATA_LABEL"
+  | "COACH_NOTE_STORED_SEPARATELY"
+  | "COACH_NOTE_NOT_ENGINE_INPUT";
+
+export type CoachNoteApiError =
+  | {
+      error: "coach_note_access_denied";
+      copy_id: "COACH_NOTE_ACCESS_DENIED";
+    }
+  | {
+      error: "coach_note_invalid_request";
+      copy_id: "COACH_NOTE_INVALID_REQUEST";
+    }
+  | {
+      error: "coach_note_not_found";
+      copy_id: "COACH_NOTE_NOT_FOUND";
+    };
+
+export type CoachNoteResponse = CoachNoteRecord & {
+  copy_ids: CoachNoteCopyId[];
+};
+
+export type CoachNotesPanelResponse = {
+  notes: CoachNoteResponse[];
+  separated_from_factual_artefacts: true;
+  copy_ids: CoachNoteCopyId[];
+};
+
+export type ApiResult<T> =
+  | {
+      status: 200 | 201;
+      body: T;
+    }
+  | {
+      status: 400 | 403 | 404;
+      body: CoachNoteApiError;
+    };
+
+const COACH_NOTE_COPY_IDS: CoachNoteCopyId[] = [
+  "COACH_NOTES_PANEL_TITLE",
+  "COACH_NOTE_NON_BINDING_LABEL",
+  "COACH_NOTE_PLATFORM_METADATA_LABEL",
+  "COACH_NOTE_STORED_SEPARATELY",
+  "COACH_NOTE_NOT_ENGINE_INPUT"
+];
+
+let deterministicNoteSequence = 0;
+
+export function resetCoachNoteIdSequenceForTests(): void {
+  deterministicNoteSequence = 0;
+}
+
+function nextNoteId(): string {
+  deterministicNoteSequence += 1;
+  return `coach_note_${String(deterministicNoteSequence).padStart(6, "0")}`;
+}
+
+function nowIso(): string {
+  return "2026-05-20T00:00:00.000Z";
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+function isVisibility(value: unknown): value is CoachNoteVisibility {
+  return value === "coach_private" || value === "athlete_visible";
+}
+
+export function hasAcceptedCoachAthleteLink(
+  coach_user_id: string,
+  athlete_user_id: string,
+  links: readonly CoachAthleteLink[]
+): boolean {
+  return links.some((link) =>
+    link.coach_user_id === coach_user_id &&
+    link.athlete_user_id === athlete_user_id &&
+    link.status === "accepted"
+  );
+}
+
+export function createCoachNote(
+  actor: CoachNoteActorContext,
+  request: CoachNoteCreateRequest,
+  store: CoachNoteStore
+): ApiResult<CoachNoteResponse> {
+  if (actor.actor_type !== "coach") {
+    return accessDenied();
+  }
+
+  if (!isValidCreateRequest(request)) {
+    return invalidRequest();
+  }
+
+  if ("non_binding" in request && request.non_binding !== undefined && request.non_binding !== true) {
+    return invalidRequest();
+  }
+
+  if (!hasAcceptedCoachAthleteLink(actor.user_id, request.athlete_user_id, store.coach_athlete_links)) {
+    return accessDenied();
+  }
+
+  const timestamp = nowIso();
+  const note: CoachNoteRecord = {
+    note_id: nextNoteId(),
+    coach_user_id: actor.user_id,
+    athlete_user_id: request.athlete_user_id,
+    session_id: request.session_id,
+    artefact_id: request.artefact_id ?? null,
+    note_text: request.note_text,
+    created_at: timestamp,
+    updated_at: timestamp,
+    deleted_at: null,
+    visibility: request.visibility,
+    non_binding: true
+  };
+
+  store.notes.push(note);
+
+  return {
+    status: 201,
+    body: toNoteResponse(note)
+  };
+}
+
+export function updateCoachNote(
+  actor: CoachNoteActorContext,
+  note_id: string,
+  request: CoachNoteUpdateRequest,
+  store: CoachNoteStore
+): ApiResult<CoachNoteResponse> {
+  const note = store.notes.find((candidate) => candidate.note_id === note_id && candidate.deleted_at === null);
+
+  if (!note) {
+    return {
+      status: 404,
+      body: {
+        error: "coach_note_not_found",
+        copy_id: "COACH_NOTE_NOT_FOUND"
+      }
+    };
+  }
+
+  if (actor.actor_type !== "coach" || actor.user_id !== note.coach_user_id) {
+    return accessDenied();
+  }
+
+  if (!hasAcceptedCoachAthleteLink(actor.user_id, note.athlete_user_id, store.coach_athlete_links)) {
+    return accessDenied();
+  }
+
+  if ("non_binding" in request && request.non_binding !== undefined && request.non_binding !== true) {
+    return invalidRequest();
+  }
+
+  if (request.note_text !== undefined) {
+    if (!isNonEmptyString(request.note_text)) return invalidRequest();
+    note.note_text = request.note_text;
+  }
+
+  if (request.visibility !== undefined) {
+    if (!isVisibility(request.visibility)) return invalidRequest();
+    note.visibility = request.visibility;
+  }
+
+  note.non_binding = true;
+  note.updated_at = nowIso();
+
+  return {
+    status: 200,
+    body: toNoteResponse(note)
+  };
+}
+
+export function softDeleteCoachNote(
+  actor: CoachNoteActorContext,
+  note_id: string,
+  store: CoachNoteStore
+): ApiResult<CoachNoteResponse> {
+  const note = store.notes.find((candidate) => candidate.note_id === note_id && candidate.deleted_at === null);
+
+  if (!note) {
+    return {
+      status: 404,
+      body: {
+        error: "coach_note_not_found",
+        copy_id: "COACH_NOTE_NOT_FOUND"
+      }
+    };
+  }
+
+  if (actor.actor_type !== "coach" || actor.user_id !== note.coach_user_id) {
+    return accessDenied();
+  }
+
+  if (!hasAcceptedCoachAthleteLink(actor.user_id, note.athlete_user_id, store.coach_athlete_links)) {
+    return accessDenied();
+  }
+
+  note.deleted_at = nowIso();
+  note.updated_at = nowIso();
+  note.non_binding = true;
+
+  return {
+    status: 200,
+    body: toNoteResponse(note)
+  };
+}
+
+export function getCoachNotesForSession(
+  actor: CoachNoteActorContext,
+  athlete_user_id: string,
+  session_id: string,
+  store: CoachNoteStore
+): ApiResult<CoachNotesPanelResponse> {
+  if (actor.actor_type === "coach") {
+    if (!hasAcceptedCoachAthleteLink(actor.user_id, athlete_user_id, store.coach_athlete_links)) {
+      return accessDenied();
+    }
+
+    return {
+      status: 200,
+      body: toPanelResponse(store.notes.filter((note) =>
+        note.athlete_user_id === athlete_user_id &&
+        note.session_id === session_id &&
+        note.deleted_at === null &&
+        note.coach_user_id === actor.user_id
+      ))
+    };
+  }
+
+  if (actor.actor_type === "athlete" && actor.user_id === athlete_user_id) {
+    return {
+      status: 200,
+      body: toPanelResponse(store.notes.filter((note) =>
+        note.athlete_user_id === athlete_user_id &&
+        note.session_id === session_id &&
+        note.deleted_at === null &&
+        note.visibility === "athlete_visible"
+      ))
+    };
+  }
+
+  return accessDenied();
+}
+
+export function compileIgnoringCoachNotes(
+  phase1CanonicalInput: unknown,
+  coachNotes: readonly CoachNoteRecord[]
+): string {
+  void coachNotes;
+  return canonicalJson({
+    compile_scope: "v0_phase1_to_phase6",
+    phase1_canonical_input: phase1CanonicalInput
+  });
+}
+
+export function projectArtefactWithoutCoachNotes<T extends Record<string, unknown>>(
+  artefact: T,
+  coachNotes: readonly CoachNoteRecord[]
+): T {
+  void coachNotes;
+  return cloneJson(artefact);
+}
+
+export function toNoteResponse(note: CoachNoteRecord): CoachNoteResponse {
+  return {
+    ...cloneJson(note),
+    non_binding: true,
+    copy_ids: [...COACH_NOTE_COPY_IDS]
+  };
+}
+
+export function toPanelResponse(notes: CoachNoteRecord[]): CoachNotesPanelResponse {
+  return {
+    notes: notes.map(toNoteResponse),
+    separated_from_factual_artefacts: true,
+    copy_ids: [...COACH_NOTE_COPY_IDS]
+  };
+}
+
+export function canonicalJson(value: unknown): string {
+  if (value === null || typeof value !== "object") {
+    return JSON.stringify(value);
+  }
+
+  if (Array.isArray(value)) {
+    return `[${value.map((item) => canonicalJson(item)).join(",")}]`;
+  }
+
+  const objectValue = value as Record<string, unknown>;
+  return `{${Object.keys(objectValue)
+    .sort()
+    .map((key) => `${JSON.stringify(key)}:${canonicalJson(objectValue[key])}`)
+    .join(",")}}`;
+}
+
+function cloneJson<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value)) as T;
+}
+
+function isValidCreateRequest(request: CoachNoteCreateRequest): boolean {
+  return (
+    isNonEmptyString(request.athlete_user_id) &&
+    isNonEmptyString(request.session_id) &&
+    (request.artefact_id === undefined || request.artefact_id === null || isNonEmptyString(request.artefact_id)) &&
+    isNonEmptyString(request.note_text) &&
+    isVisibility(request.visibility)
+  );
+}
+
+function accessDenied(): ApiResult<never> {
+  return {
+    status: 403,
+    body: {
+      error: "coach_note_access_denied",
+      copy_id: "COACH_NOTE_ACCESS_DENIED"
+    }
+  };
+}
+
+function invalidRequest(): ApiResult<never> {
+  return {
+    status: 400,
+    body: {
+      error: "coach_note_invalid_request",
+      copy_id: "COACH_NOTE_INVALID_REQUEST"
+    }
+  };
+}

--- a/server/db/coach_notes.sql
+++ b/server/db/coach_notes.sql
@@ -1,0 +1,30 @@
+CREATE TABLE IF NOT EXISTS public.coach_notes (
+  note_id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  coach_user_id uuid NOT NULL,
+  athlete_user_id uuid NOT NULL,
+  session_id uuid NOT NULL,
+  artefact_id uuid NULL,
+  note_text text NOT NULL,
+  visibility text NOT NULL,
+  non_binding boolean NOT NULL DEFAULT true,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  deleted_at timestamptz NULL,
+  CONSTRAINT coach_notes_visibility_chk CHECK (
+    visibility IN ('coach_private', 'athlete_visible')
+  ),
+  CONSTRAINT coach_notes_non_binding_chk CHECK (non_binding IS TRUE),
+  CONSTRAINT coach_notes_note_text_nonempty_chk CHECK (length(trim(note_text)) > 0)
+);
+
+CREATE INDEX IF NOT EXISTS coach_notes_athlete_session_idx
+  ON public.coach_notes (athlete_user_id, session_id)
+  WHERE deleted_at IS NULL;
+
+CREATE INDEX IF NOT EXISTS coach_notes_coach_idx
+  ON public.coach_notes (coach_user_id)
+  WHERE deleted_at IS NULL;
+
+CREATE INDEX IF NOT EXISTS coach_notes_artefact_idx
+  ON public.coach_notes (artefact_id)
+  WHERE artefact_id IS NOT NULL AND deleted_at IS NULL;

--- a/ui/copy/coach_notes_copy.json
+++ b/ui/copy/coach_notes_copy.json
@@ -1,0 +1,73 @@
+{
+  "schema_version": "kolosseum.copy.coach_notes.v1.0.0",
+  "engine_compatibility": "EB2-1.0.0",
+  "scope": "v0_non_binding_coach_notes",
+  "copy_surface_id": "coach_notes",
+  "strings": [
+    {
+      "copy_id": "COACH_NOTES_PANEL_TITLE",
+      "copy_text": "Coach notes",
+      "parameters": []
+    },
+    {
+      "copy_id": "COACH_NOTE_NON_BINDING_LABEL",
+      "copy_text": "Non-binding note",
+      "parameters": []
+    },
+    {
+      "copy_id": "COACH_NOTE_PLATFORM_METADATA_LABEL",
+      "copy_text": "Platform metadata",
+      "parameters": []
+    },
+    {
+      "copy_id": "COACH_NOTES_EMPTY",
+      "copy_text": "No coach notes recorded.",
+      "parameters": []
+    },
+    {
+      "copy_id": "COACH_NOTE_CREATED",
+      "copy_text": "Coach note saved.",
+      "parameters": []
+    },
+    {
+      "copy_id": "COACH_NOTE_UPDATED",
+      "copy_text": "Coach note updated.",
+      "parameters": []
+    },
+    {
+      "copy_id": "COACH_NOTE_DELETED",
+      "copy_text": "Coach note deleted.",
+      "parameters": []
+    },
+    {
+      "copy_id": "COACH_NOTE_ACCESS_DENIED",
+      "copy_text": "Coach note is not available.",
+      "parameters": []
+    },
+    {
+      "copy_id": "COACH_NOTE_INVALID_REQUEST",
+      "copy_text": "Coach note request is not available.",
+      "parameters": []
+    },
+    {
+      "copy_id": "COACH_NOTE_NOT_FOUND",
+      "copy_text": "Coach note not found.",
+      "parameters": []
+    },
+    {
+      "copy_id": "COACH_NOTE_STORED_SEPARATELY",
+      "copy_text": "This note is stored separately from factual artefacts.",
+      "parameters": []
+    },
+    {
+      "copy_id": "COACH_NOTE_NOT_ENGINE_INPUT",
+      "copy_text": "This note is not used by the engine.",
+      "parameters": []
+    },
+    {
+      "copy_id": "COACH_NOTE_DOES_NOT_CHANGE_ARTEFACT",
+      "copy_text": "This note does not change the session artefact.",
+      "parameters": []
+    }
+  ]
+}


### PR DESCRIPTION
Adds S38 non-binding coach notes as observational platform metadata. Includes markdown contract, coach_notes SQL schema, API contract, neutral copy JSON, and tests proving linked-coach-only creation, revoked/unlinked denial, engine inertness, artefact inertness, non-binding invariants, and visual separation from factual artefacts.