### PR TITLE
Add S39 coach assignment within limits

### DIFF
--- a/db/schema/coach_assignments.sql
+++ b/db/schema/coach_assignments.sql
@@ -1,0 +1,237 @@
+-- S39 — Coach Assignment Within Limits
+-- Platform metadata only. This schema must not create or mutate engine output.
+
+create extension if not exists pgcrypto;
+
+do $$
+begin
+  if not exists (
+    select 1
+    from pg_type
+    where typname = 'coach_assignment_status'
+  ) then
+    create type public.coach_assignment_status as enum (
+      'assigned',
+      'revoked'
+    );
+  end if;
+end
+$$;
+
+create table if not exists public.coach_assignments (
+  assignment_id uuid primary key default gen_random_uuid(),
+
+  coach_user_id uuid not null,
+  athlete_user_id uuid not null,
+  coach_athlete_link_id uuid not null,
+
+  session_id uuid null,
+  compiled_artefact_id uuid null,
+
+  assignment_status public.coach_assignment_status not null default 'assigned',
+
+  assigned_artefact_hash text not null,
+
+  assigned_at timestamptz not null default now(),
+  revoked_at timestamptz null,
+
+  created_by uuid not null,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+
+  constraint coach_assignments_exactly_one_target_chk
+    check (
+      (
+        session_id is not null
+        and compiled_artefact_id is null
+      )
+      or
+      (
+        session_id is null
+        and compiled_artefact_id is not null
+      )
+    ),
+
+  constraint coach_assignments_status_revoked_at_chk
+    check (
+      (
+        assignment_status = 'assigned'
+        and revoked_at is null
+      )
+      or
+      (
+        assignment_status = 'revoked'
+        and revoked_at is not null
+      )
+    ),
+
+  constraint coach_assignments_hash_shape_chk
+    check (
+      assigned_artefact_hash ~ '^[a-f0-9]{64}$'
+    ),
+
+  constraint coach_assignments_created_by_coach_chk
+    check (
+      created_by = coach_user_id
+    )
+);
+
+comment on table public.coach_assignments is
+'S39 platform-side coach assignment records. Assignment controls visibility/access only and must not alter engine legality, Phase 1 declarations, substitutions, progression, registries, compile admission, artefact content, or artefact hashes.';
+
+comment on column public.coach_assignments.assigned_artefact_hash is
+'Immutable echo of the target hash at assignment time, used only to prove assignment did not mutate the target artefact. Not engine truth.';
+
+create unique index if not exists coach_assignments_unique_active_session_target
+on public.coach_assignments (
+  coach_user_id,
+  athlete_user_id,
+  session_id
+)
+where assignment_status = 'assigned'
+  and session_id is not null;
+
+create unique index if not exists coach_assignments_unique_active_compiled_artefact_target
+on public.coach_assignments (
+  coach_user_id,
+  athlete_user_id,
+  compiled_artefact_id
+)
+where assignment_status = 'assigned'
+  and compiled_artefact_id is not null;
+
+create index if not exists coach_assignments_coach_idx
+on public.coach_assignments (
+  coach_user_id,
+  assignment_status,
+  created_at desc
+);
+
+create index if not exists coach_assignments_athlete_idx
+on public.coach_assignments (
+  athlete_user_id,
+  assignment_status,
+  created_at desc
+);
+
+create index if not exists coach_assignments_link_idx
+on public.coach_assignments (
+  coach_athlete_link_id
+);
+
+create or replace function public.set_coach_assignments_updated_at()
+returns trigger
+language plpgsql
+as $$
+begin
+  new.updated_at = now();
+  return new;
+end;
+$$;
+
+drop trigger if exists trg_set_coach_assignments_updated_at on public.coach_assignments;
+
+create trigger trg_set_coach_assignments_updated_at
+before update on public.coach_assignments
+for each row
+execute function public.set_coach_assignments_updated_at();
+
+create or replace function public.prevent_coach_assignment_target_mutation()
+returns trigger
+language plpgsql
+as $$
+begin
+  if old.assignment_id <> new.assignment_id then
+    raise exception 'assignment_id is immutable';
+  end if;
+
+  if old.coach_user_id <> new.coach_user_id then
+    raise exception 'coach_user_id is immutable';
+  end if;
+
+  if old.athlete_user_id <> new.athlete_user_id then
+    raise exception 'athlete_user_id is immutable';
+  end if;
+
+  if old.coach_athlete_link_id <> new.coach_athlete_link_id then
+    raise exception 'coach_athlete_link_id is immutable';
+  end if;
+
+  if old.session_id is distinct from new.session_id then
+    raise exception 'session_id is immutable';
+  end if;
+
+  if old.compiled_artefact_id is distinct from new.compiled_artefact_id then
+    raise exception 'compiled_artefact_id is immutable';
+  end if;
+
+  if old.assigned_artefact_hash <> new.assigned_artefact_hash then
+    raise exception 'assigned_artefact_hash is immutable';
+  end if;
+
+  if old.assigned_at <> new.assigned_at then
+    raise exception 'assigned_at is immutable';
+  end if;
+
+  if old.created_at <> new.created_at then
+    raise exception 'created_at is immutable';
+  end if;
+
+  if old.created_by <> new.created_by then
+    raise exception 'created_by is immutable';
+  end if;
+
+  if old.assignment_status = 'revoked' and new.assignment_status = 'assigned' then
+    raise exception 'revoked assignments cannot be reactivated';
+  end if;
+
+  return new;
+end;
+$$;
+
+drop trigger if exists trg_prevent_coach_assignment_target_mutation on public.coach_assignments;
+
+create trigger trg_prevent_coach_assignment_target_mutation
+before update on public.coach_assignments
+for each row
+execute function public.prevent_coach_assignment_target_mutation();
+
+-- Recommended foreign keys.
+-- Keep these commented until the canonical repo table names are confirmed.
+-- The semantic requirement is binding even if physical table names differ.
+--
+-- alter table public.coach_assignments
+--   add constraint coach_assignments_coach_fk
+--   foreign key (coach_user_id)
+--   references public.app_users(user_id);
+--
+-- alter table public.coach_assignments
+--   add constraint coach_assignments_athlete_fk
+--   foreign key (athlete_user_id)
+--   references public.app_users(user_id);
+--
+-- alter table public.coach_assignments
+--   add constraint coach_assignments_link_fk
+--   foreign key (coach_athlete_link_id)
+--   references public.coach_athlete_links(link_id);
+--
+-- alter table public.coach_assignments
+--   add constraint coach_assignments_session_fk
+--   foreign key (session_id)
+--   references public.sessions(session_id);
+--
+-- alter table public.coach_assignments
+--   add constraint coach_assignments_compiled_artefact_fk
+--   foreign key (compiled_artefact_id)
+--   references public.compiled_artefacts(compiled_artefact_id);
+
+-- Application-layer enforcement required before insert:
+-- 1. Authenticated actor must be coach_user_id.
+-- 2. coach_athlete_link_id must resolve to the same coach_user_id and athlete_user_id.
+-- 3. Link status must be accepted and active.
+-- 4. Target must already exist and be lawful.
+-- 5. Target hash must be read before insert and echoed in assigned_artefact_hash.
+-- 6. Hash before assignment must equal hash after assignment.
+-- 7. Active tier seat cap, when active, may deny assignment only.
+-- 8. Tier cap denial must never alter target artefact content or hash.
+-- 9. No engine compile, Phase 1 edit, substitution, progression, or registry mutation path may be called.

--- a/docs/slices/S39_COACH_ASSIGNMENT_WITHIN_LIMITS.md
+++ b/docs/slices/S39_COACH_ASSIGNMENT_WITHIN_LIMITS.md
@@ -1,0 +1,688 @@
+# S39 — Coach Assignment Within Limits
+
+Document status: v0 slice specification  
+Slice: S39  
+Title: Coach Assignment Within Limits  
+Engine compatibility: EB2-1.0.0  
+Release scope: Kolosseum v0 Deterministic Execution Alpha  
+Rewrite policy: rewrite-only  
+Scope class: closed-world  
+
+## 1. Purpose
+
+This document defines the v0 platform semantics, database model, API contract, permission rules, and negative tests for coach assignment within limits.
+
+Coach assignment is a platform access and visibility action only.
+
+A coach assignment may expose an already-existing lawful session or compiled artefact to an athlete when, and only when, the coach has an accepted active coach-athlete link and the action remains within active tier limits.
+
+Coach assignment must never create, modify, recompile, reselect, substitute, progress, repair, enrich, explain, or validate engine output.
+
+## 2. Binding v0 Boundary
+
+Kolosseum v0 permits coach-managed execution only inside the v0 boundary.
+
+The active v0 boundary is:
+
+- actor types: individual_user and coach only
+- execution scopes: individual and coach_managed only
+- activities: powerlifting, rugby_union, general_strength only
+- active engine phases: Phase 1 through Phase 6 only
+- permitted coach surface: assign, view factual artefacts, and write non-binding coach notes
+- excluded surfaces: organisation runtime, team runtime, gym runtime, evidence export, truth projection, dashboards, analytics, rankings, messaging, readiness scoring, outcome evaluation, safety or medical claims
+
+Coach assignment belongs to the permitted coach surface.
+
+It does not expand v0 scope.
+
+## 3. Definitions
+
+### 3.1 Coach Assignment
+
+A coach assignment is a platform record that links:
+
+- one coach user
+- one athlete user
+- one existing lawful session or existing lawful compiled artefact
+- one assignment status
+
+The assignment controls whether the athlete can access the assigned item through the product surface.
+
+The assignment is not engine truth.
+
+The assignment is not a Phase 1 declaration.
+
+The assignment is not a registry entry.
+
+The assignment is not a substitution instruction.
+
+The assignment is not a progression rule.
+
+The assignment is not a compile trigger.
+
+### 3.2 Existing Lawful Artefact
+
+An existing lawful artefact is a session or compiled artefact already produced through the allowed v0 compile path.
+
+For this slice, the assignment API must treat artefact validity as a precondition.
+
+The API may read artefact identity and immutable hash metadata to prove that assignment did not mutate the artefact.
+
+The API must not call engine compilation or mutation paths.
+
+### 3.3 Active Coach-Athlete Link
+
+An active coach-athlete link exists only when a link record between the same coach_user_id and athlete_user_id has status accepted and is not revoked, expired, or rejected.
+
+No inferred link is permitted.
+
+No email-domain, organisation, gym, team, roster, payment, or prior interaction may infer a link.
+
+### 3.4 Tier Seat Cap
+
+A tier seat cap is a commercial access limit.
+
+If an active coach tier cap exists, assignment must not cause the coach to exceed the permitted active athlete count.
+
+A tier cap denial prevents the platform action.
+
+A tier cap denial does not invalidate engine output, alter artefact legality, alter compiled content, or alter artefact hashes.
+
+## 4. Authority Rules
+
+### 4.1 Coach May
+
+A coach may assign an existing lawful session or compiled artefact to an athlete when all of the following are true:
+
+- coach_user_id is authenticated as the acting coach
+- athlete_user_id is the linked athlete
+- an accepted active coach-athlete link exists
+- the target session_id or compiled_artefact_id exists
+- the target item is immutable and already lawful
+- the target item belongs to the permitted v0 surface
+- active tier cap is not exceeded where tier cap enforcement is active
+- assignment_status is valid
+- no attempt is made to mutate engine truth
+
+### 4.2 Coach Must Not
+
+A coach must not use assignment to:
+
+- create engine output
+- modify engine output
+- change artefact content
+- change artefact hash
+- edit Phase 1 declarations
+- amend accepted Phase 1 declarations
+- force substitution
+- trigger substitution
+- force progression
+- trigger progression
+- bypass compile gate
+- mutate registries
+- modify registry content
+- alter legality
+- infer athlete consent
+- infer coach-athlete relationship
+- exceed an active seat cap
+- use payment/tier state to change artefact content
+
+Any such attempt must fail.
+
+## 5. Assignment Truth Model
+
+The assignment table is platform metadata.
+
+It records the fact that an assignment action occurred.
+
+It must keep an immutable echo of the assigned artefact hash at assignment time.
+
+The immutable echo exists only to prove non-mutation.
+
+The echo must not become a source of engine truth.
+
+### 5.1 Status Model
+
+Allowed assignment_status values:
+
+- assigned
+- revoked
+
+Status rules:
+
+- assigned means the assignment is currently visible/active.
+- revoked means the platform assignment has been withdrawn.
+- Revocation removes assignment visibility/access only.
+- Revocation must not delete the original artefact.
+- Revocation must not modify the original artefact.
+- Revocation must set revoked_at.
+- Revoked assignments must not be reassigned by mutating the same row back to assigned. A new assignment record must be created.
+
+No other status exists in v0.
+
+### 5.2 Target Rules
+
+An assignment must reference exactly one target:
+
+- session_id
+- compiled_artefact_id
+
+The record must not reference both.
+
+The record must not reference neither.
+
+The target must already exist before assignment.
+
+The target must be immutable at assignment time.
+
+The target hash must be captured in assigned_artefact_hash.
+
+## 6. Required Data Fields
+
+Minimum requested fields:
+
+- assignment_id
+- coach_user_id
+- athlete_user_id
+- session_id or compiled_artefact_id
+- assignment_status
+- assigned_at
+- revoked_at
+- created_at
+
+Additional implementation fields required for determinism and audit separation:
+
+- coach_athlete_link_id
+- assigned_artefact_hash
+- created_by
+- updated_at
+
+These additional fields do not extend engine behaviour. They harden auditability and permission enforcement.
+
+## 7. Database Model
+
+The canonical v0 table is public.coach_assignments.
+
+The database must enforce:
+
+- assignment_id is primary key
+- coach_user_id is required
+- athlete_user_id is required
+- coach_athlete_link_id is required
+- exactly one of session_id or compiled_artefact_id is present
+- assignment_status is closed set
+- assigned_artefact_hash is required
+- assigned_at is required
+- created_at is required
+- revoked_at is required when status is revoked
+- revoked_at is forbidden when status is assigned
+- created_by must equal coach_user_id for coach-created assignments
+- duplicate active assignment for the same coach, athlete, and target is forbidden
+
+The table must not contain fields that allow:
+
+- engine mutation
+- Phase 1 mutation
+- registry mutation
+- substitution triggering
+- progression triggering
+- compile triggering
+- content generation
+- safety or suitability claims
+
+## 8. SQL Schema
+
+See db/schema/coach_assignments.sql.
+
+The SQL schema is intentionally platform-side.
+
+It assumes existing application tables for:
+
+- app_users or equivalent user identity
+- coach_athlete_links
+- sessions or equivalent session records
+- compiled_artefacts or equivalent compiled artefact records
+
+If the repository uses different table names, map the foreign keys in one migration while preserving the same constraints and semantics.
+
+## 9. API Contract
+
+Base path:
+
+/api/v0/coach/assignments
+
+All routes are platform routes.
+
+No route may call engine compilation.
+
+No route may mutate engine artefacts.
+
+No route may write Phase 1 declarations.
+
+No route may write registries.
+
+No route may alter substitution or progression state.
+
+### 9.1 Create Assignment
+
+Method:
+
+POST /api/v0/coach/assignments
+
+Purpose:
+
+Create a platform assignment from an accepted linked coach to an athlete for an existing lawful session or compiled artefact.
+
+Request body:
+
+{
+  "athlete_user_id": "usr_athlete_001",
+  "session_id": "sess_001",
+  "compiled_artefact_id": null
+}
+
+Alternative request body:
+
+{
+  "athlete_user_id": "usr_athlete_001",
+  "session_id": null,
+  "compiled_artefact_id": "artefact_001"
+}
+
+Server-derived fields:
+
+- assignment_id
+- coach_user_id from authenticated actor
+- coach_athlete_link_id from active accepted link lookup
+- assignment_status = assigned
+- assigned_artefact_hash from immutable target
+- assigned_at
+- created_at
+- created_by
+
+Validation sequence:
+
+1. Authenticate actor.
+2. Assert actor is a coach.
+3. Assert request has exactly one target: session_id or compiled_artefact_id.
+4. Assert accepted active coach-athlete link exists for coach_user_id and athlete_user_id.
+5. Assert target exists.
+6. Assert target is already lawful and immutable.
+7. Read target hash.
+8. Assert tier seat cap does not block the action when active.
+9. Assert no active duplicate assignment exists for the same coach, athlete, and target.
+10. Insert assignment.
+11. Return assignment record.
+
+Success response:
+
+201 Created
+
+{
+  "assignment_id": "asg_001",
+  "coach_user_id": "usr_coach_001",
+  "athlete_user_id": "usr_athlete_001",
+  "coach_athlete_link_id": "link_001",
+  "session_id": "sess_001",
+  "compiled_artefact_id": null,
+  "assignment_status": "assigned",
+  "assigned_artefact_hash": "sha256_lower_hex",
+  "assigned_at": "2026-05-20T12:00:00Z",
+  "revoked_at": null,
+  "created_at": "2026-05-20T12:00:00Z"
+}
+
+Failure responses:
+
+401 unauthenticated
+
+{
+  "error": "unauthenticated"
+}
+
+403 actor_not_coach
+
+{
+  "error": "actor_not_coach"
+}
+
+403 coach_link_not_accepted
+
+{
+  "error": "coach_link_not_accepted"
+}
+
+403 coach_tier_seat_cap_exceeded
+
+{
+  "error": "coach_tier_seat_cap_exceeded"
+}
+
+404 target_not_found
+
+{
+  "error": "assignment_target_not_found"
+}
+
+409 assignment_target_not_lawful
+
+{
+  "error": "assignment_target_not_lawful"
+}
+
+409 duplicate_active_assignment
+
+{
+  "error": "duplicate_active_assignment"
+}
+
+422 invalid_assignment_target
+
+{
+  "error": "exactly_one_assignment_target_required"
+}
+
+422 engine_mutation_forbidden
+
+{
+  "error": "engine_mutation_forbidden"
+}
+
+### 9.2 List Coach Assignments
+
+Method:
+
+GET /api/v0/coach/assignments
+
+Purpose:
+
+Return assignments created by the authenticated coach.
+
+Query parameters:
+
+- athlete_user_id optional
+- assignment_status optional: assigned or revoked
+- limit optional
+- cursor optional
+
+Rules:
+
+- Coach may see only assignments where coach_user_id equals authenticated coach.
+- Cross-coach visibility is forbidden.
+- Cross-athlete visibility without accepted or archived relationship is forbidden.
+- Listing must not call engine compilation.
+- Listing must not recompute artefacts.
+
+Success response:
+
+200 OK
+
+{
+  "items": [
+    {
+      "assignment_id": "asg_001",
+      "coach_user_id": "usr_coach_001",
+      "athlete_user_id": "usr_athlete_001",
+      "session_id": "sess_001",
+      "compiled_artefact_id": null,
+      "assignment_status": "assigned",
+      "assigned_artefact_hash": "sha256_lower_hex",
+      "assigned_at": "2026-05-20T12:00:00Z",
+      "revoked_at": null,
+      "created_at": "2026-05-20T12:00:00Z"
+    }
+  ],
+  "next_cursor": null
+}
+
+### 9.3 Read Assignment
+
+Method:
+
+GET /api/v0/coach/assignments/{assignment_id}
+
+Purpose:
+
+Return one assignment if the authenticated actor has visibility.
+
+Coach visibility:
+
+- coach_user_id must equal authenticated coach_user_id
+
+Athlete visibility:
+
+- athlete_user_id must equal authenticated athlete_user_id
+- assignment_status must be assigned unless archive visibility is explicitly allowed by product policy
+
+Success response:
+
+200 OK
+
+{
+  "assignment_id": "asg_001",
+  "coach_user_id": "usr_coach_001",
+  "athlete_user_id": "usr_athlete_001",
+  "coach_athlete_link_id": "link_001",
+  "session_id": "sess_001",
+  "compiled_artefact_id": null,
+  "assignment_status": "assigned",
+  "assigned_artefact_hash": "sha256_lower_hex",
+  "assigned_at": "2026-05-20T12:00:00Z",
+  "revoked_at": null,
+  "created_at": "2026-05-20T12:00:00Z"
+}
+
+### 9.4 Revoke Assignment
+
+Method:
+
+POST /api/v0/coach/assignments/{assignment_id}/revoke
+
+Purpose:
+
+Revoke platform visibility/access for an assigned item.
+
+Rules:
+
+- Authenticated actor must be the assigning coach.
+- Assignment must currently be assigned.
+- Revocation sets assignment_status = revoked.
+- Revocation sets revoked_at.
+- Revocation must not delete the target artefact.
+- Revocation must not mutate the target artefact.
+- Revocation must not mutate artefact hash.
+- Revocation must not write Phase 1.
+- Revocation must not call compilation.
+
+Request body:
+
+{
+  "reason": null
+}
+
+The reason field is optional and must be ignored unless a later v0 policy explicitly adds neutral audit reasons. Free-text reasons should be avoided in v0 to reduce claim drift.
+
+Success response:
+
+200 OK
+
+{
+  "assignment_id": "asg_001",
+  "assignment_status": "revoked",
+  "revoked_at": "2026-05-20T12:30:00Z"
+}
+
+Failure responses:
+
+403 assignment_not_owned_by_coach
+
+{
+  "error": "assignment_not_owned_by_coach"
+}
+
+409 assignment_already_revoked
+
+{
+  "error": "assignment_already_revoked"
+}
+
+## 10. Permission Rules
+
+### 10.1 Actor Permissions
+
+Individual user:
+
+- may view assigned lawful sessions assigned to self
+- may not assign sessions
+- may not assign artefacts
+- may not revoke coach assignments unless explicit future policy permits athlete-side rejection
+- may not see other athletes assignments
+
+Coach:
+
+- may assign existing lawful artefacts to linked athletes
+- may list own assignments
+- may revoke own assignments
+- may not assign to unlinked athletes
+- may not assign to athletes linked only to another coach
+- may not assign if active tier cap is exceeded
+- may not mutate engine output
+
+System:
+
+- may enforce constraints
+- may reject invalid actions
+- may log neutral audit records
+- must not infer relationships
+- must not modify engine artefacts as a side effect of assignment
+
+### 10.2 Link Permission
+
+Required link status:
+
+accepted
+
+Forbidden link statuses:
+
+- invited
+- revoked
+- expired
+- rejected
+- missing
+
+### 10.3 Tier Cap Permission
+
+If tier cap enforcement is inactive, assignment proceeds if all non-tier conditions pass.
+
+If tier cap enforcement is active:
+
+- count active distinct athletes assigned or managed under the coach tier policy
+- include the athlete if this assignment would make them active
+- deny assignment if the count exceeds the cap
+
+Tier cap denial must return coach_tier_seat_cap_exceeded.
+
+Tier cap denial must not change target artefact content.
+
+Tier cap denial must not change target artefact hash.
+
+Tier cap denial must not alter engine legality.
+
+## 11. Hash Invariance Rules
+
+Assignment must never change artefact hash.
+
+Required invariant:
+
+target_hash_before_assignment == target_hash_after_assignment
+
+Payment and tier state must never change artefact content.
+
+Required invariant:
+
+target_hash_before_tier_check == target_hash_after_tier_check
+
+If either invariant fails, the implementation is non-canonical.
+
+## 12. Negative Tests
+
+Required negative tests:
+
+- unlinked coach cannot assign
+- invited link cannot assign
+- revoked link cannot assign
+- expired link cannot assign
+- rejected link cannot assign
+- assignment target missing fails
+- both session_id and compiled_artefact_id fails
+- neither session_id nor compiled_artefact_id fails
+- assignment cannot edit Phase 1
+- assignment cannot force substitution
+- assignment cannot bypass compile gate
+- assignment cannot create engine output
+- assignment cannot mutate artefact hash
+- payment state cannot change artefact content
+- tier cap denial cannot change artefact content
+- coach cannot exceed active seat cap where cap is active
+- duplicate active assignment fails
+- revoked assignment cannot be reactivated by row mutation
+- coach cannot revoke another coach assignment
+- athlete cannot assign to self through coach route
+- assignment cannot mutate registries
+
+## 13. Acceptance Criteria
+
+### AC1 — Valid linked coach can assign existing lawful artefact
+
+Given an authenticated coach  
+And an accepted active coach-athlete link  
+And an existing lawful immutable artefact  
+And tier cap allows the action  
+When the coach creates an assignment  
+Then an assigned coach_assignments record is created  
+And assigned_artefact_hash equals the target hash  
+And the target artefact content is unchanged  
+
+### AC2 — Unlinked coach cannot assign
+
+Given an authenticated coach  
+And no accepted active link to the athlete  
+When the coach attempts assignment  
+Then the API rejects the request  
+And no assignment row is created  
+And no engine artefact is changed  
+
+### AC3 — Assignment does not change artefact hash
+
+Given an existing lawful artefact  
+When the artefact is assigned  
+Then artefact hash before assignment equals artefact hash after assignment  
+
+### AC4 — Payment/tier state cannot change artefact content
+
+Given an existing lawful artefact  
+When tier cap state is evaluated  
+Then artefact content remains unchanged  
+And artefact hash remains unchanged  
+And only platform permission is allowed to change  
+
+## 14. CI and Implementation Notes
+
+Recommended implementation surfaces:
+
+- docs/slices/S39_COACH_ASSIGNMENT_WITHIN_LIMITS.md
+- db/schema/coach_assignments.sql
+- tests/s39/coach_assignment_within_limits.negative.json
+- tests/s39/run_coach_assignment_within_limits_negative_tests.mjs
+
+The tests in this slice are static contract tests.
+
+They do not prove runtime implementation.
+
+They prevent obvious boundary drift and provide fixtures for the later executable API layer.
+
+## 15. Final Rule
+
+Coach assignment controls platform visibility/access only.
+
+If an assignment changes engine legality, Phase 1 declarations, substitutions, progression, registries, compile admission, artefact content, artefact hashes, or payment-driven engine behaviour, the system is non-canonical and must not ship.

--- a/docs/slices/S39_COACH_ASSIGNMENT_WITHIN_LIMITS_PROMPT.md
+++ b/docs/slices/S39_COACH_ASSIGNMENT_WITHIN_LIMITS_PROMPT.md
@@ -1,0 +1,78 @@
+S39 — Coach Assignment Within Limits
+
+You are creating S39 — Coach Assignment Within Limits for Kolosseum v0.
+
+Use the existing Kolosseum v0 doctrine:
+- v0 is the Deterministic Execution Alpha.
+- v0 supports individual_user and coach only.
+- v0 supports individual and coach_managed execution only.
+- v0 is Phase 1 through Phase 6 only.
+- Coach assignment is permitted only as a platform visibility/access control.
+- Coaches may assign existing lawful artefacts/sessions within system limits.
+- Coaches may not override engine decisions, alter legality, edit Phase 1, trigger substitutions, trigger progression, mutate registries, or bypass compile.
+- Tier/payment state controls access/visibility/seat limits only and must never affect engine legality, artefact content, artefact hash, determinism, or compile validity.
+
+Create the full slice artefacts:
+1. docs/slices/S39_COACH_ASSIGNMENT_WITHIN_LIMITS.md
+2. db/schema/coach_assignments.sql
+3. tests/s39/coach_assignment_within_limits.negative.json
+4. tests/s39/run_coach_assignment_within_limits_negative_tests.mjs
+
+The markdown must include:
+- purpose
+- v0 scope boundary
+- assignment semantics
+- status model
+- target rules
+- database model
+- full API contract
+- permission rules
+- tier cap rules
+- hash invariance rules
+- negative tests
+- acceptance criteria
+- final non-mutation rule
+
+The SQL must define:
+- public.coach_assignment_status enum with assigned and revoked
+- public.coach_assignments table
+- assignment_id
+- coach_user_id
+- athlete_user_id
+- coach_athlete_link_id
+- session_id
+- compiled_artefact_id
+- assignment_status
+- assigned_artefact_hash
+- assigned_at
+- revoked_at
+- created_by
+- created_at
+- updated_at
+- exactly-one-target constraint
+- revoked_at/status consistency constraint
+- assigned_artefact_hash sha256 lowercase hex constraint
+- duplicate active assignment prevention
+- immutability trigger preventing target/hash/identity mutation
+- revoked assignment cannot be reactivated
+
+The tests must prove:
+- valid linked coach can assign existing lawful artefact
+- unlinked coach cannot assign
+- invited/revoked/expired/rejected links cannot assign
+- both targets and no target fail
+- missing/non-lawful target fails
+- assignment cannot edit Phase 1
+- assignment cannot force substitution
+- assignment cannot bypass compile gate
+- assignment cannot create engine output
+- assignment cannot mutate artefact hash
+- payment/tier state cannot change artefact content
+- active tier cap denial cannot change artefact content
+- duplicate active assignment fails
+- revoked assignment cannot be reactivated
+- coach cannot revoke another coach assignment
+- athlete cannot assign through coach route
+- assignment cannot mutate registries
+
+Keep the implementation deterministic, closed-world, and platform-side. Do not add advisory, medical, safety, readiness, outcome, optimisation, or evidence/export language.

--- a/tests/s39/coach_assignment_within_limits.negative.json
+++ b/tests/s39/coach_assignment_within_limits.negative.json
@@ -1,0 +1,157 @@
+{
+  "schema_version": "kolosseum.s39.coach_assignment_within_limits.negative_tests.v1.0.0",
+  "slice": "S39",
+  "title": "Coach Assignment Within Limits Negative Tests",
+  "engine_compatibility": "EB2-1.0.0",
+  "scope_class": "closed_world",
+  "tests": [
+    {
+      "id": "S39_NEG_001_UNLINKED_COACH_CANNOT_ASSIGN",
+      "given": ["authenticated coach", "no accepted active coach-athlete link", "existing lawful artefact"],
+      "when": "coach attempts assignment",
+      "expect_error": "coach_link_not_accepted",
+      "must_not": ["create_assignment", "mutate_artefact", "change_artefact_hash", "call_compile"]
+    },
+    {
+      "id": "S39_NEG_002_INVITED_LINK_CANNOT_ASSIGN",
+      "given": ["authenticated coach", "coach-athlete link status invited"],
+      "when": "coach attempts assignment",
+      "expect_error": "coach_link_not_accepted",
+      "must_not": ["create_assignment", "mutate_artefact", "call_compile"]
+    },
+    {
+      "id": "S39_NEG_003_REVOKED_LINK_CANNOT_ASSIGN",
+      "given": ["authenticated coach", "coach-athlete link status revoked"],
+      "when": "coach attempts assignment",
+      "expect_error": "coach_link_not_accepted",
+      "must_not": ["create_assignment", "mutate_artefact", "call_compile"]
+    },
+    {
+      "id": "S39_NEG_004_EXPIRED_LINK_CANNOT_ASSIGN",
+      "given": ["authenticated coach", "coach-athlete link status expired"],
+      "when": "coach attempts assignment",
+      "expect_error": "coach_link_not_accepted",
+      "must_not": ["create_assignment", "mutate_artefact", "call_compile"]
+    },
+    {
+      "id": "S39_NEG_005_REJECTED_LINK_CANNOT_ASSIGN",
+      "given": ["authenticated coach", "coach-athlete link status rejected"],
+      "when": "coach attempts assignment",
+      "expect_error": "coach_link_not_accepted",
+      "must_not": ["create_assignment", "mutate_artefact", "call_compile"]
+    },
+    {
+      "id": "S39_NEG_006_BOTH_TARGETS_FORBIDDEN",
+      "given": ["accepted active link", "session_id present", "compiled_artefact_id present"],
+      "when": "coach creates assignment",
+      "expect_error": "exactly_one_assignment_target_required",
+      "must_not": ["create_assignment", "mutate_artefact"]
+    },
+    {
+      "id": "S39_NEG_007_NO_TARGET_FORBIDDEN",
+      "given": ["accepted active link", "session_id null", "compiled_artefact_id null"],
+      "when": "coach creates assignment",
+      "expect_error": "exactly_one_assignment_target_required",
+      "must_not": ["create_assignment", "mutate_artefact"]
+    },
+    {
+      "id": "S39_NEG_008_MISSING_TARGET_FAILS",
+      "given": ["accepted active link", "target id does not exist"],
+      "when": "coach creates assignment",
+      "expect_error": "assignment_target_not_found",
+      "must_not": ["create_assignment", "call_compile"]
+    },
+    {
+      "id": "S39_NEG_009_NON_LAWFUL_TARGET_FAILS",
+      "given": ["accepted active link", "target exists", "target not lawful"],
+      "when": "coach creates assignment",
+      "expect_error": "assignment_target_not_lawful",
+      "must_not": ["create_assignment", "repair_target", "call_compile"]
+    },
+    {
+      "id": "S39_NEG_010_ASSIGNMENT_CANNOT_EDIT_PHASE1",
+      "given": ["accepted active link", "existing lawful artefact"],
+      "when": "request includes phase1_patch",
+      "expect_error": "engine_mutation_forbidden",
+      "must_not": ["edit_phase1", "create_assignment", "mutate_artefact"]
+    },
+    {
+      "id": "S39_NEG_011_ASSIGNMENT_CANNOT_FORCE_SUBSTITUTION",
+      "given": ["accepted active link", "existing lawful artefact"],
+      "when": "request includes substitution instruction",
+      "expect_error": "engine_mutation_forbidden",
+      "must_not": ["trigger_substitution", "mutate_artefact", "change_artefact_hash"]
+    },
+    {
+      "id": "S39_NEG_012_ASSIGNMENT_CANNOT_BYPASS_COMPILE_GATE",
+      "given": ["accepted active link", "target missing compiled lawful state"],
+      "when": "coach attempts assignment",
+      "expect_error": "assignment_target_not_lawful",
+      "must_not": ["call_compile", "create_engine_output", "create_assignment"]
+    },
+    {
+      "id": "S39_NEG_013_ASSIGNMENT_CANNOT_CREATE_ENGINE_OUTPUT",
+      "given": ["accepted active link", "request contains program/session generation payload"],
+      "when": "coach attempts assignment",
+      "expect_error": "engine_mutation_forbidden",
+      "must_not": ["create_engine_output", "call_compile", "mutate_registries"]
+    },
+    {
+      "id": "S39_NEG_014_ASSIGNMENT_DOES_NOT_CHANGE_ARTEFACT_HASH",
+      "given": ["accepted active link", "existing lawful artefact", "hash_before recorded"],
+      "when": "assignment succeeds",
+      "expect_invariant": "hash_before == hash_after",
+      "must_not": ["change_artefact_hash", "mutate_artefact"]
+    },
+    {
+      "id": "S39_NEG_015_PAYMENT_STATE_CANNOT_CHANGE_ARTEFACT_CONTENT",
+      "given": ["existing lawful artefact", "payment state changes"],
+      "when": "assignment permission is evaluated",
+      "expect_invariant": "artefact_content_before == artefact_content_after",
+      "must_not": ["change_artefact_hash", "mutate_artefact", "alter_engine_legality"]
+    },
+    {
+      "id": "S39_NEG_016_TIER_CAP_DENIAL_CANNOT_CHANGE_ARTEFACT_CONTENT",
+      "given": ["accepted active link", "existing lawful artefact", "active tier cap exceeded"],
+      "when": "coach attempts assignment",
+      "expect_error": "coach_tier_seat_cap_exceeded",
+      "expect_invariant": "hash_before == hash_after",
+      "must_not": ["create_assignment", "mutate_artefact", "alter_engine_legality"]
+    },
+    {
+      "id": "S39_NEG_017_DUPLICATE_ACTIVE_ASSIGNMENT_FAILS",
+      "given": ["accepted active link", "active assignment already exists for same coach athlete target"],
+      "when": "coach attempts duplicate assignment",
+      "expect_error": "duplicate_active_assignment",
+      "must_not": ["create_duplicate_assignment", "mutate_artefact"]
+    },
+    {
+      "id": "S39_NEG_018_REVOKED_ASSIGNMENT_CANNOT_REACTIVATE_BY_ROW_MUTATION",
+      "given": ["revoked assignment row"],
+      "when": "status update attempts revoked to assigned",
+      "expect_error": "revoked_assignments_cannot_be_reactivated",
+      "must_not": ["reactivate_assignment", "mutate_artefact"]
+    },
+    {
+      "id": "S39_NEG_019_COACH_CANNOT_REVOKE_ANOTHER_COACH_ASSIGNMENT",
+      "given": ["authenticated coach", "assignment belongs to different coach"],
+      "when": "coach attempts revoke",
+      "expect_error": "assignment_not_owned_by_coach",
+      "must_not": ["revoke_assignment", "mutate_artefact"]
+    },
+    {
+      "id": "S39_NEG_020_ATHLETE_CANNOT_ASSIGN_THROUGH_COACH_ROUTE",
+      "given": ["authenticated individual_user"],
+      "when": "actor calls coach assignment create route",
+      "expect_error": "actor_not_coach",
+      "must_not": ["create_assignment", "mutate_artefact"]
+    },
+    {
+      "id": "S39_NEG_021_ASSIGNMENT_CANNOT_MUTATE_REGISTRIES",
+      "given": ["accepted active link", "request contains registry mutation payload"],
+      "when": "coach attempts assignment",
+      "expect_error": "engine_mutation_forbidden",
+      "must_not": ["mutate_registries", "create_assignment", "call_compile"]
+    }
+  ]
+}

--- a/tests/s39/run_coach_assignment_within_limits_negative_tests.mjs
+++ b/tests/s39/run_coach_assignment_within_limits_negative_tests.mjs
@@ -1,0 +1,159 @@
+import fs from "node:fs";
+import path from "node:path";
+
+const repoRoot = process.cwd();
+
+const files = {
+  md: path.join(repoRoot, "docs", "slices", "S39_COACH_ASSIGNMENT_WITHIN_LIMITS.md"),
+  sql: path.join(repoRoot, "db", "schema", "coach_assignments.sql"),
+  tests: path.join(repoRoot, "tests", "s39", "coach_assignment_within_limits.negative.json")
+};
+
+function read(file) {
+  return fs.readFileSync(file, "utf8");
+}
+
+function fail(message) {
+  console.error(JSON.stringify({ ok: false, slice: "S39", error: message }, null, 2));
+  process.exit(1);
+}
+
+function assertIncludes(name, content, needle) {
+  if (!content.includes(needle)) {
+    fail(`${name} missing required content: ${needle}`);
+  }
+}
+
+function assertNotIncludes(name, content, needle) {
+  if (content.includes(needle)) {
+    fail(`${name} contains forbidden content: ${needle}`);
+  }
+}
+
+for (const [key, file] of Object.entries(files)) {
+  if (!fs.existsSync(file)) {
+    fail(`Missing required file: ${file}`);
+  }
+}
+
+const md = read(files.md);
+const sql = read(files.sql);
+const testsRaw = read(files.tests);
+const tests = JSON.parse(testsRaw);
+
+const requiredMarkdown = [
+  "Coach assignment is a platform access and visibility action only.",
+  "Coach assignment must never create, modify, recompile, reselect, substitute, progress, repair, enrich, explain, or validate engine output.",
+  "Coach assignment controls platform visibility/access only.",
+  "Tier cap denial must not change target artefact content.",
+  "target_hash_before_assignment == target_hash_after_assignment",
+  "Payment/tier state cannot change artefact content",
+  "Phase 1",
+  "accepted active coach-athlete link",
+  "coach_tier_seat_cap_exceeded",
+  "exactly one target"
+];
+
+for (const needle of requiredMarkdown) {
+  assertIncludes("markdown", md, needle);
+}
+
+const requiredSql = [
+  "create type public.coach_assignment_status",
+  "create table if not exists public.coach_assignments",
+  "assignment_id uuid primary key",
+  "coach_user_id uuid not null",
+  "athlete_user_id uuid not null",
+  "session_id uuid null",
+  "compiled_artefact_id uuid null",
+  "assignment_status public.coach_assignment_status not null",
+  "assigned_artefact_hash text not null",
+  "coach_assignments_exactly_one_target_chk",
+  "coach_assignments_status_revoked_at_chk",
+  "coach_assignments_hash_shape_chk",
+  "coach_assignments_unique_active_session_target",
+  "coach_assignments_unique_active_compiled_artefact_target",
+  "prevent_coach_assignment_target_mutation",
+  "revoked assignments cannot be reactivated"
+];
+
+for (const needle of requiredSql) {
+  assertIncludes("sql", sql, needle);
+}
+
+const forbiddenBoundaryDrift = [
+  "readiness score",
+  "readiness scoring enabled",
+  "safety assessment",
+  "injury prevention",
+  "optimise",
+  "optimize",
+  "medical recommendation",
+  "coach override",
+  "force progression allowed",
+  "registry edit allowed"
+];
+
+for (const needle of forbiddenBoundaryDrift) {
+  assertNotIncludes("markdown", md.toLowerCase(), needle.toLowerCase());
+  assertNotIncludes("sql", sql.toLowerCase(), needle.toLowerCase());
+}
+
+if (tests.schema_version !== "kolosseum.s39.coach_assignment_within_limits.negative_tests.v1.0.0") {
+  fail("negative test schema_version mismatch");
+}
+
+if (!Array.isArray(tests.tests)) {
+  fail("negative tests must contain tests array");
+}
+
+if (tests.tests.length < 20) {
+  fail(`expected at least 20 negative tests, got ${tests.tests.length}`);
+}
+
+const requiredTestIds = [
+  "S39_NEG_001_UNLINKED_COACH_CANNOT_ASSIGN",
+  "S39_NEG_010_ASSIGNMENT_CANNOT_EDIT_PHASE1",
+  "S39_NEG_011_ASSIGNMENT_CANNOT_FORCE_SUBSTITUTION",
+  "S39_NEG_012_ASSIGNMENT_CANNOT_BYPASS_COMPILE_GATE",
+  "S39_NEG_014_ASSIGNMENT_DOES_NOT_CHANGE_ARTEFACT_HASH",
+  "S39_NEG_015_PAYMENT_STATE_CANNOT_CHANGE_ARTEFACT_CONTENT",
+  "S39_NEG_016_TIER_CAP_DENIAL_CANNOT_CHANGE_ARTEFACT_CONTENT",
+  "S39_NEG_021_ASSIGNMENT_CANNOT_MUTATE_REGISTRIES"
+];
+
+const ids = new Set(tests.tests.map(t => t.id));
+
+for (const id of requiredTestIds) {
+  if (!ids.has(id)) {
+    fail(`missing required negative test id: ${id}`);
+  }
+}
+
+for (const test of tests.tests) {
+  if (!test.id || typeof test.id !== "string") {
+    fail("each test requires string id");
+  }
+
+  if (!Array.isArray(test.must_not)) {
+    fail(`${test.id} must include must_not array`);
+  }
+
+  const forbiddenMustNotOmission = [
+    "mutate_artefact"
+  ];
+
+  const hasHashInvariant = JSON.stringify(test).includes("hash_before == hash_after");
+  const isHashTest = test.id.includes("HASH") || test.id.includes("PAYMENT") || test.id.includes("TIER_CAP");
+
+  if (isHashTest && !hasHashInvariant && !JSON.stringify(test.must_not).includes("mutate_artefact")) {
+    fail(`${test.id} must assert hash/content non-mutation`);
+  }
+}
+
+console.log(JSON.stringify({
+  ok: true,
+  slice: "S39",
+  checked_files: files,
+  negative_test_count: tests.tests.length
+}, null, 2));


### PR DESCRIPTION
Adds S39 Coach Assignment Within Limits: markdown specification, platform SQL schema, negative test vectors, static contract runner, and reusable prompt. Assignment is platform visibility/access only and cannot mutate engine output, Phase 1, substitutions, progression, registries, compile admission, or artefact hashes.