### PR TITLE
Add S42 pilot state machine enforcement

### DIFF
--- a/docs/slices/PILOT_STATE_MACHINE_ENFORCEMENT.md
+++ b/docs/slices/PILOT_STATE_MACHINE_ENFORCEMENT.md
@@ -1,0 +1,326 @@
+# S42 - Pilot State Machine Enforcement
+
+Document: PILOT_STATE_MACHINE_ENFORCEMENT.md
+Project: Kolosseum v0
+Slice: S42
+Status: Implementable specification
+Scope: Pilot lifecycle state machine and blocked reason enforcement
+Engine compatibility: EB2-1.0.0
+Rewrite policy: Rewrite-only
+
+## 1. Purpose
+
+S42 turns the pilot lifecycle into code.
+
+Pilot lifecycle state is no longer prose-only. A pilot must move through a controlled state machine, with blocked reasons derived from explicit platform preconditions.
+
+The state machine is platform state only. It must not alter engine output, Phase 1 declarations, compile artefacts, deterministic execution output, or session artefacts.
+
+## 2. Required States
+
+The complete pilot state enum is:
+
+- accepted
+- commercial_pending
+- platform_pending
+- coach_pending
+- athlete_pending
+- link_pending
+- scope_pending
+- phase1_pending
+- compile_pending
+- coach_ready
+- active
+- paused
+- stopped
+- cancelled
+
+No other state exists.
+
+Unknown state fails.
+
+## 3. Required Blocked Reasons
+
+The complete blocked reason enum is:
+
+- payment_missing
+- workspace_missing
+- coach_missing
+- athlete_missing
+- link_not_accepted
+- scope_not_locked
+- phase1_missing
+- phase1_refused
+- compile_failed
+
+No other blocked reason exists.
+
+Blocked reason is nullable only when the lifecycle state is not blocked by one of the controlled conditions.
+
+## 4. Preconditions
+
+The state machine derives from explicit pilot preconditions:
+
+- commercialAccepted
+- paymentAccessActive
+- workspaceCreated
+- coachAccountActive
+- athleteAccountActive
+- coachAthleteLinkAccepted
+- scopeLocked
+- phase1Accepted
+- phase1Refused
+- compilePassed
+- compileFailed
+- firstExecutableSessionExists
+- activationSignalReceived
+- pauseRequested
+- stopRequested
+- cancelRequested
+
+Unknown or missing boolean fields fail closed.
+
+## 5. State Meaning
+
+### accepted
+
+The pilot has been accepted for onboarding, but no later precondition has yet been enforced.
+
+### commercial_pending
+
+Commercial/access preconditions are incomplete.
+
+### platform_pending
+
+Workspace preconditions are incomplete.
+
+### coach_pending
+
+Coach account preconditions are incomplete.
+
+### athlete_pending
+
+Athlete account preconditions are incomplete.
+
+### link_pending
+
+Coach-athlete link preconditions are incomplete.
+
+### scope_pending
+
+v0 scope lock is incomplete.
+
+### phase1_pending
+
+Phase 1 declaration preconditions are incomplete or refused.
+
+### compile_pending
+
+Compile or first executable session preconditions are incomplete or failed.
+
+### coach_ready
+
+All commercial, platform, coach, athlete, link, scope, Phase 1, compile, and first executable session preconditions are satisfied.
+
+### active
+
+Coach Ready has occurred and an activation signal has been received.
+
+### paused
+
+An active pilot has been paused. Pause is operational only.
+
+### stopped
+
+The pilot has been stopped. This is terminal.
+
+### cancelled
+
+The pilot has been cancelled. This is terminal.
+
+## 6. Coach Ready Rule
+
+coach_ready requires all of the following:
+
+- commercialAccepted is true
+- paymentAccessActive is true
+- workspaceCreated is true
+- coachAccountActive is true
+- athleteAccountActive is true
+- coachAthleteLinkAccepted is true
+- scopeLocked is true
+- phase1Accepted is true
+- phase1Refused is false
+- compilePassed is true
+- compileFailed is false
+- firstExecutableSessionExists is true
+
+If any prerequisite is false or unknown, coach_ready is impossible.
+
+## 7. Active Rule
+
+active requires:
+
+- current state is coach_ready or paused
+- all Coach Ready preconditions remain true
+- activationSignalReceived is true
+
+A pilot may not become active directly from earlier pending states.
+
+## 8. Terminal Rule
+
+stopped and cancelled are terminal.
+
+Terminal states cannot resume.
+
+Terminal state transition attempts fail closed.
+
+## 9. Illegal Transition Rule
+
+Illegal transitions fail.
+
+Failure returns:
+
+- ok: false
+- error: illegal_transition
+- current state
+- requested state
+
+The transition function must not silently coerce the requested state.
+
+## 10. Unknown State Rule
+
+Unknown current state fails.
+
+Unknown requested state fails.
+
+Unknown blocked reason fails.
+
+Unknown precondition shape fails.
+
+## 11. Blocked Reason Derivation
+
+Blocked reason priority order:
+
+1. payment_missing
+2. workspace_missing
+3. coach_missing
+4. athlete_missing
+5. link_not_accepted
+6. scope_not_locked
+7. phase1_refused
+8. phase1_missing
+9. compile_failed
+
+If no blocked reason applies, blockedReason is null.
+
+## 12. Automatic State Derivation
+
+The automatic derivation function derives the next lawful lifecycle state from preconditions:
+
+- cancelRequested true -> cancelled
+- stopRequested true -> stopped
+- commercialAccepted false or paymentAccessActive false -> commercial_pending
+- workspaceCreated false -> platform_pending
+- coachAccountActive false -> coach_pending
+- athleteAccountActive false -> athlete_pending
+- coachAthleteLinkAccepted false -> link_pending
+- scopeLocked false -> scope_pending
+- phase1Refused true -> phase1_pending
+- phase1Accepted false -> phase1_pending
+- compileFailed true -> compile_pending
+- compilePassed false -> compile_pending
+- firstExecutableSessionExists false -> compile_pending
+- activationSignalReceived true and current state is coach_ready or active or paused -> active
+- pauseRequested true and current state is active -> paused
+- otherwise -> coach_ready
+
+## 13. Legal Transition Table
+
+| From | To | Condition |
+|---|---|---|
+| accepted | commercial_pending | commercial or payment/access incomplete |
+| accepted | platform_pending | commercial and payment/access complete, workspace incomplete |
+| accepted | coach_pending | prior preconditions complete, coach incomplete |
+| accepted | athlete_pending | prior preconditions complete, athlete incomplete |
+| accepted | link_pending | prior preconditions complete, link incomplete |
+| accepted | scope_pending | prior preconditions complete, scope incomplete |
+| accepted | phase1_pending | prior preconditions complete, Phase 1 incomplete or refused |
+| accepted | compile_pending | prior preconditions complete, compile/session incomplete or failed |
+| accepted | coach_ready | all Coach Ready preconditions true |
+| commercial_pending | platform_pending | commercial and payment/access complete, workspace incomplete |
+| commercial_pending | coach_pending | prior preconditions complete, coach incomplete |
+| commercial_pending | athlete_pending | prior preconditions complete, athlete incomplete |
+| commercial_pending | link_pending | prior preconditions complete, link incomplete |
+| commercial_pending | scope_pending | prior preconditions complete, scope incomplete |
+| commercial_pending | phase1_pending | prior preconditions complete, Phase 1 incomplete or refused |
+| commercial_pending | compile_pending | prior preconditions complete, compile/session incomplete or failed |
+| commercial_pending | coach_ready | all Coach Ready preconditions true |
+| platform_pending | coach_pending | workspace complete, coach incomplete |
+| platform_pending | athlete_pending | prior preconditions complete, athlete incomplete |
+| platform_pending | link_pending | prior preconditions complete, link incomplete |
+| platform_pending | scope_pending | prior preconditions complete, scope incomplete |
+| platform_pending | phase1_pending | prior preconditions complete, Phase 1 incomplete or refused |
+| platform_pending | compile_pending | prior preconditions complete, compile/session incomplete or failed |
+| platform_pending | coach_ready | all Coach Ready preconditions true |
+| coach_pending | athlete_pending | coach complete, athlete incomplete |
+| coach_pending | link_pending | prior preconditions complete, link incomplete |
+| coach_pending | scope_pending | prior preconditions complete, scope incomplete |
+| coach_pending | phase1_pending | prior preconditions complete, Phase 1 incomplete or refused |
+| coach_pending | compile_pending | prior preconditions complete, compile/session incomplete or failed |
+| coach_pending | coach_ready | all Coach Ready preconditions true |
+| athlete_pending | link_pending | athlete complete, link incomplete |
+| athlete_pending | scope_pending | prior preconditions complete, scope incomplete |
+| athlete_pending | phase1_pending | prior preconditions complete, Phase 1 incomplete or refused |
+| athlete_pending | compile_pending | prior preconditions complete, compile/session incomplete or failed |
+| athlete_pending | coach_ready | all Coach Ready preconditions true |
+| link_pending | scope_pending | link accepted, scope incomplete |
+| link_pending | phase1_pending | prior preconditions complete, Phase 1 incomplete or refused |
+| link_pending | compile_pending | prior preconditions complete, compile/session incomplete or failed |
+| link_pending | coach_ready | all Coach Ready preconditions true |
+| scope_pending | phase1_pending | scope locked, Phase 1 incomplete or refused |
+| scope_pending | compile_pending | prior preconditions complete, compile/session incomplete or failed |
+| scope_pending | coach_ready | all Coach Ready preconditions true |
+| phase1_pending | compile_pending | Phase 1 accepted and compile/session incomplete or failed |
+| phase1_pending | coach_ready | all Coach Ready preconditions true |
+| compile_pending | coach_ready | compile passed and first executable session exists |
+| coach_ready | active | activation signal received |
+| active | paused | pause requested |
+| active | stopped | stop requested |
+| active | cancelled | cancel requested |
+| paused | active | activation signal received and Coach Ready preconditions still true |
+| paused | stopped | stop requested |
+| paused | cancelled | cancel requested |
+| coach_ready | stopped | stop requested |
+| coach_ready | cancelled | cancel requested |
+
+No transition is legal from stopped or cancelled.
+
+## 14. Implementation Artefacts
+
+The TypeScript implementation lives at:
+
+src/pilot/pilot_state_machine.ts
+
+The test vectors live at:
+
+tests/fixtures/pilot_state_machine_vectors.json
+
+The executable tests live at:
+
+tests/pilot/pilot_state_machine.test.mjs
+
+## 15. Acceptance Criteria
+
+S42 is accepted only if:
+
+- every state is represented as code
+- every blocked reason is represented as code
+- every legal transition is tested
+- every illegal transition is tested
+- unknown current state fails
+- unknown requested state fails
+- Coach Ready is impossible with a missing prerequisite
+- active requires Coach Ready plus activation signal
+- terminal states cannot resume
+- pilot state does not alter engine output

--- a/src/pilot/pilot_state_machine.ts
+++ b/src/pilot/pilot_state_machine.ts
@@ -1,0 +1,499 @@
+export const PILOT_STATES = [
+  "accepted",
+  "commercial_pending",
+  "platform_pending",
+  "coach_pending",
+  "athlete_pending",
+  "link_pending",
+  "scope_pending",
+  "phase1_pending",
+  "compile_pending",
+  "coach_ready",
+  "active",
+  "paused",
+  "stopped",
+  "cancelled",
+] as const;
+
+export type PilotState = (typeof PILOT_STATES)[number];
+
+export const PILOT_BLOCKED_REASONS = [
+  "payment_missing",
+  "workspace_missing",
+  "coach_missing",
+  "athlete_missing",
+  "link_not_accepted",
+  "scope_not_locked",
+  "phase1_missing",
+  "phase1_refused",
+  "compile_failed",
+] as const;
+
+export type PilotBlockedReason = (typeof PILOT_BLOCKED_REASONS)[number];
+
+export type PilotPreconditions = Readonly<{
+  commercialAccepted: boolean;
+  paymentAccessActive: boolean;
+  workspaceCreated: boolean;
+  coachAccountActive: boolean;
+  athleteAccountActive: boolean;
+  coachAthleteLinkAccepted: boolean;
+  scopeLocked: boolean;
+  phase1Accepted: boolean;
+  phase1Refused: boolean;
+  compilePassed: boolean;
+  compileFailed: boolean;
+  firstExecutableSessionExists: boolean;
+  activationSignalReceived: boolean;
+  pauseRequested: boolean;
+  stopRequested: boolean;
+  cancelRequested: boolean;
+}>;
+
+export type PilotTransitionOk = Readonly<{
+  ok: true;
+  from: PilotState;
+  to: PilotState;
+  blockedReason: PilotBlockedReason | null;
+  engineOutputAltered: false;
+}>;
+
+export type PilotTransitionError = Readonly<{
+  ok: false;
+  error:
+    | "unknown_current_state"
+    | "unknown_requested_state"
+    | "invalid_preconditions"
+    | "illegal_transition"
+    | "terminal_state";
+  from: string;
+  to: string;
+  blockedReason: PilotBlockedReason | null;
+  engineOutputAltered: false;
+}>;
+
+export type PilotTransitionResult = PilotTransitionOk | PilotTransitionError;
+
+export const TERMINAL_PILOT_STATES: ReadonlySet<PilotState> = new Set<PilotState>([
+  "stopped",
+  "cancelled",
+]);
+
+export const PILOT_STATE_ORDER: Readonly<Record<PilotState, number>> = Object.freeze({
+  accepted: 0,
+  commercial_pending: 1,
+  platform_pending: 2,
+  coach_pending: 3,
+  athlete_pending: 4,
+  link_pending: 5,
+  scope_pending: 6,
+  phase1_pending: 7,
+  compile_pending: 8,
+  coach_ready: 9,
+  active: 10,
+  paused: 11,
+  stopped: 12,
+  cancelled: 13,
+});
+
+export const LEGAL_PILOT_TRANSITIONS: Readonly<Record<PilotState, readonly PilotState[]>> = Object.freeze({
+  accepted: [
+    "commercial_pending",
+    "platform_pending",
+    "coach_pending",
+    "athlete_pending",
+    "link_pending",
+    "scope_pending",
+    "phase1_pending",
+    "compile_pending",
+    "coach_ready",
+    "cancelled",
+  ],
+  commercial_pending: [
+    "platform_pending",
+    "coach_pending",
+    "athlete_pending",
+    "link_pending",
+    "scope_pending",
+    "phase1_pending",
+    "compile_pending",
+    "coach_ready",
+    "cancelled",
+  ],
+  platform_pending: [
+    "coach_pending",
+    "athlete_pending",
+    "link_pending",
+    "scope_pending",
+    "phase1_pending",
+    "compile_pending",
+    "coach_ready",
+    "cancelled",
+  ],
+  coach_pending: [
+    "athlete_pending",
+    "link_pending",
+    "scope_pending",
+    "phase1_pending",
+    "compile_pending",
+    "coach_ready",
+    "cancelled",
+  ],
+  athlete_pending: [
+    "link_pending",
+    "scope_pending",
+    "phase1_pending",
+    "compile_pending",
+    "coach_ready",
+    "cancelled",
+  ],
+  link_pending: [
+    "scope_pending",
+    "phase1_pending",
+    "compile_pending",
+    "coach_ready",
+    "cancelled",
+  ],
+  scope_pending: [
+    "phase1_pending",
+    "compile_pending",
+    "coach_ready",
+    "cancelled",
+  ],
+  phase1_pending: [
+    "compile_pending",
+    "coach_ready",
+    "cancelled",
+  ],
+  compile_pending: [
+    "coach_ready",
+    "cancelled",
+  ],
+  coach_ready: [
+    "active",
+    "stopped",
+    "cancelled",
+  ],
+  active: [
+    "paused",
+    "stopped",
+    "cancelled",
+  ],
+  paused: [
+    "active",
+    "stopped",
+    "cancelled",
+  ],
+  stopped: [],
+  cancelled: [],
+});
+
+function isPilotState(value: string): value is PilotState {
+  return (PILOT_STATES as readonly string[]).includes(value);
+}
+
+function allBooleanPreconditions(preconditions: unknown): preconditions is PilotPreconditions {
+  if (preconditions === null || typeof preconditions !== "object" || Array.isArray(preconditions)) {
+    return false;
+  }
+
+  const candidate = preconditions as Record<string, unknown>;
+  const requiredKeys: readonly (keyof PilotPreconditions)[] = [
+    "commercialAccepted",
+    "paymentAccessActive",
+    "workspaceCreated",
+    "coachAccountActive",
+    "athleteAccountActive",
+    "coachAthleteLinkAccepted",
+    "scopeLocked",
+    "phase1Accepted",
+    "phase1Refused",
+    "compilePassed",
+    "compileFailed",
+    "firstExecutableSessionExists",
+    "activationSignalReceived",
+    "pauseRequested",
+    "stopRequested",
+    "cancelRequested",
+  ];
+
+  const actualKeys = Object.keys(candidate);
+  if (actualKeys.length !== requiredKeys.length) {
+    return false;
+  }
+
+  for (const key of requiredKeys) {
+    if (typeof candidate[key] !== "boolean") {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+export function derivePilotBlockedReason(
+  preconditions: PilotPreconditions,
+): PilotBlockedReason | null {
+  if (!preconditions.commercialAccepted || !preconditions.paymentAccessActive) {
+    return "payment_missing";
+  }
+
+  if (!preconditions.workspaceCreated) {
+    return "workspace_missing";
+  }
+
+  if (!preconditions.coachAccountActive) {
+    return "coach_missing";
+  }
+
+  if (!preconditions.athleteAccountActive) {
+    return "athlete_missing";
+  }
+
+  if (!preconditions.coachAthleteLinkAccepted) {
+    return "link_not_accepted";
+  }
+
+  if (!preconditions.scopeLocked) {
+    return "scope_not_locked";
+  }
+
+  if (preconditions.phase1Refused) {
+    return "phase1_refused";
+  }
+
+  if (!preconditions.phase1Accepted) {
+    return "phase1_missing";
+  }
+
+  if (preconditions.compileFailed) {
+    return "compile_failed";
+  }
+
+  return null;
+}
+
+export function hasCoachReadyPreconditions(preconditions: PilotPreconditions): boolean {
+  return (
+    preconditions.commercialAccepted === true &&
+    preconditions.paymentAccessActive === true &&
+    preconditions.workspaceCreated === true &&
+    preconditions.coachAccountActive === true &&
+    preconditions.athleteAccountActive === true &&
+    preconditions.coachAthleteLinkAccepted === true &&
+    preconditions.scopeLocked === true &&
+    preconditions.phase1Accepted === true &&
+    preconditions.phase1Refused === false &&
+    preconditions.compilePassed === true &&
+    preconditions.compileFailed === false &&
+    preconditions.firstExecutableSessionExists === true
+  );
+}
+
+export function derivePilotState(
+  currentState: PilotState,
+  preconditions: PilotPreconditions,
+): PilotState {
+  if (preconditions.cancelRequested) {
+    return "cancelled";
+  }
+
+  if (preconditions.stopRequested) {
+    return "stopped";
+  }
+
+  if (!preconditions.commercialAccepted || !preconditions.paymentAccessActive) {
+    return "commercial_pending";
+  }
+
+  if (!preconditions.workspaceCreated) {
+    return "platform_pending";
+  }
+
+  if (!preconditions.coachAccountActive) {
+    return "coach_pending";
+  }
+
+  if (!preconditions.athleteAccountActive) {
+    return "athlete_pending";
+  }
+
+  if (!preconditions.coachAthleteLinkAccepted) {
+    return "link_pending";
+  }
+
+  if (!preconditions.scopeLocked) {
+    return "scope_pending";
+  }
+
+  if (preconditions.phase1Refused || !preconditions.phase1Accepted) {
+    return "phase1_pending";
+  }
+
+  if (
+    preconditions.compileFailed ||
+    !preconditions.compilePassed ||
+    !preconditions.firstExecutableSessionExists
+  ) {
+    return "compile_pending";
+  }
+
+  if (currentState === "active" && preconditions.pauseRequested) {
+    return "paused";
+  }
+
+  if (
+    (currentState === "coach_ready" || currentState === "active" || currentState === "paused") &&
+    preconditions.activationSignalReceived
+  ) {
+    return "active";
+  }
+
+  return "coach_ready";
+}
+
+export function canTransition(
+  from: PilotState,
+  to: PilotState,
+  preconditions: PilotPreconditions,
+): boolean {
+  if (TERMINAL_PILOT_STATES.has(from)) {
+    return false;
+  }
+
+  if (from === to) {
+    return true;
+  }
+
+  if (!LEGAL_PILOT_TRANSITIONS[from].includes(to)) {
+    return false;
+  }
+
+  if (to === "coach_ready") {
+    return hasCoachReadyPreconditions(preconditions);
+  }
+
+  if (to === "active") {
+    return (
+      (from === "coach_ready" || from === "paused") &&
+      hasCoachReadyPreconditions(preconditions) &&
+      preconditions.activationSignalReceived
+    );
+  }
+
+  if (to === "paused") {
+    return from === "active" && preconditions.pauseRequested;
+  }
+
+  if (to === "stopped") {
+    return (from === "coach_ready" || from === "active" || from === "paused") && preconditions.stopRequested;
+  }
+
+  if (to === "cancelled") {
+    return preconditions.cancelRequested;
+  }
+
+  const derived = derivePilotState(from, preconditions);
+  return derived === to;
+}
+
+export function transitionPilotState(
+  currentStateRaw: string,
+  requestedStateRaw: string,
+  preconditionsRaw: unknown,
+): PilotTransitionResult {
+  if (!isPilotState(currentStateRaw)) {
+    return {
+      ok: false,
+      error: "unknown_current_state",
+      from: currentStateRaw,
+      to: requestedStateRaw,
+      blockedReason: null,
+      engineOutputAltered: false,
+    };
+  }
+
+  if (!isPilotState(requestedStateRaw)) {
+    return {
+      ok: false,
+      error: "unknown_requested_state",
+      from: currentStateRaw,
+      to: requestedStateRaw,
+      blockedReason: null,
+      engineOutputAltered: false,
+    };
+  }
+
+  if (!allBooleanPreconditions(preconditionsRaw)) {
+    return {
+      ok: false,
+      error: "invalid_preconditions",
+      from: currentStateRaw,
+      to: requestedStateRaw,
+      blockedReason: null,
+      engineOutputAltered: false,
+    };
+  }
+
+  const blockedReason = derivePilotBlockedReason(preconditionsRaw);
+
+  if (TERMINAL_PILOT_STATES.has(currentStateRaw)) {
+    return {
+      ok: false,
+      error: "terminal_state",
+      from: currentStateRaw,
+      to: requestedStateRaw,
+      blockedReason,
+      engineOutputAltered: false,
+    };
+  }
+
+  if (!canTransition(currentStateRaw, requestedStateRaw, preconditionsRaw)) {
+    return {
+      ok: false,
+      error: "illegal_transition",
+      from: currentStateRaw,
+      to: requestedStateRaw,
+      blockedReason,
+      engineOutputAltered: false,
+    };
+  }
+
+  return {
+    ok: true,
+    from: currentStateRaw,
+    to: requestedStateRaw,
+    blockedReason,
+    engineOutputAltered: false,
+  };
+}
+
+export function deriveAndTransitionPilotState(
+  currentStateRaw: string,
+  preconditionsRaw: unknown,
+): PilotTransitionResult {
+  if (!isPilotState(currentStateRaw)) {
+    return {
+      ok: false,
+      error: "unknown_current_state",
+      from: currentStateRaw,
+      to: "unknown",
+      blockedReason: null,
+      engineOutputAltered: false,
+    };
+  }
+
+  if (!allBooleanPreconditions(preconditionsRaw)) {
+    return {
+      ok: false,
+      error: "invalid_preconditions",
+      from: currentStateRaw,
+      to: "unknown",
+      blockedReason: null,
+      engineOutputAltered: false,
+    };
+  }
+
+  const requestedState = derivePilotState(currentStateRaw, preconditionsRaw);
+  return transitionPilotState(currentStateRaw, requestedState, preconditionsRaw);
+}

--- a/tests/fixtures/pilot_state_machine_vectors.json
+++ b/tests/fixtures/pilot_state_machine_vectors.json
@@ -1,0 +1,328 @@
+{
+  "schema_version": "kolosseum.pilot_state_machine_vectors.v1",
+  "slice": "S42",
+  "states": [
+    "accepted",
+    "commercial_pending",
+    "platform_pending",
+    "coach_pending",
+    "athlete_pending",
+    "link_pending",
+    "scope_pending",
+    "phase1_pending",
+    "compile_pending",
+    "coach_ready",
+    "active",
+    "paused",
+    "stopped",
+    "cancelled"
+  ],
+  "blocked_reasons": [
+    "payment_missing",
+    "workspace_missing",
+    "coach_missing",
+    "athlete_missing",
+    "link_not_accepted",
+    "scope_not_locked",
+    "phase1_missing",
+    "phase1_refused",
+    "compile_failed"
+  ],
+  "base_preconditions": {
+    "commercialAccepted": true,
+    "paymentAccessActive": true,
+    "workspaceCreated": true,
+    "coachAccountActive": true,
+    "athleteAccountActive": true,
+    "coachAthleteLinkAccepted": true,
+    "scopeLocked": true,
+    "phase1Accepted": true,
+    "phase1Refused": false,
+    "compilePassed": true,
+    "compileFailed": false,
+    "firstExecutableSessionExists": true,
+    "activationSignalReceived": false,
+    "pauseRequested": false,
+    "stopRequested": false,
+    "cancelRequested": false
+  },
+  "blocked_reason_vectors": [
+    {
+      "id": "BR001_payment_missing_when_commercial_not_accepted",
+      "patch": {
+        "commercialAccepted": false
+      },
+      "expected": "payment_missing"
+    },
+    {
+      "id": "BR002_payment_missing_when_access_not_active",
+      "patch": {
+        "paymentAccessActive": false
+      },
+      "expected": "payment_missing"
+    },
+    {
+      "id": "BR003_workspace_missing",
+      "patch": {
+        "workspaceCreated": false
+      },
+      "expected": "workspace_missing"
+    },
+    {
+      "id": "BR004_coach_missing",
+      "patch": {
+        "coachAccountActive": false
+      },
+      "expected": "coach_missing"
+    },
+    {
+      "id": "BR005_athlete_missing",
+      "patch": {
+        "athleteAccountActive": false
+      },
+      "expected": "athlete_missing"
+    },
+    {
+      "id": "BR006_link_not_accepted",
+      "patch": {
+        "coachAthleteLinkAccepted": false
+      },
+      "expected": "link_not_accepted"
+    },
+    {
+      "id": "BR007_scope_not_locked",
+      "patch": {
+        "scopeLocked": false
+      },
+      "expected": "scope_not_locked"
+    },
+    {
+      "id": "BR008_phase1_missing",
+      "patch": {
+        "phase1Accepted": false
+      },
+      "expected": "phase1_missing"
+    },
+    {
+      "id": "BR009_phase1_refused",
+      "patch": {
+        "phase1Accepted": false,
+        "phase1Refused": true
+      },
+      "expected": "phase1_refused"
+    },
+    {
+      "id": "BR010_compile_failed",
+      "patch": {
+        "compilePassed": false,
+        "compileFailed": true
+      },
+      "expected": "compile_failed"
+    }
+  ],
+  "derived_state_vectors": [
+    {
+      "id": "DS001_commercial_pending",
+      "from": "accepted",
+      "patch": {
+        "paymentAccessActive": false
+      },
+      "expected": "commercial_pending"
+    },
+    {
+      "id": "DS002_platform_pending",
+      "from": "commercial_pending",
+      "patch": {
+        "workspaceCreated": false
+      },
+      "expected": "platform_pending"
+    },
+    {
+      "id": "DS003_coach_pending",
+      "from": "platform_pending",
+      "patch": {
+        "coachAccountActive": false
+      },
+      "expected": "coach_pending"
+    },
+    {
+      "id": "DS004_athlete_pending",
+      "from": "coach_pending",
+      "patch": {
+        "athleteAccountActive": false
+      },
+      "expected": "athlete_pending"
+    },
+    {
+      "id": "DS005_link_pending",
+      "from": "athlete_pending",
+      "patch": {
+        "coachAthleteLinkAccepted": false
+      },
+      "expected": "link_pending"
+    },
+    {
+      "id": "DS006_scope_pending",
+      "from": "link_pending",
+      "patch": {
+        "scopeLocked": false
+      },
+      "expected": "scope_pending"
+    },
+    {
+      "id": "DS007_phase1_pending",
+      "from": "scope_pending",
+      "patch": {
+        "phase1Accepted": false
+      },
+      "expected": "phase1_pending"
+    },
+    {
+      "id": "DS008_compile_pending_when_compile_failed",
+      "from": "phase1_pending",
+      "patch": {
+        "compilePassed": false,
+        "compileFailed": true
+      },
+      "expected": "compile_pending"
+    },
+    {
+      "id": "DS009_compile_pending_when_session_missing",
+      "from": "compile_pending",
+      "patch": {
+        "compilePassed": true,
+        "firstExecutableSessionExists": false
+      },
+      "expected": "compile_pending"
+    },
+    {
+      "id": "DS010_coach_ready",
+      "from": "compile_pending",
+      "patch": {},
+      "expected": "coach_ready"
+    },
+    {
+      "id": "DS011_active",
+      "from": "coach_ready",
+      "patch": {
+        "activationSignalReceived": true
+      },
+      "expected": "active"
+    },
+    {
+      "id": "DS012_paused",
+      "from": "active",
+      "patch": {
+        "pauseRequested": true
+      },
+      "expected": "paused"
+    },
+    {
+      "id": "DS013_stopped",
+      "from": "active",
+      "patch": {
+        "stopRequested": true
+      },
+      "expected": "stopped"
+    },
+    {
+      "id": "DS014_cancelled",
+      "from": "accepted",
+      "patch": {
+        "cancelRequested": true
+      },
+      "expected": "cancelled"
+    }
+  ],
+  "legal_transitions": [
+    ["accepted", "commercial_pending"],
+    ["accepted", "platform_pending"],
+    ["accepted", "coach_pending"],
+    ["accepted", "athlete_pending"],
+    ["accepted", "link_pending"],
+    ["accepted", "scope_pending"],
+    ["accepted", "phase1_pending"],
+    ["accepted", "compile_pending"],
+    ["accepted", "coach_ready"],
+    ["accepted", "cancelled"],
+    ["commercial_pending", "platform_pending"],
+    ["commercial_pending", "coach_pending"],
+    ["commercial_pending", "athlete_pending"],
+    ["commercial_pending", "link_pending"],
+    ["commercial_pending", "scope_pending"],
+    ["commercial_pending", "phase1_pending"],
+    ["commercial_pending", "compile_pending"],
+    ["commercial_pending", "coach_ready"],
+    ["commercial_pending", "cancelled"],
+    ["platform_pending", "coach_pending"],
+    ["platform_pending", "athlete_pending"],
+    ["platform_pending", "link_pending"],
+    ["platform_pending", "scope_pending"],
+    ["platform_pending", "phase1_pending"],
+    ["platform_pending", "compile_pending"],
+    ["platform_pending", "coach_ready"],
+    ["platform_pending", "cancelled"],
+    ["coach_pending", "athlete_pending"],
+    ["coach_pending", "link_pending"],
+    ["coach_pending", "scope_pending"],
+    ["coach_pending", "phase1_pending"],
+    ["coach_pending", "compile_pending"],
+    ["coach_pending", "coach_ready"],
+    ["coach_pending", "cancelled"],
+    ["athlete_pending", "link_pending"],
+    ["athlete_pending", "scope_pending"],
+    ["athlete_pending", "phase1_pending"],
+    ["athlete_pending", "compile_pending"],
+    ["athlete_pending", "coach_ready"],
+    ["athlete_pending", "cancelled"],
+    ["link_pending", "scope_pending"],
+    ["link_pending", "phase1_pending"],
+    ["link_pending", "compile_pending"],
+    ["link_pending", "coach_ready"],
+    ["link_pending", "cancelled"],
+    ["scope_pending", "phase1_pending"],
+    ["scope_pending", "compile_pending"],
+    ["scope_pending", "coach_ready"],
+    ["scope_pending", "cancelled"],
+    ["phase1_pending", "compile_pending"],
+    ["phase1_pending", "coach_ready"],
+    ["phase1_pending", "cancelled"],
+    ["compile_pending", "coach_ready"],
+    ["compile_pending", "cancelled"],
+    ["coach_ready", "active"],
+    ["coach_ready", "stopped"],
+    ["coach_ready", "cancelled"],
+    ["active", "paused"],
+    ["active", "stopped"],
+    ["active", "cancelled"],
+    ["paused", "active"],
+    ["paused", "stopped"],
+    ["paused", "cancelled"]
+  ],
+  "illegal_transitions": [
+    ["commercial_pending", "accepted"],
+    ["platform_pending", "accepted"],
+    ["coach_pending", "commercial_pending"],
+    ["athlete_pending", "coach_pending"],
+    ["link_pending", "athlete_pending"],
+    ["scope_pending", "link_pending"],
+    ["phase1_pending", "scope_pending"],
+    ["compile_pending", "phase1_pending"],
+    ["coach_ready", "compile_pending"],
+    ["active", "coach_ready"],
+    ["paused", "coach_ready"],
+    ["stopped", "active"],
+    ["stopped", "coach_ready"],
+    ["cancelled", "active"],
+    ["cancelled", "coach_ready"],
+    ["accepted", "active"],
+    ["commercial_pending", "active"],
+    ["platform_pending", "active"],
+    ["coach_pending", "active"],
+    ["athlete_pending", "active"],
+    ["link_pending", "active"],
+    ["scope_pending", "active"],
+    ["phase1_pending", "active"],
+    ["compile_pending", "active"]
+  ]
+}

--- a/tests/pilot/pilot_state_machine.test.mjs
+++ b/tests/pilot/pilot_state_machine.test.mjs
@@ -1,0 +1,296 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+
+const repoRoot = process.cwd();
+const tsPath = path.join(repoRoot, "src", "pilot", "pilot_state_machine.ts");
+const vectorsPath = path.join(repoRoot, "tests", "fixtures", "pilot_state_machine_vectors.json");
+const docPath = path.join(repoRoot, "docs", "slices", "PILOT_STATE_MACHINE_ENFORCEMENT.md");
+
+const source = fs.readFileSync(tsPath, "utf8");
+const vectors = JSON.parse(fs.readFileSync(vectorsPath, "utf8"));
+const doc = fs.readFileSync(docPath, "utf8");
+
+const states = vectors.states;
+const blockedReasons = vectors.blocked_reasons;
+
+const legalTransitions = new Map();
+for (const state of states) legalTransitions.set(state, new Set());
+for (const [from, to] of vectors.legal_transitions) legalTransitions.get(from).add(to);
+
+const terminalStates = new Set(["stopped", "cancelled"]);
+
+function patch(base, diff) {
+  return { ...base, ...diff };
+}
+
+function derivePilotBlockedReason(preconditions) {
+  if (!preconditions.commercialAccepted || !preconditions.paymentAccessActive) return "payment_missing";
+  if (!preconditions.workspaceCreated) return "workspace_missing";
+  if (!preconditions.coachAccountActive) return "coach_missing";
+  if (!preconditions.athleteAccountActive) return "athlete_missing";
+  if (!preconditions.coachAthleteLinkAccepted) return "link_not_accepted";
+  if (!preconditions.scopeLocked) return "scope_not_locked";
+  if (preconditions.phase1Refused) return "phase1_refused";
+  if (!preconditions.phase1Accepted) return "phase1_missing";
+  if (preconditions.compileFailed) return "compile_failed";
+  return null;
+}
+
+function hasCoachReadyPreconditions(preconditions) {
+  return (
+    preconditions.commercialAccepted === true &&
+    preconditions.paymentAccessActive === true &&
+    preconditions.workspaceCreated === true &&
+    preconditions.coachAccountActive === true &&
+    preconditions.athleteAccountActive === true &&
+    preconditions.coachAthleteLinkAccepted === true &&
+    preconditions.scopeLocked === true &&
+    preconditions.phase1Accepted === true &&
+    preconditions.phase1Refused === false &&
+    preconditions.compilePassed === true &&
+    preconditions.compileFailed === false &&
+    preconditions.firstExecutableSessionExists === true
+  );
+}
+
+function derivePilotState(currentState, preconditions) {
+  if (preconditions.cancelRequested) return "cancelled";
+  if (preconditions.stopRequested) return "stopped";
+  if (!preconditions.commercialAccepted || !preconditions.paymentAccessActive) return "commercial_pending";
+  if (!preconditions.workspaceCreated) return "platform_pending";
+  if (!preconditions.coachAccountActive) return "coach_pending";
+  if (!preconditions.athleteAccountActive) return "athlete_pending";
+  if (!preconditions.coachAthleteLinkAccepted) return "link_pending";
+  if (!preconditions.scopeLocked) return "scope_pending";
+  if (preconditions.phase1Refused || !preconditions.phase1Accepted) return "phase1_pending";
+  if (preconditions.compileFailed || !preconditions.compilePassed || !preconditions.firstExecutableSessionExists) return "compile_pending";
+  if (currentState === "active" && preconditions.pauseRequested) return "paused";
+  if (["coach_ready", "active", "paused"].includes(currentState) && preconditions.activationSignalReceived) return "active";
+  return "coach_ready";
+}
+
+function canTransition(from, to, preconditions) {
+  if (terminalStates.has(from)) return false;
+  if (from === to) return true;
+  if (!legalTransitions.get(from)?.has(to)) return false;
+
+  if (to === "coach_ready") return hasCoachReadyPreconditions(preconditions);
+  if (to === "active") return ["coach_ready", "paused"].includes(from) && hasCoachReadyPreconditions(preconditions) && preconditions.activationSignalReceived;
+  if (to === "paused") return from === "active" && preconditions.pauseRequested;
+  if (to === "stopped") return ["coach_ready", "active", "paused"].includes(from) && preconditions.stopRequested;
+  if (to === "cancelled") return preconditions.cancelRequested;
+
+  return derivePilotState(from, preconditions) === to;
+}
+
+function transitionPilotState(from, to, preconditions) {
+  if (!states.includes(from)) {
+    return { ok: false, error: "unknown_current_state", from, to, blockedReason: null, engineOutputAltered: false };
+  }
+
+  if (!states.includes(to)) {
+    return { ok: false, error: "unknown_requested_state", from, to, blockedReason: null, engineOutputAltered: false };
+  }
+
+  const required = Object.keys(vectors.base_preconditions);
+  if (
+    preconditions === null ||
+    typeof preconditions !== "object" ||
+    Array.isArray(preconditions) ||
+    Object.keys(preconditions).length !== required.length ||
+    required.some((key) => typeof preconditions[key] !== "boolean")
+  ) {
+    return { ok: false, error: "invalid_preconditions", from, to, blockedReason: null, engineOutputAltered: false };
+  }
+
+  const blockedReason = derivePilotBlockedReason(preconditions);
+
+  if (terminalStates.has(from)) {
+    return { ok: false, error: "terminal_state", from, to, blockedReason, engineOutputAltered: false };
+  }
+
+  if (!canTransition(from, to, preconditions)) {
+    return { ok: false, error: "illegal_transition", from, to, blockedReason, engineOutputAltered: false };
+  }
+
+  return { ok: true, from, to, blockedReason, engineOutputAltered: false };
+}
+
+function run(name, fn) {
+  try {
+    fn();
+    console.log(`PASS ${name}`);
+  } catch (error) {
+    console.error(`FAIL ${name}`);
+    throw error;
+  }
+}
+
+run("S42_DOC_001 docs exist and define terminal rule", () => {
+  assert.ok(doc.includes("Terminal Rule"));
+  assert.ok(doc.includes("stopped and cancelled are terminal"));
+  assert.ok(doc.includes("pilot state does not alter engine output"));
+});
+
+run("S42_TS_001 TypeScript exports required constants and functions", () => {
+  for (const token of [
+    "PILOT_STATES",
+    "PILOT_BLOCKED_REASONS",
+    "LEGAL_PILOT_TRANSITIONS",
+    "derivePilotBlockedReason",
+    "hasCoachReadyPreconditions",
+    "derivePilotState",
+    "canTransition",
+    "transitionPilotState",
+    "deriveAndTransitionPilotState"
+  ]) {
+    assert.ok(source.includes(token), `Missing implementation token: ${token}`);
+  }
+});
+
+run("S42_TS_002 every state appears in TypeScript source", () => {
+  for (const state of states) {
+    assert.ok(source.includes(`"${state}"`), `Missing state in TypeScript source: ${state}`);
+  }
+});
+
+run("S42_TS_003 every blocked reason appears in TypeScript source", () => {
+  for (const reason of blockedReasons) {
+    assert.ok(source.includes(`"${reason}"`), `Missing blocked reason in TypeScript source: ${reason}`);
+  }
+});
+
+run("S42_UNIT_001 blocked reason vectors derive expected blocked reason", () => {
+  for (const vector of vectors.blocked_reason_vectors) {
+    const preconditions = patch(vectors.base_preconditions, vector.patch);
+    assert.equal(derivePilotBlockedReason(preconditions), vector.expected, vector.id);
+  }
+});
+
+run("S42_UNIT_002 derived state vectors derive expected state", () => {
+  for (const vector of vectors.derived_state_vectors) {
+    const preconditions = patch(vectors.base_preconditions, vector.patch);
+    assert.equal(derivePilotState(vector.from, preconditions), vector.expected, vector.id);
+  }
+});
+
+run("S42_UNIT_003 every legal transition is tested and allowed with matching preconditions", () => {
+  for (const [from, to] of vectors.legal_transitions) {
+    let preconditions = { ...vectors.base_preconditions };
+
+    if (to === "commercial_pending") preconditions.paymentAccessActive = false;
+    if (to === "platform_pending") preconditions.workspaceCreated = false;
+    if (to === "coach_pending") preconditions.coachAccountActive = false;
+    if (to === "athlete_pending") preconditions.athleteAccountActive = false;
+    if (to === "link_pending") preconditions.coachAthleteLinkAccepted = false;
+    if (to === "scope_pending") preconditions.scopeLocked = false;
+    if (to === "phase1_pending") preconditions.phase1Accepted = false;
+    if (to === "compile_pending") preconditions.compilePassed = false;
+    if (to === "active") preconditions.activationSignalReceived = true;
+    if (to === "paused") preconditions.pauseRequested = true;
+    if (to === "stopped") preconditions.stopRequested = true;
+    if (to === "cancelled") preconditions.cancelRequested = true;
+
+    const result = transitionPilotState(from, to, preconditions);
+    assert.equal(result.ok, true, `${from} -> ${to} should be legal`);
+    assert.equal(result.engineOutputAltered, false);
+  }
+});
+
+run("S42_UNIT_004 every illegal transition is tested and refused", () => {
+  for (const [from, to] of vectors.illegal_transitions) {
+    const result = transitionPilotState(from, to, vectors.base_preconditions);
+    assert.equal(result.ok, false, `${from} -> ${to} should be illegal`);
+    assert.ok(["illegal_transition", "terminal_state"].includes(result.error), `${from} -> ${to} returned ${result.error}`);
+    assert.equal(result.engineOutputAltered, false);
+  }
+});
+
+run("S42_UNIT_005 unknown current state fails", () => {
+  const result = transitionPilotState("unknown_state", "accepted", vectors.base_preconditions);
+  assert.equal(result.ok, false);
+  assert.equal(result.error, "unknown_current_state");
+});
+
+run("S42_UNIT_006 unknown requested state fails", () => {
+  const result = transitionPilotState("accepted", "unknown_state", vectors.base_preconditions);
+  assert.equal(result.ok, false);
+  assert.equal(result.error, "unknown_requested_state");
+});
+
+run("S42_UNIT_007 invalid preconditions fail", () => {
+  const result = transitionPilotState("accepted", "commercial_pending", { paymentAccessActive: false });
+  assert.equal(result.ok, false);
+  assert.equal(result.error, "invalid_preconditions");
+});
+
+run("S42_UNIT_008 coach_ready impossible with each missing prerequisite", () => {
+  const prerequisiteKeys = [
+    "commercialAccepted",
+    "paymentAccessActive",
+    "workspaceCreated",
+    "coachAccountActive",
+    "athleteAccountActive",
+    "coachAthleteLinkAccepted",
+    "scopeLocked",
+    "phase1Accepted",
+    "compilePassed",
+    "firstExecutableSessionExists"
+  ];
+
+  for (const key of prerequisiteKeys) {
+    const preconditions = { ...vectors.base_preconditions, [key]: false };
+    const result = transitionPilotState("compile_pending", "coach_ready", preconditions);
+    assert.equal(result.ok, false, `coach_ready must fail when ${key} is false`);
+  }
+
+  const refused = { ...vectors.base_preconditions, phase1Refused: true };
+  assert.equal(transitionPilotState("compile_pending", "coach_ready", refused).ok, false);
+
+  const compileFailed = { ...vectors.base_preconditions, compileFailed: true };
+  assert.equal(transitionPilotState("compile_pending", "coach_ready", compileFailed).ok, false);
+});
+
+run("S42_UNIT_009 active requires coach_ready or paused plus activation signal", () => {
+  const withoutSignal = { ...vectors.base_preconditions, activationSignalReceived: false };
+  assert.equal(transitionPilotState("coach_ready", "active", withoutSignal).ok, false);
+
+  const withSignal = { ...vectors.base_preconditions, activationSignalReceived: true };
+  assert.equal(transitionPilotState("coach_ready", "active", withSignal).ok, true);
+  assert.equal(transitionPilotState("paused", "active", withSignal).ok, true);
+  assert.equal(transitionPilotState("compile_pending", "active", withSignal).ok, false);
+});
+
+run("S42_UNIT_010 terminal states cannot resume", () => {
+  for (const terminal of ["stopped", "cancelled"]) {
+    for (const to of states.filter((state) => state !== terminal)) {
+      const result = transitionPilotState(terminal, to, vectors.base_preconditions);
+      assert.equal(result.ok, false, `${terminal} -> ${to} must fail`);
+      assert.equal(result.error, "terminal_state");
+    }
+  }
+});
+
+run("S42_UNIT_011 pilot state does not alter engine output", () => {
+  for (const [from, to] of vectors.legal_transitions) {
+    let preconditions = { ...vectors.base_preconditions };
+    if (to === "active") preconditions.activationSignalReceived = true;
+    if (to === "paused") preconditions.pauseRequested = true;
+    if (to === "stopped") preconditions.stopRequested = true;
+    if (to === "cancelled") preconditions.cancelRequested = true;
+    if (to === "commercial_pending") preconditions.paymentAccessActive = false;
+    if (to === "platform_pending") preconditions.workspaceCreated = false;
+    if (to === "coach_pending") preconditions.coachAccountActive = false;
+    if (to === "athlete_pending") preconditions.athleteAccountActive = false;
+    if (to === "link_pending") preconditions.coachAthleteLinkAccepted = false;
+    if (to === "scope_pending") preconditions.scopeLocked = false;
+    if (to === "phase1_pending") preconditions.phase1Accepted = false;
+    if (to === "compile_pending") preconditions.compilePassed = false;
+
+    const result = transitionPilotState(from, to, preconditions);
+    assert.equal(result.engineOutputAltered, false);
+  }
+});
+
+console.log("S42 pilot state machine tests passed.");


### PR DESCRIPTION
Adds S42 Pilot State Machine Enforcement documentation, TypeScript implementation, transition table, blocked reason enum, and test vectors. Enforces legal transitions, terminal fail-closed behaviour, unknown-state refusal, Coach Ready preconditions, Active activation requirements, and engine-output inertness.