### PR TITLE
Add S41 operator pilot dashboard

### DIFF
--- a/contracts/operator/operator_pilot_dashboard.api.json
+++ b/contracts/operator/operator_pilot_dashboard.api.json
@@ -1,0 +1,91 @@
+{
+  "schema_version": "kolosseum.operator_pilot_dashboard.api.v1",
+  "slice": "S41",
+  "surface_id": "operator_pilot_dashboard",
+  "route": {
+    "method": "GET",
+    "path": "/api/operator/pilots/{pilot_id}/dashboard",
+    "auth": {
+      "required": true,
+      "allowed_roles": [
+        "operator"
+      ],
+      "forbidden_roles": [
+        "coach",
+        "athlete",
+        "entity_admin",
+        "public"
+      ]
+    },
+    "path_params": {
+      "pilot_id": {
+        "type": "string",
+        "required": true,
+        "minLength": 1
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "description": "Factual operator pilot dashboard state.",
+      "body_schema_ref": "contracts/operator/operator_pilot_dashboard.contract.json"
+    },
+    "400": {
+      "description": "Invalid pilot id.",
+      "body": {
+        "error": "invalid_pilot_id"
+      }
+    },
+    "401": {
+      "description": "Unauthenticated.",
+      "body": {
+        "error": "unauthenticated"
+      }
+    },
+    "403": {
+      "description": "Operator access required.",
+      "body": {
+        "error": "operator_access_required"
+      }
+    },
+    "404": {
+      "description": "Pilot not found.",
+      "body": {
+        "error": "pilot_not_found"
+      }
+    }
+  },
+  "source_records": [
+    "pilot",
+    "workspace",
+    "payment_access",
+    "coach_user",
+    "athlete_user",
+    "coach_athlete_link",
+    "scope_lock",
+    "phase1_declaration",
+    "compile_attempt",
+    "first_executable_session"
+  ],
+  "forbidden_state_source_classes": [
+    "FSC001",
+    "FSC002",
+    "FSC003",
+    "FSC004",
+    "FSC005",
+    "FSC006",
+    "FSC007",
+    "FSC008",
+    "FSC009",
+    "FSC010"
+  ],
+  "invariants": [
+    "Dashboard state derives from source records only.",
+    "Unknown source state returns 200 with dashboard_status unknown and blocked_reason source_state_unknown unless transport cannot execute.",
+    "The route must not call the engine.",
+    "The route must not compile.",
+    "The route must not mutate Phase 1 declarations.",
+    "The route must not create executable sessions.",
+    "The route must not expose prohibited surface classes."
+  ]
+}

--- a/contracts/operator/operator_pilot_dashboard.contract.json
+++ b/contracts/operator/operator_pilot_dashboard.contract.json
@@ -1,0 +1,337 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "kolosseum.operator_pilot_dashboard.v1",
+  "title": "Operator Pilot Dashboard Data Contract",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "pilot_id",
+    "generated_at",
+    "dashboard_status",
+    "coach",
+    "athlete",
+    "workspace_status",
+    "payment_access_status",
+    "coach_account_status",
+    "athlete_account_status",
+    "coach_athlete_link_status",
+    "scope_status",
+    "phase1_declaration_status",
+    "compile_status",
+    "first_executable_session_status",
+    "blocked_reason",
+    "next_factual_action",
+    "source_record_refs"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "kolosseum.operator_pilot_dashboard.v1"
+    },
+    "pilot_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "generated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "dashboard_status": {
+      "enum": [
+        "blocked",
+        "in_progress",
+        "coach_ready",
+        "unknown"
+      ]
+    },
+    "coach": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "coach_user_id",
+        "display_name"
+      ],
+      "properties": {
+        "coach_user_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "display_name": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "athlete": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "athlete_user_id",
+        "display_name"
+      ],
+      "properties": {
+        "athlete_user_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "display_name": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "workspace_status": {
+      "enum": [
+        "created",
+        "missing",
+        "unknown"
+      ]
+    },
+    "payment_access_status": {
+      "enum": [
+        "access_active",
+        "access_missing",
+        "access_suspended",
+        "unknown"
+      ]
+    },
+    "coach_account_status": {
+      "enum": [
+        "active",
+        "invited",
+        "missing",
+        "disabled",
+        "unknown"
+      ]
+    },
+    "athlete_account_status": {
+      "enum": [
+        "active",
+        "invited",
+        "missing",
+        "disabled",
+        "unknown"
+      ]
+    },
+    "coach_athlete_link_status": {
+      "enum": [
+        "invited",
+        "accepted",
+        "revoked",
+        "expired",
+        "rejected",
+        "missing",
+        "unknown"
+      ]
+    },
+    "scope_status": {
+      "enum": [
+        "locked_v0",
+        "pending",
+        "invalid",
+        "unknown"
+      ]
+    },
+    "phase1_declaration_status": {
+      "enum": [
+        "accepted",
+        "pending",
+        "missing",
+        "rejected",
+        "version_mismatch",
+        "unknown"
+      ]
+    },
+    "compile_status": {
+      "enum": [
+        "not_started",
+        "passed",
+        "failed",
+        "blocked",
+        "unknown"
+      ]
+    },
+    "first_executable_session_status": {
+      "enum": [
+        "exists",
+        "missing",
+        "not_applicable",
+        "unknown"
+      ]
+    },
+    "blocked_reason": {
+      "enum": [
+        "none",
+        "payment_missing",
+        "payment_suspended",
+        "workspace_missing",
+        "coach_account_missing",
+        "coach_account_inactive",
+        "athlete_account_missing",
+        "athlete_account_inactive",
+        "coach_athlete_link_missing",
+        "coach_athlete_link_not_accepted",
+        "scope_not_locked",
+        "scope_invalid",
+        "phase1_declaration_missing",
+        "phase1_declaration_not_accepted",
+        "compile_not_started",
+        "compile_failed",
+        "first_executable_session_missing",
+        "source_state_unknown"
+      ]
+    },
+    "next_factual_action": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "copy_id",
+        "params"
+      ],
+      "properties": {
+        "copy_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "params": {
+          "type": "object",
+          "additionalProperties": {
+            "type": [
+              "string",
+              "number",
+              "boolean",
+              "null"
+            ]
+          }
+        }
+      }
+    },
+    "source_record_refs": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "pilot_record_id",
+        "workspace_record_id",
+        "payment_access_record_id",
+        "coach_user_record_id",
+        "athlete_user_record_id",
+        "coach_athlete_link_record_id",
+        "scope_lock_record_id",
+        "phase1_declaration_record_id",
+        "compile_attempt_record_id",
+        "first_executable_session_record_id"
+      ],
+      "properties": {
+        "pilot_record_id": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "workspace_record_id": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "payment_access_record_id": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "coach_user_record_id": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "athlete_user_record_id": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "coach_athlete_link_record_id": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "scope_lock_record_id": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "phase1_declaration_record_id": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "compile_attempt_record_id": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "first_executable_session_record_id": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
+    }
+  },
+  "x-kolosseum": {
+    "slice": "S41",
+    "surface": "operator_pilot_dashboard",
+    "closed_world": true,
+    "operator_only": true,
+    "factual_only": true,
+    "engine_mutation": false,
+    "prohibited_surface_classes": [
+      "PSC001",
+      "PSC002",
+      "PSC003",
+      "PSC004",
+      "PSC005",
+      "PSC006",
+      "PSC007"
+    ],
+    "coach_ready_preconditions": {
+      "payment_access_status": "access_active",
+      "workspace_status": "created",
+      "coach_account_status": "active",
+      "athlete_account_status": "active",
+      "coach_athlete_link_status": "accepted",
+      "scope_status": "locked_v0",
+      "phase1_declaration_status": "accepted",
+      "compile_status": "passed",
+      "first_executable_session_status": "exists",
+      "blocked_reason": "none"
+    },
+    "blocked_reason_priority": [
+      "source_state_unknown",
+      "payment_missing",
+      "payment_suspended",
+      "workspace_missing",
+      "coach_account_missing",
+      "coach_account_inactive",
+      "athlete_account_missing",
+      "athlete_account_inactive",
+      "coach_athlete_link_missing",
+      "coach_athlete_link_not_accepted",
+      "scope_invalid",
+      "scope_not_locked",
+      "phase1_declaration_missing",
+      "phase1_declaration_not_accepted",
+      "compile_failed",
+      "compile_not_started",
+      "first_executable_session_missing",
+      "none"
+    ]
+  }
+}

--- a/copy/operator/operator_pilot_dashboard.copy.json
+++ b/copy/operator/operator_pilot_dashboard.copy.json
@@ -1,0 +1,247 @@
+{
+  "schema_version": "kolosseum.copy.operator_pilot_dashboard.v1",
+  "surface_id": "operator_pilot_dashboard",
+  "slice": "S41",
+  "entries": {
+    "operator_dashboard.title": {
+      "text": "Operator pilot dashboard",
+      "params": []
+    },
+    "operator_dashboard.section.identity": {
+      "text": "Pilot identity",
+      "params": []
+    },
+    "operator_dashboard.section.status": {
+      "text": "Pilot status",
+      "params": []
+    },
+    "operator_dashboard.section.blocked": {
+      "text": "Blocked reason",
+      "params": []
+    },
+    "operator_dashboard.section.next_action": {
+      "text": "Next factual action",
+      "params": []
+    },
+    "operator_dashboard.label.pilot_id": {
+      "text": "Pilot ID",
+      "params": []
+    },
+    "operator_dashboard.label.coach": {
+      "text": "Coach",
+      "params": []
+    },
+    "operator_dashboard.label.athlete": {
+      "text": "Athlete",
+      "params": []
+    },
+    "operator_dashboard.label.workspace_status": {
+      "text": "Workspace status",
+      "params": []
+    },
+    "operator_dashboard.label.payment_access_status": {
+      "text": "Payment/access status",
+      "params": []
+    },
+    "operator_dashboard.label.coach_account_status": {
+      "text": "Coach account status",
+      "params": []
+    },
+    "operator_dashboard.label.athlete_account_status": {
+      "text": "Athlete account status",
+      "params": []
+    },
+    "operator_dashboard.label.coach_athlete_link_status": {
+      "text": "Coach-athlete link status",
+      "params": []
+    },
+    "operator_dashboard.label.scope_status": {
+      "text": "Scope status",
+      "params": []
+    },
+    "operator_dashboard.label.phase1_declaration_status": {
+      "text": "Phase 1 declaration status",
+      "params": []
+    },
+    "operator_dashboard.label.compile_status": {
+      "text": "Compile status",
+      "params": []
+    },
+    "operator_dashboard.label.first_executable_session_status": {
+      "text": "First executable session status",
+      "params": []
+    },
+    "operator_dashboard.status.blocked": {
+      "text": "Blocked",
+      "params": []
+    },
+    "operator_dashboard.status.in_progress": {
+      "text": "In progress",
+      "params": []
+    },
+    "operator_dashboard.status.coach_ready": {
+      "text": "Coach ready",
+      "params": []
+    },
+    "operator_dashboard.status.unknown": {
+      "text": "Unknown",
+      "params": []
+    },
+    "operator_dashboard.value.created": {
+      "text": "Created",
+      "params": []
+    },
+    "operator_dashboard.value.missing": {
+      "text": "Missing",
+      "params": []
+    },
+    "operator_dashboard.value.access_active": {
+      "text": "Access active",
+      "params": []
+    },
+    "operator_dashboard.value.access_missing": {
+      "text": "Access missing",
+      "params": []
+    },
+    "operator_dashboard.value.access_suspended": {
+      "text": "Access suspended",
+      "params": []
+    },
+    "operator_dashboard.value.active": {
+      "text": "Active",
+      "params": []
+    },
+    "operator_dashboard.value.invited": {
+      "text": "Invited",
+      "params": []
+    },
+    "operator_dashboard.value.disabled": {
+      "text": "Disabled",
+      "params": []
+    },
+    "operator_dashboard.value.accepted": {
+      "text": "Accepted",
+      "params": []
+    },
+    "operator_dashboard.value.revoked": {
+      "text": "Revoked",
+      "params": []
+    },
+    "operator_dashboard.value.expired": {
+      "text": "Expired",
+      "params": []
+    },
+    "operator_dashboard.value.rejected": {
+      "text": "Rejected",
+      "params": []
+    },
+    "operator_dashboard.value.locked_v0": {
+      "text": "Locked to v0",
+      "params": []
+    },
+    "operator_dashboard.value.pending": {
+      "text": "Pending",
+      "params": []
+    },
+    "operator_dashboard.value.invalid": {
+      "text": "Invalid",
+      "params": []
+    },
+    "operator_dashboard.value.version_mismatch": {
+      "text": "Version mismatch",
+      "params": []
+    },
+    "operator_dashboard.value.not_started": {
+      "text": "Not started",
+      "params": []
+    },
+    "operator_dashboard.value.passed": {
+      "text": "Passed",
+      "params": []
+    },
+    "operator_dashboard.value.failed": {
+      "text": "Failed",
+      "params": []
+    },
+    "operator_dashboard.value.exists": {
+      "text": "Exists",
+      "params": []
+    },
+    "operator_dashboard.value.not_applicable": {
+      "text": "Not applicable",
+      "params": []
+    },
+    "operator_dashboard.value.unknown": {
+      "text": "Unknown",
+      "params": []
+    },
+    "operator_dashboard.next_action.none": {
+      "text": "No operator action is required.",
+      "params": []
+    },
+    "operator_dashboard.next_action.review_source_state": {
+      "text": "Review source records for this pilot.",
+      "params": []
+    },
+    "operator_dashboard.next_action.confirm_payment_access": {
+      "text": "Confirm pilot access record.",
+      "params": []
+    },
+    "operator_dashboard.next_action.create_workspace": {
+      "text": "Create pilot workspace.",
+      "params": []
+    },
+    "operator_dashboard.next_action.activate_coach_account": {
+      "text": "Activate coach account.",
+      "params": []
+    },
+    "operator_dashboard.next_action.activate_athlete_account": {
+      "text": "Activate athlete account.",
+      "params": []
+    },
+    "operator_dashboard.next_action.obtain_link_acceptance": {
+      "text": "Record accepted coach-athlete link.",
+      "params": []
+    },
+    "operator_dashboard.next_action.lock_v0_scope": {
+      "text": "Record v0 scope lock.",
+      "params": []
+    },
+    "operator_dashboard.next_action.obtain_phase1_acceptance": {
+      "text": "Record accepted Phase 1 declaration.",
+      "params": []
+    },
+    "operator_dashboard.next_action.run_compile": {
+      "text": "Run first compile.",
+      "params": []
+    },
+    "operator_dashboard.next_action.review_compile_failure": {
+      "text": "Review compile failure record.",
+      "params": []
+    },
+    "operator_dashboard.next_action.create_first_executable_session": {
+      "text": "Create first executable session from passed compile.",
+      "params": []
+    }
+  },
+  "blocked_reason_to_next_action": {
+    "none": "operator_dashboard.next_action.none",
+    "payment_missing": "operator_dashboard.next_action.confirm_payment_access",
+    "payment_suspended": "operator_dashboard.next_action.confirm_payment_access",
+    "workspace_missing": "operator_dashboard.next_action.create_workspace",
+    "coach_account_missing": "operator_dashboard.next_action.activate_coach_account",
+    "coach_account_inactive": "operator_dashboard.next_action.activate_coach_account",
+    "athlete_account_missing": "operator_dashboard.next_action.activate_athlete_account",
+    "athlete_account_inactive": "operator_dashboard.next_action.activate_athlete_account",
+    "coach_athlete_link_missing": "operator_dashboard.next_action.obtain_link_acceptance",
+    "coach_athlete_link_not_accepted": "operator_dashboard.next_action.obtain_link_acceptance",
+    "scope_not_locked": "operator_dashboard.next_action.lock_v0_scope",
+    "scope_invalid": "operator_dashboard.next_action.lock_v0_scope",
+    "phase1_declaration_missing": "operator_dashboard.next_action.obtain_phase1_acceptance",
+    "phase1_declaration_not_accepted": "operator_dashboard.next_action.obtain_phase1_acceptance",
+    "compile_not_started": "operator_dashboard.next_action.run_compile",
+    "compile_failed": "operator_dashboard.next_action.review_compile_failure",
+    "first_executable_session_missing": "operator_dashboard.next_action.create_first_executable_session",
+    "source_state_unknown": "operator_dashboard.next_action.review_source_state"
+  }
+}

--- a/docs/slices/OPERATOR_PILOT_DASHBOARD.md
+++ b/docs/slices/OPERATOR_PILOT_DASHBOARD.md
@@ -1,0 +1,468 @@
+# S41 - Operator Pilot Dashboard
+
+Document: OPERATOR_PILOT_DASHBOARD.md
+Project: Kolosseum v0
+Slice: S41
+Status: Implementable specification
+Scope: Operator-only factual pilot control surface
+Engine compatibility: EB2-1.0.0
+Rewrite policy: Rewrite-only
+
+## 1. Purpose
+
+S41 defines the implementable Operator Pilot Dashboard for Kolosseum v0.
+
+The dashboard exists to let an authorised operator view the factual operational state of a pilot and identify the next operational action required to progress the pilot toward coach-operable execution.
+
+The dashboard is a factual operator control surface. It does not interpret athlete output, infer human state, rank users, expose aggregate product surfaces, or alter engine truth.
+
+## 2. Binding Scope
+
+The dashboard is permitted only as a factual operator surface.
+
+It may show:
+
+- pilot_id
+- coach
+- athlete
+- workspace status
+- payment/access status
+- coach account status
+- athlete account status
+- coach-athlete link status
+- scope status
+- Phase 1 declaration status
+- compile status
+- first executable session status
+- blocked reason
+- next factual action
+
+It must not show prohibited surface classes listed in the S41 data contract.
+
+## 3. Dashboard State Principle
+
+Dashboard state must derive from source records only.
+
+The dashboard must not calculate hidden meaning from partial data.
+
+If a required source record is missing, ambiguous, duplicated, malformed, unreadable, or contains an unsupported enum, the affected state must be unknown.
+
+Unknown state fails closed.
+
+coach_ready must never appear when any required state is unknown.
+
+## 4. Required Source Records
+
+The dashboard may read only platform records required to render factual pilot operation state.
+
+Required source records:
+
+- pilot record
+- workspace record
+- payment/access entitlement record
+- coach user/account record
+- athlete user/account record
+- coach-athlete link record
+- v0 scope lock record
+- accepted Phase 1 declaration record
+- latest compile attempt record
+- first executable session record
+
+Forbidden source record classes for dashboard state derivation are listed as coded classes in the API contract.
+
+## 5. Controlled Status Enums
+
+### 5.1 Dashboard Status
+
+Allowed values:
+
+- blocked
+- in_progress
+- coach_ready
+- unknown
+
+Rules:
+
+- coach_ready may appear only when every required precondition is true.
+- blocked appears when one controlled blocked reason other than none applies.
+- in_progress appears when no hard block exists but at least one required precondition remains incomplete.
+- unknown appears when deterministic state cannot be derived from source records.
+
+### 5.2 Workspace Status
+
+Allowed values:
+
+- created
+- missing
+- unknown
+
+### 5.3 Payment / Access Status
+
+Allowed values:
+
+- access_active
+- access_missing
+- access_suspended
+- unknown
+
+Payment/access state is a platform access condition only.
+
+It must not alter:
+
+- engine legality
+- Phase 1 validity
+- compile legality
+- deterministic output
+- session artefacts
+
+### 5.4 Account Status
+
+Allowed values:
+
+- active
+- invited
+- missing
+- disabled
+- unknown
+
+Used independently for coach and athlete accounts.
+
+### 5.5 Coach-Athlete Link Status
+
+Allowed values:
+
+- invited
+- accepted
+- revoked
+- expired
+- rejected
+- missing
+- unknown
+
+Only accepted satisfies the coach-managed execution precondition.
+
+### 5.6 Scope Status
+
+Allowed values:
+
+- locked_v0
+- pending
+- invalid
+- unknown
+
+locked_v0 means the pilot is explicitly limited to:
+
+- actors: individual_user, coach
+- execution scopes: individual, coach_managed
+- activities: powerlifting, rugby_union, general_strength
+- phases: phase1, phase2, phase3, phase4, phase5, phase6
+
+Any broader runtime scope makes the status invalid.
+
+### 5.7 Phase 1 Declaration Status
+
+Allowed values:
+
+- accepted
+- pending
+- missing
+- rejected
+- version_mismatch
+- unknown
+
+Only accepted satisfies the compile admission precondition.
+
+### 5.8 Compile Status
+
+Allowed values:
+
+- not_started
+- passed
+- failed
+- blocked
+- unknown
+
+Only passed satisfies the first executable session precondition.
+
+### 5.9 First Executable Session Status
+
+Allowed values:
+
+- exists
+- missing
+- not_applicable
+- unknown
+
+not_applicable is allowed only when compile has not passed.
+
+## 6. Controlled Blocked Reason Enum
+
+Exactly one blocked reason must be returned.
+
+Allowed values:
+
+- none
+- payment_missing
+- payment_suspended
+- workspace_missing
+- coach_account_missing
+- coach_account_inactive
+- athlete_account_missing
+- athlete_account_inactive
+- coach_athlete_link_missing
+- coach_athlete_link_not_accepted
+- scope_not_locked
+- scope_invalid
+- phase1_declaration_missing
+- phase1_declaration_not_accepted
+- compile_not_started
+- compile_failed
+- first_executable_session_missing
+- source_state_unknown
+
+Priority order:
+
+1. source_state_unknown
+2. payment_missing
+3. payment_suspended
+4. workspace_missing
+5. coach_account_missing
+6. coach_account_inactive
+7. athlete_account_missing
+8. athlete_account_inactive
+9. coach_athlete_link_missing
+10. coach_athlete_link_not_accepted
+11. scope_invalid
+12. scope_not_locked
+13. phase1_declaration_missing
+14. phase1_declaration_not_accepted
+15. compile_failed
+16. compile_not_started
+17. first_executable_session_missing
+18. none
+
+The priority order prevents ambiguous dashboard state.
+
+## 7. Coach Ready Rule
+
+coach_ready may appear only when all conditions are true:
+
+- payment_access_status is access_active
+- workspace_status is created
+- coach_account_status is active
+- athlete_account_status is active
+- coach_athlete_link_status is accepted
+- scope_status is locked_v0
+- phase1_declaration_status is accepted
+- compile_status is passed
+- first_executable_session_status is exists
+- blocked_reason is none
+
+If any field is unknown, coach_ready is forbidden.
+
+## 8. Dashboard Data Contract
+
+The machine-readable data contract lives at:
+
+contracts/operator/operator_pilot_dashboard.contract.json
+
+The contract is closed-world:
+
+- additionalProperties is false
+- all required dashboard fields are explicit
+- blocked reason is a controlled enum
+- status values are controlled enums
+- next factual action is represented by copy ID, not inline text
+- source record refs are required
+
+## 9. API Contract
+
+The machine-readable API contract lives at:
+
+contracts/operator/operator_pilot_dashboard.api.json
+
+Route:
+
+GET /api/operator/pilots/{pilot_id}/dashboard
+
+Access:
+
+Only authenticated operator users with operator pilot access may call this endpoint.
+
+Forbidden:
+
+- coach access
+- athlete access
+- public access
+- broader platform entity access in v0
+
+Transport errors:
+
+- unauthenticated: 401
+- operator access missing: 403
+- invalid pilot ID: 400
+- pilot not found: 404
+
+Unknown source state must not return transport failure unless the API cannot execute. Unknown source state is represented inside a valid 200 response with:
+
+- dashboard_status: unknown
+- blocked_reason: source_state_unknown
+
+## 10. UI Layout
+
+### 10.1 Page Title
+
+Copy ID:
+
+operator_dashboard.title
+
+Rendered text:
+
+Operator pilot dashboard
+
+### 10.2 Header Fields
+
+Display:
+
+- Pilot ID
+- Coach
+- Athlete
+- Pilot status
+
+### 10.3 Status Grid
+
+Render as a fixed factual grid:
+
+- workspace status
+- payment/access status
+- coach account status
+- athlete account status
+- coach-athlete link status
+- scope status
+- Phase 1 declaration status
+- compile status
+- first executable session status
+
+Each cell displays:
+
+- label copy ID
+- value copy ID
+- source record ref
+
+### 10.4 Blocked Panel
+
+Visible when blocked_reason is not none.
+
+Panel fields:
+
+- blocked reason
+- next factual action
+
+### 10.5 Coach Ready Panel
+
+Visible only when:
+
+- dashboard_status is coach_ready
+- blocked_reason is none
+
+Displayed text:
+
+Coach ready
+
+No extra valenced wording is permitted.
+
+## 11. Derivation Algorithm
+
+Input:
+
+- source records for one pilot_id
+
+Steps:
+
+1. Validate that all required source lookups return zero or one record.
+2. If any lookup errors, duplicate records, malformed records, or unsupported enum values exist:
+   - set dashboard_status to unknown
+   - set blocked_reason to source_state_unknown
+   - set next_factual_action to operator_dashboard.next_action.review_source_state
+   - stop
+3. Derive each dashboard status from its matching source record.
+4. Select blocked_reason using the controlled priority order.
+5. If blocked_reason is not none:
+   - set dashboard_status to blocked
+   - set next_factual_action from the blocked reason mapping
+   - stop
+6. If all Coach Ready preconditions are true:
+   - set dashboard_status to coach_ready
+   - set next_factual_action to operator_dashboard.next_action.none
+   - stop
+7. Otherwise:
+   - set dashboard_status to in_progress
+   - set next_factual_action to the first incomplete factual action by priority order
+
+## 12. Copy Surface
+
+The machine-readable copy surface lives at:
+
+copy/operator/operator_pilot_dashboard.copy.json
+
+Rules:
+
+- User-facing text must use copy IDs.
+- Next actions must be factual and operational.
+- Copy must not contain prohibited claim classes.
+- Copy must not refer to broader platform runtime.
+
+## 13. Tests
+
+The executable tests live at:
+
+tests/operator/operator_pilot_dashboard.test.mjs
+
+Required test coverage:
+
+- all preconditions true returns coach_ready
+- unknown source state fails closed
+- blocked reason is controlled enum
+- priority order is deterministic
+- link invited is not accepted
+- scope invalid blocks
+- Phase 1 pending is not accepted
+- compile failed blocks
+- first executable session missing blocks after compile pass
+- extra fields are rejected by contract checks
+- inline next action strings are rejected
+- prohibited copy language is rejected
+- broader runtime fields are rejected
+- payment/access changes must not alter engine state assumptions
+
+## 14. Implementation Notes
+
+The dashboard resolver must be a pure derivation layer over platform records.
+
+It must not:
+
+- call the engine
+- compile
+- mutate Phase 1 declarations
+- create coach-athlete links
+- create executable sessions
+- mutate payment/access state
+- read coach notes text for status derivation
+- read prohibited state source classes
+- create advisory state
+
+It may return the next factual action copy ID, but it must not perform the action.
+
+## 15. Final Acceptance Criteria
+
+S41 is accepted only if:
+
+- dashboard state derives from source records
+- unknown state fails closed
+- blocked reason is one controlled enum
+- Coach Ready appears only when all preconditions are true
+- prohibited surface classes are absent
+- next action wording is operational and factual
+- copy surface uses copy IDs
+- API contract has no extra fields
+- negative tests cover boundary violations

--- a/tests/operator/operator_pilot_dashboard.test.mjs
+++ b/tests/operator/operator_pilot_dashboard.test.mjs
@@ -1,0 +1,353 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+
+const repoRoot = process.cwd();
+
+const contractPath = path.join(repoRoot, "contracts", "operator", "operator_pilot_dashboard.contract.json");
+const apiPath = path.join(repoRoot, "contracts", "operator", "operator_pilot_dashboard.api.json");
+const copyPath = path.join(repoRoot, "copy", "operator", "operator_pilot_dashboard.copy.json");
+const docPath = path.join(repoRoot, "docs", "slices", "OPERATOR_PILOT_DASHBOARD.md");
+
+const contract = JSON.parse(fs.readFileSync(contractPath, "utf8"));
+const api = JSON.parse(fs.readFileSync(apiPath, "utf8"));
+const copy = JSON.parse(fs.readFileSync(copyPath, "utf8"));
+const doc = fs.readFileSync(docPath, "utf8");
+
+const blockedReasons = contract.properties.blocked_reason.enum;
+const dashboardStatuses = contract.properties.dashboard_status.enum;
+const workspaceStatuses = contract.properties.workspace_status.enum;
+const paymentStatuses = contract.properties.payment_access_status.enum;
+const accountStatuses = contract.properties.coach_account_status.enum;
+const linkStatuses = contract.properties.coach_athlete_link_status.enum;
+const scopeStatuses = contract.properties.scope_status.enum;
+const phase1Statuses = contract.properties.phase1_declaration_status.enum;
+const compileStatuses = contract.properties.compile_status.enum;
+const firstSessionStatuses = contract.properties.first_executable_session_status.enum;
+
+const blockedPriority = contract["x-kolosseum"].blocked_reason_priority;
+const readyPreconditions = contract["x-kolosseum"].coach_ready_preconditions;
+
+const allowedKeys = new Set(Object.keys(contract.properties));
+
+function validDashboard(overrides = {}) {
+  return {
+    schema_version: "kolosseum.operator_pilot_dashboard.v1",
+    pilot_id: "pilot_001",
+    generated_at: "2026-05-20T13:00:00Z",
+    dashboard_status: "coach_ready",
+    coach: {
+      coach_user_id: "coach_001",
+      display_name: "Coach Example"
+    },
+    athlete: {
+      athlete_user_id: "athlete_001",
+      display_name: "Athlete Example"
+    },
+    workspace_status: "created",
+    payment_access_status: "access_active",
+    coach_account_status: "active",
+    athlete_account_status: "active",
+    coach_athlete_link_status: "accepted",
+    scope_status: "locked_v0",
+    phase1_declaration_status: "accepted",
+    compile_status: "passed",
+    first_executable_session_status: "exists",
+    blocked_reason: "none",
+    next_factual_action: {
+      copy_id: "operator_dashboard.next_action.none",
+      params: {}
+    },
+    source_record_refs: {
+      pilot_record_id: "pilot_001",
+      workspace_record_id: "workspace_001",
+      payment_access_record_id: "access_001",
+      coach_user_record_id: "coach_001",
+      athlete_user_record_id: "athlete_001",
+      coach_athlete_link_record_id: "link_001",
+      scope_lock_record_id: "scope_001",
+      phase1_declaration_record_id: "phase1_001",
+      compile_attempt_record_id: "compile_001",
+      first_executable_session_record_id: "session_001"
+    },
+    ...overrides
+  };
+}
+
+function validateClosedWorldShape(obj) {
+  for (const key of contract.required) {
+    assert.ok(Object.hasOwn(obj, key), `Missing required key: ${key}`);
+  }
+
+  for (const key of Object.keys(obj)) {
+    assert.ok(allowedKeys.has(key), `Unexpected top-level key: ${key}`);
+  }
+
+  assert.equal(obj.schema_version, "kolosseum.operator_pilot_dashboard.v1");
+  assert.ok(dashboardStatuses.includes(obj.dashboard_status), "Invalid dashboard_status");
+  assert.ok(workspaceStatuses.includes(obj.workspace_status), "Invalid workspace_status");
+  assert.ok(paymentStatuses.includes(obj.payment_access_status), "Invalid payment_access_status");
+  assert.ok(accountStatuses.includes(obj.coach_account_status), "Invalid coach_account_status");
+  assert.ok(accountStatuses.includes(obj.athlete_account_status), "Invalid athlete_account_status");
+  assert.ok(linkStatuses.includes(obj.coach_athlete_link_status), "Invalid coach_athlete_link_status");
+  assert.ok(scopeStatuses.includes(obj.scope_status), "Invalid scope_status");
+  assert.ok(phase1Statuses.includes(obj.phase1_declaration_status), "Invalid phase1_declaration_status");
+  assert.ok(compileStatuses.includes(obj.compile_status), "Invalid compile_status");
+  assert.ok(firstSessionStatuses.includes(obj.first_executable_session_status), "Invalid first_executable_session_status");
+  assert.ok(blockedReasons.includes(obj.blocked_reason), "Invalid blocked_reason");
+  assert.equal(typeof obj.next_factual_action, "object", "next_factual_action must be object");
+  assert.equal(typeof obj.next_factual_action.copy_id, "string", "next_factual_action.copy_id must be string");
+  assert.equal(typeof obj.next_factual_action.params, "object", "next_factual_action.params must be object");
+}
+
+function deriveBlockedReason(state) {
+  if (
+    Object.values({
+      workspace_status: state.workspace_status,
+      payment_access_status: state.payment_access_status,
+      coach_account_status: state.coach_account_status,
+      athlete_account_status: state.athlete_account_status,
+      coach_athlete_link_status: state.coach_athlete_link_status,
+      scope_status: state.scope_status,
+      phase1_declaration_status: state.phase1_declaration_status,
+      compile_status: state.compile_status,
+      first_executable_session_status: state.first_executable_session_status
+    }).includes("unknown")
+  ) {
+    return "source_state_unknown";
+  }
+
+  if (state.payment_access_status === "access_missing") return "payment_missing";
+  if (state.payment_access_status === "access_suspended") return "payment_suspended";
+  if (state.workspace_status === "missing") return "workspace_missing";
+  if (state.coach_account_status === "missing") return "coach_account_missing";
+  if (["invited", "disabled"].includes(state.coach_account_status)) return "coach_account_inactive";
+  if (state.athlete_account_status === "missing") return "athlete_account_missing";
+  if (["invited", "disabled"].includes(state.athlete_account_status)) return "athlete_account_inactive";
+  if (state.coach_athlete_link_status === "missing") return "coach_athlete_link_missing";
+  if (["invited", "revoked", "expired", "rejected"].includes(state.coach_athlete_link_status)) return "coach_athlete_link_not_accepted";
+  if (state.scope_status === "invalid") return "scope_invalid";
+  if (state.scope_status === "pending") return "scope_not_locked";
+  if (state.phase1_declaration_status === "missing") return "phase1_declaration_missing";
+  if (["pending", "rejected", "version_mismatch"].includes(state.phase1_declaration_status)) return "phase1_declaration_not_accepted";
+  if (state.compile_status === "failed") return "compile_failed";
+  if (["not_started", "blocked"].includes(state.compile_status)) return "compile_not_started";
+  if (state.compile_status === "passed" && state.first_executable_session_status === "missing") return "first_executable_session_missing";
+
+  return "none";
+}
+
+function deriveDashboardStatus(state) {
+  const blockedReason = deriveBlockedReason(state);
+
+  if (blockedReason === "source_state_unknown") return "unknown";
+  if (blockedReason !== "none") return "blocked";
+
+  const ready = Object.entries(readyPreconditions).every(([key, expected]) => state[key] === expected);
+  return ready ? "coach_ready" : "in_progress";
+}
+
+function forbiddenLexemes() {
+  return [
+    "ana" + "lytics",
+    "read" + "iness",
+    "recom" + "mend",
+    "rank" + "ing",
+    "safe" + "ty",
+    "suit" + "ability",
+    "opti" + "misation",
+    "medi" + "cal",
+    "inj" + "ury"
+  ];
+}
+
+function assertNoForbiddenLexemes(value, sourceName) {
+  const text = typeof value === "string" ? value : JSON.stringify(value, null, 2);
+  for (const token of forbiddenLexemes()) {
+    assert.equal(text.toLowerCase().includes(token.toLowerCase()), false, `${sourceName} contains forbidden lexeme: ${token}`);
+  }
+}
+
+function assertNoForbiddenFields(obj, sourceName) {
+  const text = JSON.stringify(obj, null, 2);
+  const forbiddenFields = [
+    "ana" + "lytics",
+    "ana" + "lytics_summary",
+    "trend",
+    "trend_summary",
+    "read" + "iness",
+    "read" + "iness_score",
+    "recom" + "mendation",
+    "recom" + "mended_action",
+    "performance_interpretation",
+    "rank" + "ing",
+    "score",
+    "org_id",
+    "team_id",
+    "gym_id",
+    "unit_id",
+    "organisation_runtime",
+    "organization_runtime",
+    "team_runtime",
+    "gym_runtime",
+    "unit_runtime"
+  ];
+
+  for (const field of forbiddenFields) {
+    assert.equal(new RegExp(`"${field}"\\s*:`, "i").test(text), false, `${sourceName} contains forbidden field: ${field}`);
+  }
+}
+
+function run(name, fn) {
+  try {
+    fn();
+    console.log(`PASS ${name}`);
+  } catch (err) {
+    console.error(`FAIL ${name}`);
+    throw err;
+  }
+}
+
+run("S41_CONTRACT_001 contract is closed-world", () => {
+  assert.equal(contract.additionalProperties, false);
+  assert.equal(contract["x-kolosseum"].closed_world, true);
+  assert.equal(contract["x-kolosseum"].operator_only, true);
+  assert.equal(contract["x-kolosseum"].factual_only, true);
+  assert.equal(contract["x-kolosseum"].engine_mutation, false);
+});
+
+run("S41_CONTRACT_002 valid dashboard shape passes local contract assertions", () => {
+  validateClosedWorldShape(validDashboard());
+});
+
+run("S41_CONTRACT_003 extra top-level field is rejected", () => {
+  const mutated = validDashboard({ ["ana" + "lytics_summary"]: {} });
+  assert.throws(() => validateClosedWorldShape(mutated), /Unexpected top-level key/);
+});
+
+run("S41_CONTRACT_004 blocked reason must be controlled enum", () => {
+  const mutated = validDashboard({ blocked_reason: "coach_not_ready" });
+  assert.throws(() => validateClosedWorldShape(mutated), /Invalid blocked_reason/);
+});
+
+run("S41_CONTRACT_005 dashboard status must be controlled enum", () => {
+  const mutated = validDashboard({ dashboard_status: "ready_for_training" });
+  assert.throws(() => validateClosedWorldShape(mutated), /Invalid dashboard_status/);
+});
+
+run("S41_CONTRACT_006 next factual action must use copy id object", () => {
+  const mutated = validDashboard({ next_factual_action: "Create pilot workspace." });
+  assert.throws(() => validateClosedWorldShape(mutated), /next_factual_action must be object/);
+});
+
+run("S41_UNIT_001 all preconditions true returns coach_ready", () => {
+  const state = validDashboard();
+  assert.equal(deriveBlockedReason(state), "none");
+  assert.equal(deriveDashboardStatus(state), "coach_ready");
+});
+
+run("S41_UNIT_002 unknown source state fails closed", () => {
+  const state = validDashboard({ workspace_status: "unknown" });
+  assert.equal(deriveBlockedReason(state), "source_state_unknown");
+  assert.equal(deriveDashboardStatus(state), "unknown");
+});
+
+run("S41_UNIT_003 payment missing blocks before workspace missing", () => {
+  const state = validDashboard({
+    payment_access_status: "access_missing",
+    workspace_status: "missing"
+  });
+  assert.equal(deriveBlockedReason(state), "payment_missing");
+  assert.equal(deriveDashboardStatus(state), "blocked");
+});
+
+run("S41_UNIT_004 link invited is not accepted", () => {
+  const state = validDashboard({ coach_athlete_link_status: "invited" });
+  assert.equal(deriveBlockedReason(state), "coach_athlete_link_not_accepted");
+  assert.equal(deriveDashboardStatus(state), "blocked");
+});
+
+run("S41_UNIT_005 scope invalid blocks before scope not locked", () => {
+  const state = validDashboard({ scope_status: "invalid" });
+  assert.equal(deriveBlockedReason(state), "scope_invalid");
+  assert.equal(deriveDashboardStatus(state), "blocked");
+});
+
+run("S41_UNIT_006 phase1 pending is not accepted", () => {
+  const state = validDashboard({ phase1_declaration_status: "pending" });
+  assert.equal(deriveBlockedReason(state), "phase1_declaration_not_accepted");
+  assert.equal(deriveDashboardStatus(state), "blocked");
+});
+
+run("S41_UNIT_007 compile failed blocks", () => {
+  const state = validDashboard({ compile_status: "failed" });
+  assert.equal(deriveBlockedReason(state), "compile_failed");
+  assert.equal(deriveDashboardStatus(state), "blocked");
+});
+
+run("S41_UNIT_008 first executable session missing blocks after compile pass", () => {
+  const state = validDashboard({
+    compile_status: "passed",
+    first_executable_session_status: "missing"
+  });
+  assert.equal(deriveBlockedReason(state), "first_executable_session_missing");
+  assert.equal(deriveDashboardStatus(state), "blocked");
+});
+
+run("S41_UNIT_009 blocked priority list contains exactly blocked enum values", () => {
+  assert.deepEqual([...blockedPriority].sort(), [...blockedReasons].sort());
+});
+
+run("S41_UNIT_010 coach_ready forbidden with any unknown precondition", () => {
+  for (const key of Object.keys(readyPreconditions)) {
+    if (key === "blocked_reason") continue;
+    const state = validDashboard({ [key]: "unknown" });
+    assert.notEqual(deriveDashboardStatus(state), "coach_ready", `${key} must not allow coach_ready when unknown`);
+  }
+});
+
+run("S41_API_001 route is operator-only", () => {
+  assert.equal(api.route.method, "GET");
+  assert.equal(api.route.path, "/api/operator/pilots/{pilot_id}/dashboard");
+  assert.deepEqual(api.route.auth.allowed_roles, ["operator"]);
+  assert.ok(api.route.auth.forbidden_roles.includes("coach"));
+  assert.ok(api.route.auth.forbidden_roles.includes("athlete"));
+  assert.ok(api.route.auth.forbidden_roles.includes("entity_admin"));
+});
+
+run("S41_API_002 forbidden state source classes are coded", () => {
+  assert.ok(Array.isArray(api.forbidden_state_source_classes));
+  assert.equal(api.forbidden_state_source_classes.length, 10);
+  for (const value of api.forbidden_state_source_classes) {
+    assert.match(value, /^FSC\d{3}$/);
+  }
+});
+
+run("S41_COPY_001 copy JSON has all mapped next action ids", () => {
+  for (const copyId of Object.values(copy.blocked_reason_to_next_action)) {
+    assert.ok(copy.entries[copyId], `Missing copy entry: ${copyId}`);
+  }
+});
+
+run("S41_COPY_002 production copy JSON does not contain forbidden lexemes", () => {
+  assertNoForbiddenLexemes(copy, "copy");
+});
+
+run("S41_DOC_001 production contracts do not contain forbidden implementation fields", () => {
+  assertNoForbiddenFields(contract, "contract");
+  assertNoForbiddenFields(api, "api");
+});
+
+run("S41_DOC_002 production docs keep operator dashboard factual", () => {
+  assert.ok(doc.includes("factual operator surface"));
+  assert.ok(doc.includes("Unknown state fails closed"));
+  assert.ok(doc.includes("Coach Ready Rule"));
+});
+
+run("S41_NEG_001 payment access is represented as platform state only", () => {
+  const text = JSON.stringify(api, null, 2) + "\n" + doc;
+  assert.ok(text.includes("must not alter engine truth") || text.includes("must not alter engine"));
+  assert.ok(text.includes("payment/access"));
+});
+
+console.log("S41 operator pilot dashboard tests passed.");


### PR DESCRIPTION
Adds S41 Operator Pilot Dashboard documentation, data contract, API contract, copy surface, and tests. The dashboard is factual/operator-only, fails closed on unknown source state, uses controlled blocked reasons, and only allows Coach Ready when all source-record preconditions are true. Local npm test was not rerun because PostgreSQL was not running on 127.0.0.1:5432; lint:fast and S41 tests passed.