### PR TITLE
Add S40 history counts only

### DIFF
--- a/docs/slices/S40_HISTORY_COUNTS_ONLY.md
+++ b/docs/slices/S40_HISTORY_COUNTS_ONLY.md
@@ -1,0 +1,297 @@
+# S40 — History Counts Only
+
+Project: Kolosseum
+Slice: S40
+Title: History Counts Only
+Status: v0 implementation contract
+Engine compatibility: EB2-1.0.0
+Scope: v0 Deterministic Execution Alpha
+Rewrite policy: rewrite-only
+
+## 1. Purpose
+
+S40 defines the v0 history surface for athletes and linked coaches.
+
+The surface shows derived factual counts and factual session records only.
+
+Counts are derived facts. Counts are not advice.
+
+## 2. v0 Boundary
+
+Allowed surface:
+
+- Athlete own history
+- Linked coach athlete history
+- Factual counts
+- Factual session list
+- Factual session statuses
+- Optional extra work event count only where S36 is active
+
+Excluded semantic classes are enforced by the copy fixture and tests.
+
+## 3. Authority Rules
+
+### 3.1 Athlete Access
+
+An athlete may read only their own history.
+
+### 3.2 Coach Access
+
+A coach may read factual history for an athlete only where all of the following are true:
+
+- coach_user_id matches requester_user_id
+- athlete_user_id is explicitly provided
+- an accepted coach-athlete link exists
+- the link is active at query time
+- the link scope permits factual history visibility
+
+Coach access is observational only.
+
+Coach access must not alter:
+
+- runtime events
+- session truth
+- counts
+- athlete history
+- engine behaviour
+- future compilation
+- future execution
+
+### 3.3 Revoked Link Rule
+
+Revoked link visibility fails closed unless an explicit historical access policy exists.
+
+v0 default:
+
+    revoked_link_history_visibility = denied
+
+If no explicit historical policy is present, coach access after revocation must return:
+
+    {
+      "error": {
+        "code": "HISTORY_VISIBILITY_DENIED",
+        "message_copy_id": "history.error.visibility_denied"
+      }
+    }
+
+No partial response is allowed.
+
+## 4. Data Model
+
+S40 reads from app-layer persistence only.
+
+The engine remains stateless.
+
+Required source records:
+
+    sessions
+    session_runtime_items
+    runtime_events
+    coach_athlete_links
+
+Optional source records where S36 is active:
+
+    extra_work_events
+
+### 4.1 sessions
+
+    create table if not exists sessions (
+      session_id text primary key,
+      athlete_user_id text not null,
+      execution_scope text not null check (execution_scope in ('individual', 'coach_managed')),
+      status text not null check (status in ('not_started', 'in_progress', 'completed', 'partially_completed', 'stopped')),
+      started_at timestamptz null,
+      completed_at timestamptz null,
+      created_at timestamptz not null default now()
+    );
+
+### 4.2 session_runtime_items
+
+    create table if not exists session_runtime_items (
+      runtime_item_id text primary key,
+      session_id text not null references sessions(session_id),
+      athlete_user_id text not null,
+      status text not null check (status in ('completed', 'skipped', 'partial')),
+      recorded_at timestamptz not null
+    );
+
+### 4.3 extra_work_events
+
+Only active when S36 is active.
+
+    create table if not exists extra_work_events (
+      extra_work_event_id text primary key,
+      session_id text not null references sessions(session_id),
+      athlete_user_id text not null,
+      recorded_at timestamptz not null
+    );
+
+### 4.4 coach_athlete_links
+
+    create table if not exists coach_athlete_links (
+      link_id text primary key,
+      coach_user_id text not null,
+      athlete_user_id text not null,
+      status text not null check (status in ('invited', 'accepted', 'revoked', 'expired', 'rejected')),
+      scope jsonb not null,
+      invited_at timestamptz null,
+      accepted_at timestamptz null,
+      revoked_at timestamptz null,
+      rejected_at timestamptz null,
+      expires_at timestamptz null,
+      created_by text not null,
+      created_at timestamptz not null default now(),
+      updated_at timestamptz not null default now()
+    );
+
+## 5. Allowed Response Fields
+
+The summary response may include only:
+
+- session_count
+- completed_item_count
+- skipped_item_count
+- partial_item_count
+- extra_work_event_count
+- first_session_at
+- latest_session_at
+- sessions
+
+extra_work_event_count is allowed only when S36 is active.
+
+sessions may include only factual identifiers, timestamps, and factual statuses.
+
+## 6. Query Contract
+
+### 6.1 Summary Query
+
+    select
+      count(distinct s.session_id)::integer as session_count,
+      count(ri.runtime_item_id) filter (where ri.status = 'completed')::integer as completed_item_count,
+      count(ri.runtime_item_id) filter (where ri.status = 'skipped')::integer as skipped_item_count,
+      count(ri.runtime_item_id) filter (where ri.status = 'partial')::integer as partial_item_count,
+      min(s.started_at) as first_session_at,
+      max(coalesce(s.completed_at, s.started_at, s.created_at)) as latest_session_at
+    from sessions s
+    left join session_runtime_items ri
+      on ri.session_id = s.session_id
+    where s.athlete_user_id = :athlete_user_id;
+
+### 6.2 Extra Work Query
+
+Only used when S36 is active.
+
+    select
+      count(extra_work_event_id)::integer as extra_work_event_count
+    from extra_work_events
+    where athlete_user_id = :athlete_user_id;
+
+### 6.3 Session List Query
+
+    select
+      session_id,
+      status,
+      started_at,
+      completed_at,
+      created_at
+    from sessions
+    where athlete_user_id = :athlete_user_id
+    order by coalesce(started_at, created_at) desc, session_id asc
+    limit :limit
+    offset :offset;
+
+### 6.4 Coach Link Verification Query
+
+    select
+      link_id,
+      status,
+      scope,
+      accepted_at,
+      revoked_at,
+      expires_at
+    from coach_athlete_links
+    where coach_user_id = :coach_user_id
+      and athlete_user_id = :athlete_user_id
+      and status = 'accepted'
+      and accepted_at is not null
+      and revoked_at is null
+      and (expires_at is null or expires_at > now())
+    limit 1;
+
+### 6.5 Link Scope Check
+
+The link scope must explicitly permit factual history visibility.
+
+Required scope flag:
+
+    {
+      "history_counts": true
+    }
+
+Missing scope flag means denied.
+
+No inference is permitted.
+
+## 7. API Contract
+
+Endpoint:
+
+    GET /api/v0/history/:athlete_user_id/counts
+
+Query params:
+
+    {
+      "limit": "integer optional, default 25, max 100",
+      "offset": "integer optional, default 0"
+    }
+
+Denied response:
+
+    {
+      "error": {
+        "code": "HISTORY_VISIBILITY_DENIED",
+        "message_copy_id": "history.error.visibility_denied"
+      }
+    }
+
+No data is not an error.
+
+## 8. UI Copy Surface
+
+All copy must be rendered by copy ID.
+
+Inline user-facing strings are forbidden.
+
+Allowed copy IDs are defined in ui/copy/history_counts.copy.json.
+
+## 9. UI Surface Rules
+
+The UI may show:
+
+- count cards
+- factual date labels
+- factual session list
+- factual status chips
+
+Status chips must use neutral styling.
+
+Colour must not encode judgement.
+
+## 10. Acceptance Criteria
+
+S40 is accepted only when:
+
+- Athlete can read own factual history.
+- Athlete cannot read another athlete history.
+- Coach can read linked athlete factual history only with accepted active scoped link.
+- Revoked link access fails closed.
+- Counts match persisted runtime events.
+- S36 extra work count appears only where S36 is active.
+- Session list contains factual statuses only.
+- API response contains no forbidden derived fields.
+- UI copy uses only registered copy IDs.
+- No inline production copy exists.
+- Copy lint passes.
+- Negative tests prove excluded semantic classes fail.
+- Engine output is unaffected by history queries.
+- Coach access remains observational only.

--- a/server/history/historyCounts.access.ts
+++ b/server/history/historyCounts.access.ts
@@ -1,0 +1,106 @@
+import type { HistoryAccessDecision, HistoryRequesterRole } from "./historyCounts.contract";
+
+export type CoachAthleteLinkStatus = "invited" | "accepted" | "revoked" | "expired" | "rejected";
+
+export type CoachAthleteLinkForHistory = {
+  link_id: string;
+  coach_user_id: string;
+  athlete_user_id: string;
+  status: CoachAthleteLinkStatus;
+  scope: {
+    history_counts?: boolean;
+    [key: string]: unknown;
+  };
+  accepted_at: string | null;
+  revoked_at: string | null;
+  expires_at: string | null;
+};
+
+export type HistoryRequesterContext = {
+  requester_user_id: string;
+  requester_role: HistoryRequesterRole;
+};
+
+function isExpired(expiresAt: string | null, nowIso: string): boolean {
+  return expiresAt !== null && expiresAt <= nowIso;
+}
+
+export function decideHistoryAccess(input: {
+  requester: HistoryRequesterContext;
+  athlete_user_id: string;
+  links: CoachAthleteLinkForHistory[];
+  now_iso: string;
+}): HistoryAccessDecision {
+  const { requester, athlete_user_id, links, now_iso } = input;
+
+  if (requester.requester_role === "athlete") {
+    if (requester.requester_user_id === athlete_user_id) {
+      return {
+        allowed: true,
+        viewer_type: "athlete",
+        athlete_user_id
+      };
+    }
+
+    return {
+      allowed: false,
+      reason: "requester_not_athlete"
+    };
+  }
+
+  if (requester.requester_role === "coach") {
+    const link = links.find(
+      item =>
+        item.coach_user_id === requester.requester_user_id &&
+        item.athlete_user_id === athlete_user_id
+    );
+
+    if (!link) {
+      return {
+        allowed: false,
+        reason: "coach_link_missing"
+      };
+    }
+
+    if (link.status === "revoked" || link.revoked_at !== null) {
+      return {
+        allowed: false,
+        reason: "coach_link_revoked"
+      };
+    }
+
+    if (link.status === "expired" || isExpired(link.expires_at, now_iso)) {
+      return {
+        allowed: false,
+        reason: "coach_link_expired"
+      };
+    }
+
+    if (link.status !== "accepted" || link.accepted_at === null) {
+      return {
+        allowed: false,
+        reason: "coach_link_not_accepted"
+      };
+    }
+
+    if (link.scope.history_counts !== true) {
+      return {
+        allowed: false,
+        reason: "coach_scope_missing"
+      };
+    }
+
+    return {
+      allowed: true,
+      viewer_type: "linked_coach",
+      coach_user_id: requester.requester_user_id,
+      athlete_user_id,
+      link_id: link.link_id
+    };
+  }
+
+  return {
+    allowed: false,
+    reason: "unknown_role"
+  };
+}

--- a/server/history/historyCounts.contract.ts
+++ b/server/history/historyCounts.contract.ts
@@ -1,0 +1,123 @@
+export const HISTORY_COUNTS_SCHEMA_VERSION = "kolosseum.history_counts.v0.1" as const;
+
+export const HISTORY_VISIBILITY_DENIED = "HISTORY_VISIBILITY_DENIED" as const;
+
+export type HistoryViewerType = "athlete" | "linked_coach";
+
+export type HistoryRequesterRole = "athlete" | "coach";
+
+export type HistorySessionStatus =
+  | "not_started"
+  | "in_progress"
+  | "completed"
+  | "partially_completed"
+  | "stopped";
+
+export type HistoryCounts = {
+  session_count: number;
+  completed_item_count: number;
+  skipped_item_count: number;
+  partial_item_count: number;
+  extra_work_event_count?: number;
+  first_session_at: string | null;
+  latest_session_at: string | null;
+};
+
+export type HistorySession = {
+  session_id: string;
+  status: HistorySessionStatus;
+  started_at: string | null;
+  completed_at: string | null;
+  created_at: string;
+};
+
+export type HistoryCountsResponse = {
+  schema_version: typeof HISTORY_COUNTS_SCHEMA_VERSION;
+  athlete_user_id: string;
+  viewer_type: HistoryViewerType;
+  counts: HistoryCounts;
+  sessions: HistorySession[];
+};
+
+export type HistoryDeniedResponse = {
+  error: {
+    code: typeof HISTORY_VISIBILITY_DENIED;
+    message_copy_id: "history.error.visibility_denied";
+  };
+};
+
+export type HistoryApiResponse = HistoryCountsResponse | HistoryDeniedResponse;
+
+export type HistoryAccessAllowed =
+  | {
+      allowed: true;
+      viewer_type: "athlete";
+      athlete_user_id: string;
+    }
+  | {
+      allowed: true;
+      viewer_type: "linked_coach";
+      coach_user_id: string;
+      athlete_user_id: string;
+      link_id: string;
+    };
+
+export type HistoryAccessDenied = {
+  allowed: false;
+  reason:
+    | "requester_not_athlete"
+    | "coach_link_missing"
+    | "coach_link_not_accepted"
+    | "coach_link_revoked"
+    | "coach_link_expired"
+    | "coach_scope_missing"
+    | "unknown_role";
+};
+
+export type HistoryAccessDecision = HistoryAccessAllowed | HistoryAccessDenied;
+
+export const ALLOWED_HISTORY_COUNT_FIELDS = [
+  "session_count",
+  "completed_item_count",
+  "skipped_item_count",
+  "partial_item_count",
+  "extra_work_event_count",
+  "first_session_at",
+  "latest_session_at"
+] as const;
+
+export const ALLOWED_HISTORY_SESSION_FIELDS = [
+  "session_id",
+  "status",
+  "started_at",
+  "completed_at",
+  "created_at"
+] as const;
+
+export function deniedHistoryResponse(): HistoryDeniedResponse {
+  return {
+    error: {
+      code: HISTORY_VISIBILITY_DENIED,
+      message_copy_id: "history.error.visibility_denied"
+    }
+  };
+}
+
+export function assertHistoryResponseClosedWorld(response: HistoryCountsResponse): void {
+  const allowedCountKeys = new Set<string>(ALLOWED_HISTORY_COUNT_FIELDS);
+  const allowedSessionKeys = new Set<string>(ALLOWED_HISTORY_SESSION_FIELDS);
+
+  for (const key of Object.keys(response.counts)) {
+    if (!allowedCountKeys.has(key)) {
+      throw new Error(`Forbidden history count field: ${key}`);
+    }
+  }
+
+  for (const session of response.sessions) {
+    for (const key of Object.keys(session)) {
+      if (!allowedSessionKeys.has(key)) {
+        throw new Error(`Forbidden history session field: ${key}`);
+      }
+    }
+  }
+}

--- a/server/history/historyCounts.query.ts
+++ b/server/history/historyCounts.query.ts
@@ -1,0 +1,166 @@
+import {
+  HISTORY_COUNTS_SCHEMA_VERSION,
+  assertHistoryResponseClosedWorld,
+  type HistoryCounts,
+  type HistoryCountsResponse,
+  type HistorySession
+} from "./historyCounts.contract";
+
+export type HistorySessionRecord = {
+  session_id: string;
+  athlete_user_id: string;
+  status: HistorySession["status"];
+  started_at: string | null;
+  completed_at: string | null;
+  created_at: string;
+};
+
+export type HistoryRuntimeItemRecord = {
+  runtime_item_id: string;
+  session_id: string;
+  athlete_user_id: string;
+  status: "completed" | "skipped" | "partial";
+  recorded_at: string;
+};
+
+export type HistoryExtraWorkEventRecord = {
+  extra_work_event_id: string;
+  session_id: string;
+  athlete_user_id: string;
+  recorded_at: string;
+};
+
+export type BuildHistoryCountsInput = {
+  athlete_user_id: string;
+  viewer_type: "athlete" | "linked_coach";
+  sessions: HistorySessionRecord[];
+  runtime_items: HistoryRuntimeItemRecord[];
+  extra_work_events?: HistoryExtraWorkEventRecord[];
+  s36_active: boolean;
+  limit?: number;
+  offset?: number;
+};
+
+export const HISTORY_COUNTS_SQL = {
+  summary: [
+    "select",
+    "  count(distinct s.session_id)::integer as session_count,",
+    "  count(ri.runtime_item_id) filter (where ri.status = 'completed')::integer as completed_item_count,",
+    "  count(ri.runtime_item_id) filter (where ri.status = 'skipped')::integer as skipped_item_count,",
+    "  count(ri.runtime_item_id) filter (where ri.status = 'partial')::integer as partial_item_count,",
+    "  min(s.started_at) as first_session_at,",
+    "  max(coalesce(s.completed_at, s.started_at, s.created_at)) as latest_session_at",
+    "from sessions s",
+    "left join session_runtime_items ri",
+    "  on ri.session_id = s.session_id",
+    "where s.athlete_user_id = :athlete_user_id;"
+  ].join("\n"),
+  extraWork: [
+    "select",
+    "  count(extra_work_event_id)::integer as extra_work_event_count",
+    "from extra_work_events",
+    "where athlete_user_id = :athlete_user_id;"
+  ].join("\n"),
+  sessions: [
+    "select",
+    "  session_id,",
+    "  status,",
+    "  started_at,",
+    "  completed_at,",
+    "  created_at",
+    "from sessions",
+    "where athlete_user_id = :athlete_user_id",
+    "order by coalesce(started_at, created_at) desc, session_id asc",
+    "limit :limit",
+    "offset :offset;"
+  ].join("\n"),
+  coachLink: [
+    "select",
+    "  link_id,",
+    "  status,",
+    "  scope,",
+    "  accepted_at,",
+    "  revoked_at,",
+    "  expires_at",
+    "from coach_athlete_links",
+    "where coach_user_id = :coach_user_id",
+    "  and athlete_user_id = :athlete_user_id",
+    "  and status = 'accepted'",
+    "  and accepted_at is not null",
+    "  and revoked_at is null",
+    "  and (expires_at is null or expires_at > now())",
+    "limit 1;"
+  ].join("\n")
+} as const;
+
+function latestDateForSession(session: HistorySessionRecord): string {
+  return session.completed_at ?? session.started_at ?? session.created_at;
+}
+
+function firstDateForSession(session: HistorySessionRecord): string {
+  return session.started_at ?? session.created_at;
+}
+
+function clampPagination(limit: number | undefined, offset: number | undefined): { limit: number; offset: number } {
+  return {
+    limit: Math.min(Math.max(limit ?? 25, 0), 100),
+    offset: Math.max(offset ?? 0, 0)
+  };
+}
+
+export function buildHistoryCountsResponse(input: BuildHistoryCountsInput): HistoryCountsResponse {
+  const scopedSessions = input.sessions.filter(session => session.athlete_user_id === input.athlete_user_id);
+  const sessionIds = new Set(scopedSessions.map(session => session.session_id));
+
+  const scopedItems = input.runtime_items.filter(
+    item => item.athlete_user_id === input.athlete_user_id && sessionIds.has(item.session_id)
+  );
+
+  const sortedSessions = [...scopedSessions].sort((a, b) => {
+    const dateComparison = latestDateForSession(b).localeCompare(latestDateForSession(a));
+    if (dateComparison !== 0) return dateComparison;
+    return a.session_id.localeCompare(b.session_id);
+  });
+
+  const firstSession = scopedSessions.length
+    ? [...scopedSessions].sort((a, b) => firstDateForSession(a).localeCompare(firstDateForSession(b)))[0]
+    : null;
+
+  const latestSession = scopedSessions.length
+    ? [...scopedSessions].sort((a, b) => latestDateForSession(b).localeCompare(latestDateForSession(a)))[0]
+    : null;
+
+  const counts: HistoryCounts = {
+    session_count: scopedSessions.length,
+    completed_item_count: scopedItems.filter(item => item.status === "completed").length,
+    skipped_item_count: scopedItems.filter(item => item.status === "skipped").length,
+    partial_item_count: scopedItems.filter(item => item.status === "partial").length,
+    first_session_at: firstSession ? firstDateForSession(firstSession) : null,
+    latest_session_at: latestSession ? latestDateForSession(latestSession) : null
+  };
+
+  if (input.s36_active) {
+    counts.extra_work_event_count = (input.extra_work_events ?? []).filter(
+      event => event.athlete_user_id === input.athlete_user_id && sessionIds.has(event.session_id)
+    ).length;
+  }
+
+  const pagination = clampPagination(input.limit, input.offset);
+
+  const response: HistoryCountsResponse = {
+    schema_version: HISTORY_COUNTS_SCHEMA_VERSION,
+    athlete_user_id: input.athlete_user_id,
+    viewer_type: input.viewer_type,
+    counts,
+    sessions: sortedSessions.slice(pagination.offset, pagination.offset + pagination.limit).map(session => ({
+      session_id: session.session_id,
+      status: session.status,
+      started_at: session.started_at,
+      completed_at: session.completed_at,
+      created_at: session.created_at
+    }))
+  };
+
+  assertHistoryResponseClosedWorld(response);
+  return response;
+}

--- a/tests/fixtures/history_counts_forbidden_copy_terms.json
+++ b/tests/fixtures/history_counts_forbidden_copy_terms.json
@@ -1,0 +1,23 @@
+{
+  "schema_version": "kolosseum.history_counts.negative_copy_fixture.v0.1",
+  "fixture_id": "history_counts_forbidden_copy_terms",
+  "tests_only": true,
+  "forbidden_terms": [
+    "trend",
+    "dashboard",
+    "graph",
+    "performance analysis",
+    "readiness",
+    "ranking",
+    "compliance",
+    "adherence scoring",
+    "improvement",
+    "prediction",
+    "recommendation",
+    "safety",
+    "medical interpretation",
+    "optimisation",
+    "optimization"
+  ],
+  "expected_failure": "CI_LINT_FORBIDDEN_CLAIM_SEMANTIC"
+}

--- a/tests/fixtures/history_counts_positive_basic.json
+++ b/tests/fixtures/history_counts_positive_basic.json
@@ -1,0 +1,64 @@
+{
+  "schema_version": "kolosseum.history_counts.test_fixture.v0.1",
+  "fixture_id": "history_counts_positive_basic",
+  "s36_active": true,
+  "athlete_user_id": "ath_001",
+  "sessions": [
+    {
+      "session_id": "sess_001",
+      "athlete_user_id": "ath_001",
+      "status": "completed",
+      "started_at": "2026-05-01T10:00:00.000Z",
+      "completed_at": "2026-05-01T11:00:00.000Z",
+      "created_at": "2026-05-01T09:30:00.000Z"
+    },
+    {
+      "session_id": "sess_002",
+      "athlete_user_id": "ath_001",
+      "status": "partially_completed",
+      "started_at": "2026-05-03T10:00:00.000Z",
+      "completed_at": null,
+      "created_at": "2026-05-03T09:30:00.000Z"
+    }
+  ],
+  "runtime_items": [
+    {
+      "runtime_item_id": "ri_001",
+      "session_id": "sess_001",
+      "athlete_user_id": "ath_001",
+      "status": "completed",
+      "recorded_at": "2026-05-01T10:10:00.000Z"
+    },
+    {
+      "runtime_item_id": "ri_002",
+      "session_id": "sess_001",
+      "athlete_user_id": "ath_001",
+      "status": "skipped",
+      "recorded_at": "2026-05-01T10:20:00.000Z"
+    },
+    {
+      "runtime_item_id": "ri_003",
+      "session_id": "sess_002",
+      "athlete_user_id": "ath_001",
+      "status": "partial",
+      "recorded_at": "2026-05-03T10:20:00.000Z"
+    }
+  ],
+  "extra_work_events": [
+    {
+      "extra_work_event_id": "ew_001",
+      "session_id": "sess_002",
+      "athlete_user_id": "ath_001",
+      "recorded_at": "2026-05-03T10:40:00.000Z"
+    }
+  ],
+  "expected": {
+    "session_count": 2,
+    "completed_item_count": 1,
+    "skipped_item_count": 1,
+    "partial_item_count": 1,
+    "extra_work_event_count": 1,
+    "first_session_at": "2026-05-01T10:00:00.000Z",
+    "latest_session_at": "2026-05-03T10:00:00.000Z"
+  }
+}

--- a/tests/history/historyCounts.copy.test.ts
+++ b/tests/history/historyCounts.copy.test.ts
@@ -1,0 +1,72 @@
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+const repoRoot = path.resolve(__dirname, "../..");
+const copyPath = path.join(repoRoot, "ui/copy/history_counts.copy.json");
+
+const forbiddenProductionPatterns = [
+  /\btrend\b/i,
+  /\btrends\b/i,
+  /\bdashboard\b/i,
+  /\bgraph\b/i,
+  /\bperformance analysis\b/i,
+  /\breadiness\b/i,
+  /\branking\b/i,
+  /\bscore\b/i,
+  /\bcompliance\b/i,
+  /\badherence\b/i,
+  /\bimprovement\b/i,
+  /\bprediction\b/i,
+  /\brecommendation\b/i,
+  /\bsafety\b/i,
+  /\bmedical\b/i,
+  /\boptimisation\b/i,
+  /\boptimization\b/i
+];
+
+function assertNoForbiddenProductionCopy(value: unknown, pathParts: string[] = []): void {
+  if (typeof value === "string") {
+    for (const pattern of forbiddenProductionPatterns) {
+      expect(value, `Forbidden production copy at ${pathParts.join(".")}: ${value}`).not.toMatch(pattern);
+    }
+    return;
+  }
+
+  if (Array.isArray(value)) {
+    value.forEach((item, index) => assertNoForbiddenProductionCopy(item, [...pathParts, String(index)]));
+    return;
+  }
+
+  if (value && typeof value === "object") {
+    for (const [key, nested] of Object.entries(value)) {
+      if (key === "ui_rules" || key === "allowed_response_fields") continue;
+      assertNoForbiddenProductionCopy(nested, [...pathParts, key]);
+    }
+  }
+}
+
+describe("S40 history copy surface", () => {
+  it("contains only registered neutral copy strings", () => {
+    const copy = JSON.parse(fs.readFileSync(copyPath, "utf8"));
+
+    expect(copy.schema_version).toBe("kolosseum.copy_surface.history_counts.v0.1");
+    expect(copy.surface_id).toBe("history_counts_only");
+    expect(copy.ui_rules.inline_copy_allowed).toBe(false);
+    expect(copy.ui_rules.graphs_allowed).toBe(false);
+    expect(copy.ui_rules.analytics_language_allowed).toBe(false);
+    expect(copy.ui_rules.valenced_labels_allowed).toBe(false);
+    expect(copy.ui_rules.coach_recommendation_prompts_allowed).toBe(false);
+
+    assertNoForbiddenProductionCopy(copy.copy);
+  });
+
+  it("does not use blocked surface wording in allowed copy", () => {
+    const copy = JSON.parse(fs.readFileSync(copyPath, "utf8"));
+    const renderedCopy = Object.values(copy.copy).join("\n");
+
+    expect(renderedCopy).not.toMatch(/\bgraph\b/i);
+    expect(renderedCopy).not.toMatch(/\bdashboard\b/i);
+    expect(renderedCopy).not.toMatch(/\btrend\b/i);
+  });
+});

--- a/tests/history/historyCounts.test.ts
+++ b/tests/history/historyCounts.test.ts
@@ -1,0 +1,292 @@
+import { describe, expect, it } from "vitest";
+import {
+  ALLOWED_HISTORY_COUNT_FIELDS,
+  assertHistoryResponseClosedWorld,
+  deniedHistoryResponse
+} from "../../server/history/historyCounts.contract";
+import { decideHistoryAccess } from "../../server/history/historyCounts.access";
+import { buildHistoryCountsResponse } from "../../server/history/historyCounts.query";
+
+describe("S40 History Counts Only", () => {
+  it("derives factual counts from runtime events only", () => {
+    const response = buildHistoryCountsResponse({
+      athlete_user_id: "ath_001",
+      viewer_type: "athlete",
+      s36_active: true,
+      sessions: [
+        {
+          session_id: "sess_001",
+          athlete_user_id: "ath_001",
+          status: "completed",
+          started_at: "2026-05-01T10:00:00.000Z",
+          completed_at: "2026-05-01T11:00:00.000Z",
+          created_at: "2026-05-01T09:30:00.000Z"
+        },
+        {
+          session_id: "sess_002",
+          athlete_user_id: "ath_001",
+          status: "partially_completed",
+          started_at: "2026-05-03T10:00:00.000Z",
+          completed_at: null,
+          created_at: "2026-05-03T09:30:00.000Z"
+        },
+        {
+          session_id: "sess_other",
+          athlete_user_id: "ath_999",
+          status: "completed",
+          started_at: "2026-05-04T10:00:00.000Z",
+          completed_at: "2026-05-04T11:00:00.000Z",
+          created_at: "2026-05-04T09:30:00.000Z"
+        }
+      ],
+      runtime_items: [
+        {
+          runtime_item_id: "ri_001",
+          session_id: "sess_001",
+          athlete_user_id: "ath_001",
+          status: "completed",
+          recorded_at: "2026-05-01T10:10:00.000Z"
+        },
+        {
+          runtime_item_id: "ri_002",
+          session_id: "sess_001",
+          athlete_user_id: "ath_001",
+          status: "skipped",
+          recorded_at: "2026-05-01T10:20:00.000Z"
+        },
+        {
+          runtime_item_id: "ri_003",
+          session_id: "sess_002",
+          athlete_user_id: "ath_001",
+          status: "partial",
+          recorded_at: "2026-05-03T10:20:00.000Z"
+        },
+        {
+          runtime_item_id: "ri_other",
+          session_id: "sess_other",
+          athlete_user_id: "ath_999",
+          status: "completed",
+          recorded_at: "2026-05-04T10:20:00.000Z"
+        }
+      ],
+      extra_work_events: [
+        {
+          extra_work_event_id: "ew_001",
+          session_id: "sess_002",
+          athlete_user_id: "ath_001",
+          recorded_at: "2026-05-03T10:40:00.000Z"
+        }
+      ]
+    });
+
+    expect(response.counts).toEqual({
+      session_count: 2,
+      completed_item_count: 1,
+      skipped_item_count: 1,
+      partial_item_count: 1,
+      extra_work_event_count: 1,
+      first_session_at: "2026-05-01T10:00:00.000Z",
+      latest_session_at: "2026-05-03T10:00:00.000Z"
+    });
+
+    expect(response.sessions.map(session => session.session_id)).toEqual(["sess_002", "sess_001"]);
+  });
+
+  it("omits extra_work_event_count when S36 is inactive", () => {
+    const response = buildHistoryCountsResponse({
+      athlete_user_id: "ath_001",
+      viewer_type: "athlete",
+      s36_active: false,
+      sessions: [],
+      runtime_items: [],
+      extra_work_events: [
+        {
+          extra_work_event_id: "ew_001",
+          session_id: "sess_001",
+          athlete_user_id: "ath_001",
+          recorded_at: "2026-05-03T10:40:00.000Z"
+        }
+      ]
+    });
+
+    expect(Object.prototype.hasOwnProperty.call(response.counts, "extra_work_event_count")).toBe(false);
+  });
+
+  it("allows athlete to read own history", () => {
+    expect(
+      decideHistoryAccess({
+        requester: {
+          requester_user_id: "ath_001",
+          requester_role: "athlete"
+        },
+        athlete_user_id: "ath_001",
+        links: [],
+        now_iso: "2026-05-20T12:00:00.000Z"
+      })
+    ).toEqual({
+      allowed: true,
+      viewer_type: "athlete",
+      athlete_user_id: "ath_001"
+    });
+  });
+
+  it("denies athlete reading another athlete history", () => {
+    expect(
+      decideHistoryAccess({
+        requester: {
+          requester_user_id: "ath_001",
+          requester_role: "athlete"
+        },
+        athlete_user_id: "ath_002",
+        links: [],
+        now_iso: "2026-05-20T12:00:00.000Z"
+      })
+    ).toEqual({
+      allowed: false,
+      reason: "requester_not_athlete"
+    });
+  });
+
+  it("allows coach with accepted active scoped link", () => {
+    expect(
+      decideHistoryAccess({
+        requester: {
+          requester_user_id: "coach_001",
+          requester_role: "coach"
+        },
+        athlete_user_id: "ath_001",
+        now_iso: "2026-05-20T12:00:00.000Z",
+        links: [
+          {
+            link_id: "link_001",
+            coach_user_id: "coach_001",
+            athlete_user_id: "ath_001",
+            status: "accepted",
+            scope: { history_counts: true },
+            accepted_at: "2026-05-01T12:00:00.000Z",
+            revoked_at: null,
+            expires_at: null
+          }
+        ]
+      })
+    ).toEqual({
+      allowed: true,
+      viewer_type: "linked_coach",
+      coach_user_id: "coach_001",
+      athlete_user_id: "ath_001",
+      link_id: "link_001"
+    });
+  });
+
+  it.each([
+    ["invited", "coach_link_not_accepted"],
+    ["rejected", "coach_link_not_accepted"],
+    ["revoked", "coach_link_revoked"],
+    ["expired", "coach_link_expired"]
+  ] as const)("denies coach where link status is %s", (status, reason) => {
+    expect(
+      decideHistoryAccess({
+        requester: {
+          requester_user_id: "coach_001",
+          requester_role: "coach"
+        },
+        athlete_user_id: "ath_001",
+        now_iso: "2026-05-20T12:00:00.000Z",
+        links: [
+          {
+            link_id: "link_001",
+            coach_user_id: "coach_001",
+            athlete_user_id: "ath_001",
+            status,
+            scope: { history_counts: true },
+            accepted_at: null,
+            revoked_at: status === "revoked" ? "2026-05-10T12:00:00.000Z" : null,
+            expires_at: status === "expired" ? "2026-05-10T12:00:00.000Z" : null
+          }
+        ]
+      })
+    ).toEqual({
+      allowed: false,
+      reason
+    });
+  });
+
+  it("denies accepted coach link without history_counts scope", () => {
+    expect(
+      decideHistoryAccess({
+        requester: {
+          requester_user_id: "coach_001",
+          requester_role: "coach"
+        },
+        athlete_user_id: "ath_001",
+        now_iso: "2026-05-20T12:00:00.000Z",
+        links: [
+          {
+            link_id: "link_001",
+            coach_user_id: "coach_001",
+            athlete_user_id: "ath_001",
+            status: "accepted",
+            scope: {},
+            accepted_at: "2026-05-01T12:00:00.000Z",
+            revoked_at: null,
+            expires_at: null
+          }
+        ]
+      })
+    ).toEqual({
+      allowed: false,
+      reason: "coach_scope_missing"
+    });
+  });
+
+  it("denied response contains no counts and no sessions", () => {
+    const response = deniedHistoryResponse();
+
+    expect(response).toEqual({
+      error: {
+        code: "HISTORY_VISIBILITY_DENIED",
+        message_copy_id: "history.error.visibility_denied"
+      }
+    });
+
+    expect("counts" in response).toBe(false);
+    expect("sessions" in response).toBe(false);
+  });
+
+  it("keeps response fields closed-world", () => {
+    const response = buildHistoryCountsResponse({
+      athlete_user_id: "ath_001",
+      viewer_type: "athlete",
+      s36_active: true,
+      sessions: [],
+      runtime_items: [],
+      extra_work_events: []
+    });
+
+    expect(() => assertHistoryResponseClosedWorld(response)).not.toThrow();
+    expect(ALLOWED_HISTORY_COUNT_FIELDS).toContain("session_count");
+    expect(ALLOWED_HISTORY_COUNT_FIELDS).not.toContain("readiness" as never);
+  });
+
+  it("rejects unknown response fields", () => {
+    const response = {
+      schema_version: "kolosseum.history_counts.v0.1" as const,
+      athlete_user_id: "ath_001",
+      viewer_type: "athlete" as const,
+      counts: {
+        session_count: 0,
+        completed_item_count: 0,
+        skipped_item_count: 0,
+        partial_item_count: 0,
+        first_session_at: null,
+        latest_session_at: null,
+        readiness: "not_allowed"
+      },
+      sessions: []
+    };
+
+    expect(() => assertHistoryResponseClosedWorld(response as never)).toThrow(
+      "Forbidden history count field: readiness"
+    );
+  });
+});

--- a/ui/copy/history_counts.copy.json
+++ b/ui/copy/history_counts.copy.json
@@ -1,0 +1,50 @@
+{
+  "schema_version": "kolosseum.copy_surface.history_counts.v0.1",
+  "surface_id": "history_counts_only",
+  "status": "active",
+  "copy": {
+    "history.title": "History",
+    "history.subtitle": "Factual session records.",
+    "history.count.sessions": "Sessions",
+    "history.count.completed_items": "Completed items",
+    "history.count.skipped_items": "Skipped items",
+    "history.count.partial_items": "Partial items",
+    "history.count.extra_work_events": "Extra work events",
+    "history.date.first_session": "First session",
+    "history.date.latest_session": "Latest session",
+    "history.sessions.title": "Sessions",
+    "history.session.status.not_started": "Not started",
+    "history.session.status.in_progress": "In progress",
+    "history.session.status.completed": "Completed",
+    "history.session.status.partially_completed": "Partially completed",
+    "history.session.status.stopped": "Stopped",
+    "history.empty": "No sessions recorded.",
+    "history.error.visibility_denied": "This history is not available.",
+    "history.error.unavailable": "History is unavailable."
+  },
+  "allowed_response_fields": {
+    "counts": [
+      "session_count",
+      "completed_item_count",
+      "skipped_item_count",
+      "partial_item_count",
+      "extra_work_event_count",
+      "first_session_at",
+      "latest_session_at"
+    ],
+    "sessions": [
+      "session_id",
+      "status",
+      "started_at",
+      "completed_at",
+      "created_at"
+    ]
+  },
+  "ui_rules": {
+    "inline_copy_allowed": false,
+    "graphs_allowed": false,
+    "analytics_language_allowed": false,
+    "valenced_labels_allowed": false,
+    "coach_recommendation_prompts_allowed": false
+  }
+}


### PR DESCRIPTION
Adds factual history count contracts, copy surface, and tests for athlete and linked coach views.