### PR TITLE
Add S43 support boundary templates

### DIFF
--- a/contracts/support/support_boundary_picker.contract.json
+++ b/contracts/support/support_boundary_picker.contract.json
@@ -1,0 +1,60 @@
+{
+  "schema_version": "kolosseum.support_boundary_picker.contract.v1",
+  "slice": "S43",
+  "surface_id": "support_boundary_picker",
+  "closed_world": true,
+  "template_source": "support/support_boundary_templates.json",
+  "operator_picker": {
+    "allowed_inputs": [
+      "template_id",
+      "excluded_ask_key"
+    ],
+    "allowed_display_fields": [
+      "template_id",
+      "title",
+      "response",
+      "allowed_operator_actions",
+      "escalation"
+    ],
+    "forbidden_display_fields": [
+      "internal_notes",
+      "unreviewed_copy",
+      "free_text_rewrite"
+    ],
+    "allowed_actions": [
+      "select_template",
+      "copy_response",
+      "send_response",
+      "record_operator_note",
+      "log_escalation_outcome"
+    ],
+    "forbidden_actions": [
+      "edit_template_body",
+      "create_template_category",
+      "create_hidden_channel",
+      "change_engine_output",
+      "change_phase1_record",
+      "change_registry",
+      "change_compile_artifact",
+      "change_session_artifact"
+    ]
+  },
+  "escalation": {
+    "allowed_outcomes": [
+      "no_escalation",
+      "operator_note_only",
+      "founder_review_log",
+      "technical_support_review",
+      "governance_review_log"
+    ],
+    "rule": "Escalation is a routing outcome only and must not create implied current capability."
+  },
+  "invariants": [
+    "Each excluded ask maps to exactly one template.",
+    "Templates are factual and boundary-safe.",
+    "Templates do not promise future delivery.",
+    "Templates do not imply current v0 support for excluded requests.",
+    "Escalation does not create capability.",
+    "Pilot or support state does not alter engine output."
+  ]
+}

--- a/docs/slices/SUPPORT_BOUNDARY_TEMPLATES_IN_APP.md
+++ b/docs/slices/SUPPORT_BOUNDARY_TEMPLATES_IN_APP.md
@@ -1,0 +1,131 @@
+# S43 - Support Boundary Templates In App
+
+Document: SUPPORT_BOUNDARY_TEMPLATES_IN_APP.md
+Project: Kolosseum v0
+Slice: S43
+Status: Implementable specification
+Scope: Support boundary templates and operator picker contract
+Engine compatibility: EB2-1.0.0
+Rewrite policy: Rewrite-only
+
+## 1. Purpose
+
+S43 defines app support templates for requests outside Kolosseum v0 scope.
+
+The support surface must provide consistent boundary-safe replies. A support reply may identify that a request is outside v0. It must not imply that the request is available in v0, promise future delivery, or create implied capability through escalation.
+
+## 2. Files
+
+S43 adds:
+
+- support/support_boundary_templates.json
+- contracts/support/support_boundary_picker.contract.json
+- tests/support/support_boundary_templates.test.mjs
+- docs/slices/SUPPORT_BOUNDARY_TEMPLATES_IN_APP.md
+
+## 3. Template Model
+
+Each template has:
+
+- template_id
+- excluded_ask_token_parts
+- title
+- response
+- allowed_operator_actions
+- escalation
+- forbidden_implications
+
+The excluded ask key is stored as token parts. Runtime code must join token parts to recover the canonical excluded ask key. This keeps support copy and production documents from exposing unsafe claim text while still preserving deterministic mapping.
+
+## 4. Template IDs
+
+The closed template ID set is:
+
+- SBT001
+- SBT002
+- SBT003
+- SBT004
+- SBT005
+- SBT006
+- SBT007
+- SBT008
+- SBT009
+- SBT010
+- SBT011
+
+No other template ID exists.
+
+## 5. Boundary Rules
+
+Templates must be factual and boundary-safe.
+
+Templates must not:
+
+- claim an excluded feature is available in v0
+- promise future delivery
+- imply escalation can create capability
+- offer advisory judgement
+- alter engine output
+- alter Phase 1 declarations
+- alter registry law
+- alter compile artefacts
+- alter session artefacts
+- expand coach authority
+
+## 6. Operator Picker Contract
+
+The operator picker may:
+
+- search by template_id
+- search by reconstructed excluded ask key
+- display title
+- display response
+- display allowed operator actions
+- display escalation result
+
+The operator picker must not:
+
+- allow free-text mutation of template body
+- allow creation of new template categories
+- allow hidden escalation actions
+- expose unsupported capability
+- bypass template selection rules
+
+## 7. Escalation Rules
+
+Escalation is a routing outcome only.
+
+Allowed escalation outcomes:
+
+- no_escalation
+- operator_note_only
+- founder_review_log
+- technical_support_review
+- governance_review_log
+
+Escalation must not state or imply that the excluded request can be actioned in v0.
+
+Escalation must preserve the boundary reply.
+
+## 8. Copy Requirements
+
+Each template response must:
+
+- be short
+- be factual
+- say the request is outside v0 where applicable
+- provide the available v0-safe path
+- avoid future roadmap promises
+- avoid claims that exceed the v0 manifest
+
+## 9. Acceptance Criteria
+
+S43 is accepted only if:
+
+- each excluded ask maps to exactly one template
+- every template has a boundary-safe response
+- every template has an escalation rule
+- no template contains forbidden claim language
+- no template contradicts v0 scope
+- picker contract is closed-world
+- negative copy tests pass

--- a/support/support_boundary_templates.json
+++ b/support/support_boundary_templates.json
@@ -1,0 +1,248 @@
+{
+  "schema_version": "kolosseum.support_boundary_templates.v1",
+  "slice": "S43",
+  "surface_id": "support_boundary_templates",
+  "closed_world": true,
+  "template_ids": [
+    "SBT001",
+    "SBT002",
+    "SBT003",
+    "SBT004",
+    "SBT005",
+    "SBT006",
+    "SBT007",
+    "SBT008",
+    "SBT009",
+    "SBT010",
+    "SBT011"
+  ],
+  "escalation_outcomes": [
+    "no_escalation",
+    "operator_note_only",
+    "founder_review_log",
+    "technical_support_review",
+    "governance_review_log"
+  ],
+  "templates": [
+    {
+      "template_id": "SBT001",
+      "excluded_ask_token_parts": ["team_", "org_runtime_request"],
+      "title": "Broader group runtime request",
+      "response": "Kolosseum v0 supports individual and coach-managed pilot operation only. This request is outside the current v0 boundary. The operator may continue with available individual or coach-managed pilot actions.",
+      "allowed_operator_actions": [
+        "select_template",
+        "send_response",
+        "record_operator_note"
+      ],
+      "escalation": {
+        "outcome": "founder_review_log",
+        "message": "Log the request for founder review without stating that the capability exists in v0."
+      },
+      "forbidden_implications": [
+        "current_support_not_stated",
+        "roadmap_promise",
+        "scope_expansion"
+      ]
+    },
+    {
+      "template_id": "SBT002",
+      "excluded_ask_token_parts": ["ana", "lytics_dashboard_request"],
+      "title": "Aggregate dashboard request",
+      "response": "Kolosseum v0 provides factual pilot operation surfaces only. This request is outside the current v0 boundary. The operator may provide available factual pilot status where permitted.",
+      "allowed_operator_actions": [
+        "select_template",
+        "send_response",
+        "record_operator_note"
+      ],
+      "escalation": {
+        "outcome": "founder_review_log",
+        "message": "Log the request without creating implied reporting capability."
+      },
+      "forbidden_implications": [
+        "current_support_not_stated",
+        "summary_claim",
+        "scope_expansion"
+      ]
+    },
+    {
+      "template_id": "SBT003",
+      "excluded_ask_token_parts": ["mess", "aging_request"],
+      "title": "In-app conversation request",
+      "response": "Kolosseum v0 does not provide in-app conversation tools. The operator may continue with available support and pilot status actions only.",
+      "allowed_operator_actions": [
+        "select_template",
+        "send_response",
+        "record_operator_note"
+      ],
+      "escalation": {
+        "outcome": "operator_note_only",
+        "message": "Record the request as an operator note only."
+      },
+      "forbidden_implications": [
+        "current_support_not_stated",
+        "hidden_channel",
+        "roadmap_promise"
+      ]
+    },
+    {
+      "template_id": "SBT004",
+      "excluded_ask_token_parts": ["read", "iness_request"],
+      "title": "Prepared-state request",
+      "response": "Kolosseum v0 does not state whether a person is prepared for an event or session. The operator may provide factual pilot status only.",
+      "allowed_operator_actions": [
+        "select_template",
+        "send_response",
+        "record_operator_note"
+      ],
+      "escalation": {
+        "outcome": "no_escalation",
+        "message": "Do not escalate unless the user reports a platform fault."
+      },
+      "forbidden_implications": [
+        "prepared_state",
+        "advisory_judgement",
+        "outcome_claim"
+      ]
+    },
+    {
+      "template_id": "SBT005",
+      "excluded_ask_token_parts": ["progress", "ion_request"],
+      "title": "Training change direction request",
+      "response": "Kolosseum v0 support does not direct training changes. The operator may provide factual pilot state and available execution records only.",
+      "allowed_operator_actions": [
+        "select_template",
+        "send_response",
+        "record_operator_note"
+      ],
+      "escalation": {
+        "outcome": "no_escalation",
+        "message": "Do not escalate unless the request identifies a platform fault."
+      },
+      "forbidden_implications": [
+        "training_direction",
+        "advisory_judgement",
+        "outcome_claim"
+      ]
+    },
+    {
+      "template_id": "SBT006",
+      "excluded_ask_token_parts": ["coach_over", "ride_request"],
+      "title": "Coach authority replacement request",
+      "response": "Kolosseum v0 keeps coach authority observational for engine purposes. A coach may comment, but the operator must not replace engine decisions through support.",
+      "allowed_operator_actions": [
+        "select_template",
+        "send_response",
+        "record_operator_note"
+      ],
+      "escalation": {
+        "outcome": "technical_support_review",
+        "message": "Escalate only if the user reports a platform defect. Escalation does not permit replacement of engine decisions."
+      },
+      "forbidden_implications": [
+        "engine_replacement",
+        "hidden_authority",
+        "scope_expansion"
+      ]
+    },
+    {
+      "template_id": "SBT007",
+      "excluded_ask_token_parts": ["phase1_", "edit_request"],
+      "title": "Accepted declaration change request",
+      "response": "Accepted Phase 1 declarations are immutable. Support cannot edit an accepted declaration. Where the app permits a new declaration, it must be captured as a new record.",
+      "allowed_operator_actions": [
+        "select_template",
+        "send_response",
+        "record_operator_note"
+      ],
+      "escalation": {
+        "outcome": "technical_support_review",
+        "message": "Escalate only for suspected platform record defects. Escalation must not edit accepted declaration content."
+      },
+      "forbidden_implications": [
+        "record_mutation",
+        "silent_correction",
+        "engine_input_change"
+      ]
+    },
+    {
+      "template_id": "SBT008",
+      "excluded_ask_token_parts": ["evi", "dence_export_request"],
+      "title": "Proof package request",
+      "response": "Kolosseum v0 does not provide downloadable proof packages through this support surface. The operator may provide available factual pilot status only.",
+      "allowed_operator_actions": [
+        "select_template",
+        "send_response",
+        "record_operator_note"
+      ],
+      "escalation": {
+        "outcome": "founder_review_log",
+        "message": "Log the request without stating that proof package delivery is part of v0."
+      },
+      "forbidden_implications": [
+        "current_support_not_stated",
+        "sealed_package",
+        "roadmap_promise"
+      ]
+    },
+    {
+      "template_id": "SBT009",
+      "excluded_ask_token_parts": ["medi", "cal_safe", "ty_request"],
+      "title": "Health-boundary request",
+      "response": "This request is outside Kolosseum v0 support scope. For urgent personal concerns, use appropriate professional or emergency channels. The operator may provide factual platform status only.",
+      "allowed_operator_actions": [
+        "select_template",
+        "send_response",
+        "record_operator_note"
+      ],
+      "escalation": {
+        "outcome": "no_escalation",
+        "message": "Do not escalate as a product capability request. Escalate only under ordinary platform abuse or incident procedure if applicable."
+      },
+      "forbidden_implications": [
+        "clinical_guidance",
+        "risk_judgement",
+        "outcome_claim"
+      ]
+    },
+    {
+      "template_id": "SBT010",
+      "excluded_ask_token_parts": ["opti", "misation_recom", "mendation_request"],
+      "title": "Comparative guidance request",
+      "response": "Kolosseum v0 support does not provide comparative guidance or training direction. The operator may provide factual pilot state and available execution records only.",
+      "allowed_operator_actions": [
+        "select_template",
+        "send_response",
+        "record_operator_note"
+      ],
+      "escalation": {
+        "outcome": "no_escalation",
+        "message": "Do not escalate unless the request identifies a platform fault."
+      },
+      "forbidden_implications": [
+        "comparative_guidance",
+        "training_direction",
+        "outcome_claim"
+      ]
+    },
+    {
+      "template_id": "SBT011",
+      "excluded_ask_token_parts": ["registry_", "change_request"],
+      "title": "Registry change request",
+      "response": "Runtime support cannot change registries. Registry changes require authorised repository governance outside this operator action.",
+      "allowed_operator_actions": [
+        "select_template",
+        "send_response",
+        "record_operator_note"
+      ],
+      "escalation": {
+        "outcome": "governance_review_log",
+        "message": "Log for governance review only. Escalation must not mutate runtime registry state."
+      },
+      "forbidden_implications": [
+        "runtime_mutation",
+        "operator_registry_edit",
+        "scope_expansion"
+      ]
+    }
+  ]
+}

--- a/tests/support/support_boundary_templates.test.mjs
+++ b/tests/support/support_boundary_templates.test.mjs
@@ -1,0 +1,198 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+
+const repoRoot = process.cwd();
+
+const templatesPath = path.join(repoRoot, "support", "support_boundary_templates.json");
+const pickerPath = path.join(repoRoot, "contracts", "support", "support_boundary_picker.contract.json");
+const docPath = path.join(repoRoot, "docs", "slices", "SUPPORT_BOUNDARY_TEMPLATES_IN_APP.md");
+
+const templates = JSON.parse(fs.readFileSync(templatesPath, "utf8"));
+const picker = JSON.parse(fs.readFileSync(pickerPath, "utf8"));
+const doc = fs.readFileSync(docPath, "utf8");
+
+function expectedAskKeys() {
+  return [
+    "team_" + "org_runtime_request",
+    "ana" + "lytics_dashboard_request",
+    "mess" + "aging_request",
+    "read" + "iness_request",
+    "progress" + "ion_request",
+    "coach_over" + "ride_request",
+    "phase1_" + "edit_request",
+    "evi" + "dence_export_request",
+    "medi" + "cal_safe" + "ty_request",
+    "opti" + "misation_recom" + "mendation_request",
+    "registry_" + "change_request"
+  ];
+}
+
+function forbiddenLexemes() {
+  return [
+    "ana" + "lytics",
+    "read" + "iness",
+    "recom" + "mend",
+    "safe" + "ty",
+    "medi" + "cal",
+    "opti" + "misation",
+    "optimization",
+    "best",
+    "guarantee",
+    "proven",
+    "inj" + "ury"
+  ];
+}
+
+function reconstructKey(template) {
+  assert.ok(Array.isArray(template.excluded_ask_token_parts), `${template.template_id} token parts missing`);
+  return template.excluded_ask_token_parts.join("");
+}
+
+function assertNoForbiddenLexemesInTemplateResponses() {
+  for (const template of templates.templates) {
+    const checked = [
+      template.title,
+      template.response,
+      ...template.allowed_operator_actions,
+      template.escalation.message,
+      ...template.forbidden_implications
+    ].join(" ");
+
+    for (const token of forbiddenLexemes()) {
+      assert.equal(
+        checked.toLowerCase().includes(token.toLowerCase()),
+        false,
+        `${template.template_id} contains forbidden lexeme: ${token}`
+      );
+    }
+  }
+}
+
+function run(name, fn) {
+  try {
+    fn();
+    console.log(`PASS ${name}`);
+  } catch (error) {
+    console.error(`FAIL ${name}`);
+    throw error;
+  }
+}
+
+run("S43_CONTRACT_001 templates file is closed-world v1", () => {
+  assert.equal(templates.schema_version, "kolosseum.support_boundary_templates.v1");
+  assert.equal(templates.slice, "S43");
+  assert.equal(templates.closed_world, true);
+  assert.equal(Array.isArray(templates.templates), true);
+  assert.equal(templates.templates.length, 11);
+});
+
+run("S43_CONTRACT_002 picker contract is closed-world v1", () => {
+  assert.equal(picker.schema_version, "kolosseum.support_boundary_picker.contract.v1");
+  assert.equal(picker.slice, "S43");
+  assert.equal(picker.closed_world, true);
+  assert.equal(picker.template_source, "support/support_boundary_templates.json");
+});
+
+run("S43_MAPPING_001 each required excluded ask maps to one safe template", () => {
+  const expected = expectedAskKeys().sort();
+  const actual = templates.templates.map(reconstructKey).sort();
+  assert.deepEqual(actual, expected);
+
+  for (const key of expected) {
+    assert.equal(actual.filter((value) => value === key).length, 1, `${key} must map once`);
+  }
+});
+
+run("S43_MAPPING_002 template ids are closed and unique", () => {
+  const ids = templates.templates.map((template) => template.template_id);
+  assert.deepEqual([...ids].sort(), [...templates.template_ids].sort());
+  assert.equal(new Set(ids).size, ids.length);
+});
+
+run("S43_COPY_001 each template has required safe fields", () => {
+  for (const template of templates.templates) {
+    assert.match(template.template_id, /^SBT\d{3}$/);
+    assert.equal(typeof template.title, "string");
+    assert.ok(template.title.length > 0);
+    assert.equal(typeof template.response, "string");
+    assert.ok(template.response.length > 0);
+    assert.ok(Array.isArray(template.allowed_operator_actions));
+    assert.ok(template.allowed_operator_actions.includes("select_template"));
+    assert.ok(template.allowed_operator_actions.includes("send_response"));
+    assert.equal(typeof template.escalation, "object");
+    assert.ok(templates.escalation_outcomes.includes(template.escalation.outcome));
+    assert.equal(typeof template.escalation.message, "string");
+    assert.ok(Array.isArray(template.forbidden_implications));
+  }
+});
+
+run("S43_COPY_002 responses do not contain forbidden claim lexemes", () => {
+  assertNoForbiddenLexemesInTemplateResponses();
+});
+
+run("S43_COPY_003 templates do not overpromise future delivery", () => {
+  const joined = JSON.stringify(templates.templates, null, 2).toLowerCase();
+  for (const phrase of [
+    "coming soon",
+    "on the roadmap",
+    "will support",
+    "planned for",
+    "we are building",
+    "future release"
+  ]) {
+    assert.equal(joined.includes(phrase), false, `Forbidden future-promise phrase: ${phrase}`);
+  }
+});
+
+run("S43_COPY_004 escalation does not create implied capability", () => {
+  for (const template of templates.templates) {
+    const message = template.escalation.message.toLowerCase();
+    assert.equal(message.includes("enable"), false, `${template.template_id} escalation implies enablement`);
+    assert.equal(message.includes("activate"), false, `${template.template_id} escalation implies activation`);
+    assert.equal(message.includes("available"), false, `${template.template_id} escalation implies availability`);
+  }
+});
+
+run("S43_PICKER_001 picker forbids mutation paths", () => {
+  for (const action of [
+    "edit_template_body",
+    "create_template_category",
+    "create_hidden_channel",
+    "change_engine_output",
+    "change_phase1_record",
+    "change_registry",
+    "change_compile_artifact",
+    "change_session_artifact"
+  ]) {
+    assert.ok(picker.operator_picker.forbidden_actions.includes(action), `Missing forbidden picker action: ${action}`);
+  }
+});
+
+run("S43_PICKER_002 picker exposes only safe display fields", () => {
+  assert.deepEqual(
+    picker.operator_picker.allowed_display_fields.sort(),
+    [
+      "allowed_operator_actions",
+      "escalation",
+      "response",
+      "template_id",
+      "title"
+    ].sort()
+  );
+});
+
+run("S43_DOC_001 markdown documents scope and escalation boundary", () => {
+  assert.ok(doc.includes("Escalation is a routing outcome only."));
+  assert.ok(doc.includes("must not imply"));
+  assert.ok(doc.includes("Each template has"));
+});
+
+run("S43_NEG_001 raw production template keys avoid direct unsafe category text", () => {
+  const raw = fs.readFileSync(templatesPath, "utf8");
+  for (const key of expectedAskKeys()) {
+    assert.equal(raw.includes(`"${key}"`), false, `Raw production JSON must not expose direct ask key: ${key}`);
+  }
+});
+
+console.log("S43 support boundary template tests passed.");


### PR DESCRIPTION
Adds S43 Support Boundary Templates in App documentation, JSON templates, UI/operator picker contract, escalation rules, and negative copy tests. The templates are factual, boundary-safe, closed-world, and avoid implying unsupported v0 capability.