### PR TITLE
Add S44 public sales claim registry guard

### DIFF
--- a/ci/scripts/run_public_sales_claim_registry_guard.mjs
+++ b/ci/scripts/run_public_sales_claim_registry_guard.mjs
@@ -1,0 +1,326 @@
+import fs from "node:fs";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+const DEFAULT_REGISTRY_PATH = path.join(process.cwd(), "claims", "public_sales_claim_registry.json");
+
+function readJson(filePath) {
+  return JSON.parse(fs.readFileSync(filePath, "utf8"));
+}
+
+function reconstruct(parts) {
+  if (!Array.isArray(parts)) return String(parts);
+  return parts.join("");
+}
+
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function lineNumberAt(text, index) {
+  return text.slice(0, index).split(/\n/).length;
+}
+
+function excerptAt(text, index, length = 140) {
+  const start = Math.max(0, index - 60);
+  const end = Math.min(text.length, index + length);
+  return text.slice(start, end).replace(/\s+/g, " ").trim();
+}
+
+function makeFailure({ code, filePath, line, ruleId = null, claim = null, excerpt = "" }) {
+  return {
+    code,
+    path: filePath,
+    line,
+    rule_id: ruleId,
+    claim,
+    excerpt,
+  };
+}
+
+export function loadRegistry(registryPath = DEFAULT_REGISTRY_PATH) {
+  return readJson(registryPath);
+}
+
+export function validateRegistry(registry) {
+  const failures = [];
+
+  if (!registry || typeof registry !== "object") {
+    failures.push(makeFailure({
+      code: "PSCRG_INVALID_REGISTRY",
+      filePath: "registry",
+      line: 0,
+      excerpt: "Registry is not an object",
+    }));
+    return failures;
+  }
+
+  if (registry.schema_version !== "kolosseum.public_sales_claim_registry.v1") {
+    failures.push(makeFailure({
+      code: "PSCRG_INVALID_REGISTRY_VERSION",
+      filePath: "registry",
+      line: 0,
+      excerpt: "Unexpected registry schema version",
+    }));
+  }
+
+  if (registry.closed_world !== true) {
+    failures.push(makeFailure({
+      code: "PSCRG_REGISTRY_NOT_CLOSED",
+      filePath: "registry",
+      line: 0,
+      excerpt: "Registry must be closed_world true",
+    }));
+  }
+
+  const proofIds = new Set((registry.proofs ?? []).map((proof) => proof.proof_id));
+  const claimIds = new Set();
+  const claimPhrases = new Set();
+
+  for (const claim of registry.allowed_claims ?? []) {
+    if (claimIds.has(claim.claim_id)) {
+      failures.push(makeFailure({
+        code: "PSCRG_DUPLICATE_CLAIM_ID",
+        filePath: "registry",
+        line: 0,
+        claim: claim.claim_id,
+        excerpt: claim.phrase ?? "",
+      }));
+    }
+
+    claimIds.add(claim.claim_id);
+
+    if (claimPhrases.has(claim.phrase)) {
+      failures.push(makeFailure({
+        code: "PSCRG_DUPLICATE_CLAIM_PHRASE",
+        filePath: "registry",
+        line: 0,
+        claim: claim.phrase,
+        excerpt: claim.phrase,
+      }));
+    }
+
+    claimPhrases.add(claim.phrase);
+
+    if (!registry.allowed_claim_types.includes(claim.claim_type)) {
+      failures.push(makeFailure({
+        code: "PSCRG_INVALID_CLAIM_TYPE",
+        filePath: "registry",
+        line: 0,
+        claim: claim.phrase,
+        excerpt: claim.claim_type,
+      }));
+    }
+
+    if (!Array.isArray(claim.proof_ids) || claim.proof_ids.length === 0) {
+      failures.push(makeFailure({
+        code: "PSCRG_MISSING_PROOF_LINK",
+        filePath: "registry",
+        line: 0,
+        claim: claim.phrase,
+        excerpt: claim.phrase,
+      }));
+      continue;
+    }
+
+    for (const proofId of claim.proof_ids) {
+      if (!proofIds.has(proofId)) {
+        failures.push(makeFailure({
+          code: "PSCRG_UNKNOWN_PROOF_LINK",
+          filePath: "registry",
+          line: 0,
+          claim: claim.phrase,
+          excerpt: proofId,
+        }));
+      }
+    }
+  }
+
+  return failures;
+}
+
+export function scanText({ text, filePath, registry }) {
+  const failures = [];
+  const marker = registry.claim_marker ?? "PUBLIC_CLAIM:";
+  const allowedClaims = new Set((registry.allowed_claims ?? []).map((claim) => claim.phrase));
+  const lines = text.split(/\n/);
+
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = lines[index];
+    const markerIndex = line.indexOf(marker);
+
+    if (markerIndex === -1) continue;
+
+    const claim = line.slice(markerIndex + marker.length).trim();
+
+    if (!allowedClaims.has(claim)) {
+      failures.push(makeFailure({
+        code: "PSCRG_UNKNOWN_PUBLIC_CLAIM",
+        filePath,
+        line: index + 1,
+        claim,
+        excerpt: line.trim(),
+      }));
+    }
+  }
+
+  for (const rule of registry.forbidden_semantics?.substring_rules ?? []) {
+    for (const patternParts of rule.patterns ?? []) {
+      const pattern = reconstruct(patternParts);
+      const regex = new RegExp(escapeRegExp(pattern), "i");
+      const match = regex.exec(text);
+
+      if (match) {
+        failures.push(makeFailure({
+          code: "PSCRG_FORBIDDEN_SEMANTIC",
+          filePath,
+          line: lineNumberAt(text, match.index),
+          ruleId: rule.rule_id,
+          excerpt: excerptAt(text, match.index),
+        }));
+      }
+    }
+  }
+
+  for (const rule of registry.forbidden_semantics?.context_rules ?? []) {
+    const windowSize = Number(rule.window ?? 80);
+
+    for (const leftParts of rule.left_patterns ?? []) {
+      const left = reconstruct(leftParts);
+      const leftRegex = new RegExp(escapeRegExp(left), "ig");
+      let leftMatch;
+
+      while ((leftMatch = leftRegex.exec(text)) !== null) {
+        const start = Math.max(0, leftMatch.index - windowSize);
+        const end = Math.min(text.length, leftMatch.index + left.length + windowSize);
+        const context = text.slice(start, end);
+
+        for (const rightParts of rule.right_patterns ?? []) {
+          const right = reconstruct(rightParts);
+          const rightRegex = new RegExp(escapeRegExp(right), "i");
+
+          if (rightRegex.test(context)) {
+            failures.push(makeFailure({
+              code: "PSCRG_FORBIDDEN_CONTEXT",
+              filePath,
+              line: lineNumberAt(text, leftMatch.index),
+              ruleId: rule.rule_id,
+              excerpt: context.replace(/\s+/g, " ").trim(),
+            }));
+          }
+        }
+      }
+    }
+  }
+
+  return failures;
+}
+
+export function scanFiles({ files, registry }) {
+  const failures = [...validateRegistry(registry)];
+  let scannedFiles = 0;
+
+  for (const filePath of files) {
+    let text;
+    try {
+      text = fs.readFileSync(filePath, "utf8");
+    } catch (error) {
+      failures.push(makeFailure({
+        code: "PSCRG_SCAN_FILE_UNREADABLE",
+        filePath,
+        line: 0,
+        excerpt: error instanceof Error ? error.message : String(error),
+      }));
+      continue;
+    }
+
+    scannedFiles += 1;
+    failures.push(...scanText({ text, filePath, registry }));
+  }
+
+  return {
+    ok: failures.length === 0,
+    registry_id: registry.registry_id ?? "unknown",
+    scanned_files: scannedFiles,
+    failures,
+  };
+}
+
+export function writeReport(report, reportPath) {
+  fs.mkdirSync(path.dirname(reportPath), { recursive: true });
+  fs.writeFileSync(reportPath, `${JSON.stringify(report, null, 2)}\n`, "utf8");
+}
+
+function parseArgs(argv) {
+  const args = {
+    registryPath: DEFAULT_REGISTRY_PATH,
+    reportPath: path.join(process.cwd(), "tmp", "public_sales_claim_registry_guard.report.json"),
+    files: [],
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const value = argv[index];
+
+    if (value === "--registry") {
+      args.registryPath = argv[index + 1];
+      index += 1;
+      continue;
+    }
+
+    if (value === "--report") {
+      args.reportPath = argv[index + 1];
+      index += 1;
+      continue;
+    }
+
+    if (value === "--file") {
+      args.files.push(argv[index + 1]);
+      index += 1;
+      continue;
+    }
+  }
+
+  return args;
+}
+
+export function main(argv = process.argv.slice(2)) {
+  const args = parseArgs(argv);
+  const registry = loadRegistry(args.registryPath);
+
+  if (args.files.length === 0) {
+    const registryOnlyFailures = validateRegistry(registry);
+    const report = {
+      ok: registryOnlyFailures.length === 0,
+      registry_id: registry.registry_id ?? "unknown",
+      scanned_files: 0,
+      failures: registryOnlyFailures,
+    };
+
+    writeReport(report, args.reportPath);
+
+    if (!report.ok) {
+      console.error(JSON.stringify(report, null, 2));
+      process.exitCode = 1;
+      return report;
+    }
+
+    console.log(JSON.stringify(report, null, 2));
+    return report;
+  }
+
+  const report = scanFiles({ files: args.files, registry });
+  writeReport(report, args.reportPath);
+
+  if (!report.ok) {
+    console.error(JSON.stringify(report, null, 2));
+    process.exitCode = 1;
+    return report;
+  }
+
+  console.log(JSON.stringify(report, null, 2));
+  return report;
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main();
+}

--- a/claims/public_sales_claim_registry.json
+++ b/claims/public_sales_claim_registry.json
@@ -1,0 +1,292 @@
+{
+  "schema_version": "kolosseum.public_sales_claim_registry.v1",
+  "registry_id": "public_sales_claim_registry",
+  "slice": "S44",
+  "closed_world": true,
+  "claim_marker": "PUBLIC_CLAIM:",
+  "allowed_claim_types": [
+    "price_fact",
+    "seat_cap_fact",
+    "access_fact",
+    "visibility_fact",
+    "authority_limit",
+    "proof_scoped_value",
+    "factual_runtime_surface"
+  ],
+  "proofs": [
+    {
+      "proof_id": "proof_pricing_row_coach_16",
+      "source": "coach_16_pricing_boundary",
+      "anchor": "price_and_seat_cap"
+    },
+    {
+      "proof_id": "proof_v0_coach_authority_limit",
+      "source": "v0_scope_manifest",
+      "anchor": "coach_authority_observational_only"
+    },
+    {
+      "proof_id": "proof_v0_access_visibility_scope",
+      "source": "v0_scope_manifest",
+      "anchor": "platform_access_and_visibility"
+    },
+    {
+      "proof_id": "proof_v0_payment_engine_separation",
+      "source": "v0_engine_boundary",
+      "anchor": "payment_does_not_change_engine_output"
+    },
+    {
+      "proof_id": "proof_v0_factual_runtime_surface",
+      "source": "v0_scope_manifest",
+      "anchor": "factual_operator_surfaces_only"
+    }
+  ],
+  "allowed_claims": [
+    {
+      "claim_id": "PSC_ALLOWED_001",
+      "claim_type": "price_fact",
+      "phrase": "£59.99 per month",
+      "proof_ids": [
+        "proof_pricing_row_coach_16"
+      ]
+    },
+    {
+      "claim_id": "PSC_ALLOWED_002",
+      "claim_type": "seat_cap_fact",
+      "phrase": "Manage up to 16 athletes",
+      "proof_ids": [
+        "proof_pricing_row_coach_16"
+      ]
+    },
+    {
+      "claim_id": "PSC_ALLOWED_003",
+      "claim_type": "access_fact",
+      "phrase": "Access to coach-managed pilot operation",
+      "proof_ids": [
+        "proof_v0_access_visibility_scope"
+      ]
+    },
+    {
+      "claim_id": "PSC_ALLOWED_004",
+      "claim_type": "visibility_fact",
+      "phrase": "View athlete execution artefacts",
+      "proof_ids": [
+        "proof_v0_access_visibility_scope"
+      ]
+    },
+    {
+      "claim_id": "PSC_ALLOWED_005",
+      "claim_type": "authority_limit",
+      "phrase": "Assign programs within system limits",
+      "proof_ids": [
+        "proof_v0_coach_authority_limit"
+      ]
+    },
+    {
+      "claim_id": "PSC_ALLOWED_006",
+      "claim_type": "authority_limit",
+      "phrase": "Write non-binding coach notes",
+      "proof_ids": [
+        "proof_v0_coach_authority_limit"
+      ]
+    },
+    {
+      "claim_id": "PSC_ALLOWED_007",
+      "claim_type": "authority_limit",
+      "phrase": "Coaches may comment, never decide",
+      "proof_ids": [
+        "proof_v0_coach_authority_limit"
+      ]
+    },
+    {
+      "claim_id": "PSC_ALLOWED_008",
+      "claim_type": "proof_scoped_value",
+      "phrase": "Payment controls access only and does not change engine output",
+      "proof_ids": [
+        "proof_v0_payment_engine_separation"
+      ]
+    },
+    {
+      "claim_id": "PSC_ALLOWED_009",
+      "claim_type": "factual_runtime_surface",
+      "phrase": "Factual pilot status only",
+      "proof_ids": [
+        "proof_v0_factual_runtime_surface"
+      ]
+    },
+    {
+      "claim_id": "PSC_ALLOWED_010",
+      "claim_type": "factual_runtime_surface",
+      "phrase": "Factual execution records only",
+      "proof_ids": [
+        "proof_v0_factual_runtime_surface"
+      ]
+    }
+  ],
+  "forbidden_semantics": {
+    "substring_rules": [
+      {
+        "rule_id": "FSC001",
+        "label": "forbidden_semantic_class_001",
+        "patterns": [
+          ["im", "prove"],
+          ["im", "proves"],
+          ["im", "proved"],
+          ["boo", "st"],
+          ["better out", "comes"]
+        ]
+      },
+      {
+        "rule_id": "FSC002",
+        "label": "forbidden_semantic_class_002",
+        "patterns": [
+          ["opti", "mise"],
+          ["opti", "mises"],
+          ["opti", "mised"],
+          ["opti", "misation"],
+          ["opti", "mize"],
+          ["opti", "mization"]
+        ]
+      },
+      {
+        "rule_id": "FSC003",
+        "label": "forbidden_semantic_class_003",
+        "patterns": [
+          ["risk reduc", "tion"],
+          ["reduces risk"],
+          ["safe", "r training"],
+          ["safe", "ty"]
+        ]
+      },
+      {
+        "rule_id": "FSC004",
+        "label": "forbidden_semantic_class_004",
+        "patterns": [
+          ["medi", "cal"],
+          ["re", "hab"],
+          ["clinical"]
+        ]
+      },
+      {
+        "rule_id": "FSC005",
+        "label": "forbidden_semantic_class_005",
+        "patterns": [
+          ["read", "iness"],
+          ["ready for training"],
+          ["suit", "ability"],
+          ["suit", "able for"]
+        ]
+      },
+      {
+        "rule_id": "FSC006",
+        "label": "forbidden_semantic_class_006",
+        "patterns": [
+          ["compli", "ance"],
+          ["correc", "tion"],
+          ["correc", "ts"],
+          ["recom", "mend"],
+          ["recom", "mendation"]
+        ]
+      },
+      {
+        "rule_id": "FSC007",
+        "label": "forbidden_semantic_class_007",
+        "patterns": [
+          ["coach decides"],
+          ["coach can decide"],
+          ["coach may decide"],
+          ["coach controls engine"],
+          ["coach changes engine"]
+        ]
+      },
+      {
+        "rule_id": "FSC008",
+        "label": "forbidden_semantic_class_008",
+        "patterns": [
+          ["org runtime"],
+          ["team runtime"],
+          ["gym runtime"],
+          ["unit runtime"],
+          ["organisation runtime"],
+          ["organization runtime"]
+        ]
+      },
+      {
+        "rule_id": "FSC009",
+        "label": "forbidden_semantic_class_009",
+        "patterns": [
+          ["evi", "dence export"],
+          ["proof export"],
+          ["downloadable proof pack"],
+          ["sealed export"]
+        ]
+      },
+      {
+        "rule_id": "FSC010",
+        "label": "forbidden_semantic_class_010",
+        "patterns": [
+          ["payment changes engine"],
+          ["payment alters engine"],
+          ["payment changes program validity"],
+          ["paid users get different engine output"]
+        ]
+      },
+      {
+        "rule_id": "FSC011",
+        "label": "forbidden_semantic_class_011",
+        "patterns": [
+          ["coach over", "ride"],
+          ["coach can over", "ride"],
+          ["coach may over", "ride"],
+          ["over", "ride engine"]
+        ]
+      }
+    ],
+    "context_rules": [
+      {
+        "rule_id": "CTX001",
+        "label": "payment_near_engine_change",
+        "window": 90,
+        "left_patterns": [
+          ["payment"],
+          ["paid"]
+        ],
+        "right_patterns": [
+          ["changes engine"],
+          ["alters engine"],
+          ["changes output"],
+          ["changes validity"]
+        ]
+      },
+      {
+        "rule_id": "CTX002",
+        "label": "coach_near_decision_authority",
+        "window": 90,
+        "left_patterns": [
+          ["coach"],
+          ["coaches"]
+        ],
+        "right_patterns": [
+          ["can decide"],
+          ["may decide"],
+          ["controls engine"],
+          ["over", "ride"]
+        ]
+      }
+    ]
+  },
+  "report_format": {
+    "ok": "boolean",
+    "registry_id": "string",
+    "scanned_files": "number",
+    "failures": [
+      {
+        "code": "string",
+        "path": "string",
+        "line": "number",
+        "rule_id": "string|null",
+        "claim": "string|null",
+        "excerpt": "string"
+      }
+    ]
+  }
+}

--- a/docs/slices/PUBLIC_SALES_CLAIM_REGISTRY_GUARD.md
+++ b/docs/slices/PUBLIC_SALES_CLAIM_REGISTRY_GUARD.md
@@ -1,0 +1,125 @@
+# S44 - Public Sales Claim Registry Guard
+
+Document: PUBLIC_SALES_CLAIM_REGISTRY_GUARD.md
+Project: Kolosseum v0
+Slice: S44
+Status: Implementable specification
+Scope: Public copy claim registry and fail-closed guard
+Engine compatibility: EB2-1.0.0
+Rewrite policy: Rewrite-only
+
+## 1. Purpose
+
+S44 defines a CI-ready guard for surfaced public copy.
+
+The guard protects public, pricing, sales, admin, app, and documentation copy by requiring surfaced claims to match a registered allowed claim exactly.
+
+Coach tier copy is especially sensitive. The binding authority limit is:
+
+Coaches may comment, never decide
+
+## 2. Files
+
+S44 adds:
+
+- claims/public_sales_claim_registry.json
+- ci/scripts/run_public_sales_claim_registry_guard.mjs
+- tests/fixtures/public_sales_claim_registry_guard_fixtures.json
+- tests/claims/public_sales_claim_registry_guard.test.mjs
+- docs/slices/PUBLIC_SALES_CLAIM_REGISTRY_GUARD.md
+
+## 3. Claim Registration Rule
+
+Any surfaced public claim must be marked in source text as:
+
+PUBLIC_CLAIM: exact registered claim phrase
+
+The guard extracts the phrase after PUBLIC_CLAIM and compares it with the registry.
+
+A surfaced claim passes only when:
+
+- the phrase exactly matches one registered claim
+- the registered claim has at least one proof id
+- every proof id resolves to a registry proof entry
+- no forbidden semantic rule matches the surfaced text
+
+## 4. Allowed Claim Types
+
+The registry supports only these allowed claim type ids:
+
+- price_fact
+- seat_cap_fact
+- access_fact
+- visibility_fact
+- authority_limit
+- proof_scoped_value
+- factual_runtime_surface
+
+No other claim type is valid.
+
+## 5. Forbidden Semantic Rules
+
+Forbidden semantic classes are encoded in the registry as FSC rules.
+
+The registry stores sensitive terms as token parts. The guard reconstructs those terms at runtime before scanning candidate copy.
+
+This prevents the guard's own source files from becoming accidental public claim violations while still enforcing the required semantics.
+
+## 6. Fail-Closed Behaviour
+
+The guard fails when:
+
+- a surfaced public claim is unknown
+- a registered claim has no proof link
+- a registered proof id is missing
+- a forbidden semantic rule matches
+- a context rule matches
+- the registry shape is invalid
+- a scan file cannot be read
+
+## 7. Report Format
+
+The guard report is JSON:
+
+- ok
+- registry_id
+- scanned_files
+- failures
+
+Each failure includes:
+
+- code
+- path
+- line
+- rule_id
+- claim
+- excerpt
+
+## 8. Coach 16 Public Copy
+
+The coach_16 public copy is allowed only when exact registered phrases are used.
+
+Allowed phrases include:
+
+- £59.99 per month
+- Manage up to 16 athletes
+- Assign programs within system limits
+- View athlete execution artefacts
+- Write non-binding coach notes
+- Coaches may comment, never decide
+- Payment controls access only and does not change engine output
+
+Any stronger claim fails.
+
+## 9. Acceptance Criteria
+
+S44 is accepted only if:
+
+- allowed coach_16 pricing copy passes
+- a stronger unregistered claim fails
+- proof package claims in public copy fail
+- forbidden FSC public copy fails
+- unknown claims fail
+- missing proof links fail
+- the report format is deterministic
+- the guard fails closed

--- a/tests/claims/public_sales_claim_registry_guard.test.mjs
+++ b/tests/claims/public_sales_claim_registry_guard.test.mjs
@@ -1,0 +1,165 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import {
+  loadRegistry,
+  scanFiles,
+  validateRegistry,
+} from "../../ci/scripts/run_public_sales_claim_registry_guard.mjs";
+
+const repoRoot = process.cwd();
+const registryPath = path.join(repoRoot, "claims", "public_sales_claim_registry.json");
+const fixturesPath = path.join(repoRoot, "tests", "fixtures", "public_sales_claim_registry_guard_fixtures.json");
+const docPath = path.join(repoRoot, "docs", "slices", "PUBLIC_SALES_CLAIM_REGISTRY_GUARD.md");
+const guardPath = path.join(repoRoot, "ci", "scripts", "run_public_sales_claim_registry_guard.mjs");
+
+const registry = loadRegistry(registryPath);
+const fixtures = JSON.parse(fs.readFileSync(fixturesPath, "utf8"));
+const doc = fs.readFileSync(docPath, "utf8");
+const guardSource = fs.readFileSync(guardPath, "utf8");
+
+const tmpDir = path.join(os.tmpdir(), "kolosseum_s44_public_sales_claim_guard");
+
+function writeTmpFile(name, content) {
+  fs.mkdirSync(tmpDir, { recursive: true });
+  const filePath = path.join(tmpDir, name);
+  fs.writeFileSync(filePath, `${content}\n`, "utf8");
+  return filePath;
+}
+
+function joinParts(parts) {
+  return parts.join("");
+}
+
+function run(name, fn) {
+  try {
+    fn();
+    console.log(`PASS ${name}`);
+  } catch (error) {
+    console.error(`FAIL ${name}`);
+    throw error;
+  }
+}
+
+run("S44_REGISTRY_001 registry is closed-world and valid", () => {
+  assert.equal(registry.schema_version, "kolosseum.public_sales_claim_registry.v1");
+  assert.equal(registry.closed_world, true);
+  assert.equal(registry.claim_marker, "PUBLIC_CLAIM:");
+  assert.deepEqual(validateRegistry(registry), []);
+});
+
+run("S44_REGISTRY_002 allowed claim types are exact", () => {
+  assert.deepEqual(
+    registry.allowed_claim_types.sort(),
+    [
+      "access_fact",
+      "authority_limit",
+      "factual_runtime_surface",
+      "price_fact",
+      "proof_scoped_value",
+      "seat_cap_fact",
+      "visibility_fact"
+    ].sort()
+  );
+});
+
+run("S44_REGISTRY_003 every allowed claim has proof", () => {
+  const proofIds = new Set(registry.proofs.map((proof) => proof.proof_id));
+
+  for (const claim of registry.allowed_claims) {
+    assert.ok(Array.isArray(claim.proof_ids), `${claim.claim_id} proof_ids missing`);
+    assert.ok(claim.proof_ids.length > 0, `${claim.claim_id} proof_ids empty`);
+
+    for (const proofId of claim.proof_ids) {
+      assert.ok(proofIds.has(proofId), `${claim.claim_id} unknown proof ${proofId}`);
+    }
+  }
+});
+
+run("S44_ALLOWED_001 coach_16 pricing copy passes", () => {
+  const copy = fixtures.allowed_coach_16_claims.map((claim) => `PUBLIC_CLAIM: ${claim}`).join("\n");
+  const filePath = writeTmpFile("allowed_coach_16.txt", copy);
+  const report = scanFiles({ files: [filePath], registry });
+
+  assert.equal(report.ok, true, JSON.stringify(report, null, 2));
+  assert.equal(report.scanned_files, 1);
+  assert.deepEqual(report.failures, []);
+});
+
+run("S44_FAIL_001 unknown and stronger claims fail", () => {
+  for (const fixture of fixtures.bad_claim_token_sets) {
+    const filePath = writeTmpFile(`${fixture.id}.txt`, joinParts(fixture.parts));
+    const report = scanFiles({ files: [filePath], registry });
+
+    assert.equal(report.ok, false, `${fixture.id} should fail`);
+    assert.ok(
+      report.failures.some((failure) => failure.code === fixture.expected_code),
+      `${fixture.id} expected ${fixture.expected_code}, got ${JSON.stringify(report.failures, null, 2)}`
+    );
+  }
+});
+
+run("S44_FAIL_002 missing proof link fails closed", () => {
+  const badRegistry = JSON.parse(JSON.stringify(registry));
+  badRegistry.allowed_claims[0].proof_ids = [];
+
+  const failures = validateRegistry(badRegistry);
+  assert.ok(failures.some((failure) => failure.code === "PSCRG_MISSING_PROOF_LINK"));
+});
+
+run("S44_FAIL_003 unknown proof link fails closed", () => {
+  const badRegistry = JSON.parse(JSON.stringify(registry));
+  badRegistry.allowed_claims[0].proof_ids = ["proof_missing"];
+
+  const failures = validateRegistry(badRegistry);
+  assert.ok(failures.some((failure) => failure.code === "PSCRG_UNKNOWN_PROOF_LINK"));
+});
+
+run("S44_FAIL_004 invalid claim type fails closed", () => {
+  const badRegistry = JSON.parse(JSON.stringify(registry));
+  badRegistry.allowed_claims[0].claim_type = "unregistered_claim_type";
+
+  const failures = validateRegistry(badRegistry);
+  assert.ok(failures.some((failure) => failure.code === "PSCRG_INVALID_CLAIM_TYPE"));
+});
+
+run("S44_REPORT_001 report format is deterministic", () => {
+  const filePath = writeTmpFile("report_unknown.txt", joinParts(["PUBLIC_CLAIM: Unknown stronger claim"]));
+  const report = scanFiles({ files: [filePath], registry });
+
+  assert.equal(typeof report.ok, "boolean");
+  assert.equal(report.registry_id, "public_sales_claim_registry");
+  assert.equal(typeof report.scanned_files, "number");
+  assert.ok(Array.isArray(report.failures));
+
+  const failure = report.failures[0];
+  assert.ok(Object.hasOwn(failure, "code"));
+  assert.ok(Object.hasOwn(failure, "path"));
+  assert.ok(Object.hasOwn(failure, "line"));
+  assert.ok(Object.hasOwn(failure, "rule_id"));
+  assert.ok(Object.hasOwn(failure, "claim"));
+  assert.ok(Object.hasOwn(failure, "excerpt"));
+});
+
+run("S44_DOC_001 markdown documents exact-match and fail-closed rules", () => {
+  assert.ok(doc.includes("PUBLIC_CLAIM: exact registered claim phrase"));
+  assert.ok(doc.includes("Fail-Closed Behaviour"));
+  assert.ok(doc.includes("Coaches may comment, never decide"));
+});
+
+run("S44_GUARD_001 guard exports required functions", () => {
+  for (const token of [
+    "loadRegistry",
+    "validateRegistry",
+    "scanText",
+    "scanFiles",
+    "writeReport",
+    "main"
+  ]) {
+    assert.ok(guardSource.includes(`export function ${token}`), `Missing export: ${token}`);
+  }
+});
+
+console.log("S44 public sales claim registry guard tests passed.");

--- a/tests/fixtures/public_sales_claim_registry_guard_fixtures.json
+++ b/tests/fixtures/public_sales_claim_registry_guard_fixtures.json
@@ -1,0 +1,58 @@
+{
+  "schema_version": "kolosseum.public_sales_claim_registry_guard_fixtures.v1",
+  "slice": "S44",
+  "allowed_coach_16_claims": [
+    "£59.99 per month",
+    "Manage up to 16 athletes",
+    "Access to coach-managed pilot operation",
+    "View athlete execution artefacts",
+    "Assign programs within system limits",
+    "Write non-binding coach notes",
+    "Coaches may comment, never decide",
+    "Payment controls access only and does not change engine output",
+    "Factual pilot status only",
+    "Factual execution records only"
+  ],
+  "bad_claim_token_sets": [
+    {
+      "id": "BAD001_unknown_claim",
+      "parts": ["PUBLIC_CLAIM: Coaches ", "dec", "ide training changes"],
+      "expected_code": "PSCRG_UNKNOWN_PUBLIC_CLAIM"
+    },
+    {
+      "id": "BAD002_stronger_claim",
+      "parts": ["PUBLIC_CLAIM: Coaches help athletes im", "prove outcomes"],
+      "expected_code": "PSCRG_UNKNOWN_PUBLIC_CLAIM"
+    },
+    {
+      "id": "BAD003_public_proof_package_claim",
+      "parts": ["PUBLIC_CLAIM: Evi", "dence export is part of v0"],
+      "expected_code": "PSCRG_UNKNOWN_PUBLIC_CLAIM"
+    },
+    {
+      "id": "BAD004_forbidden_fsc_text",
+      "parts": ["This public page says Kolosseum can opti", "mise training choices."],
+      "expected_code": "PSCRG_FORBIDDEN_SEMANTIC"
+    },
+    {
+      "id": "BAD005_forbidden_prepared_state_text",
+      "parts": ["This public page states read", "iness for a session."],
+      "expected_code": "PSCRG_FORBIDDEN_SEMANTIC"
+    },
+    {
+      "id": "BAD006_forbidden_risk_text",
+      "parts": ["This public page claims risk reduc", "tion."],
+      "expected_code": "PSCRG_FORBIDDEN_SEMANTIC"
+    },
+    {
+      "id": "BAD007_forbidden_coach_context",
+      "parts": ["This public page says a coach can ", "decide engine outcomes."],
+      "expected_code": "PSCRG_FORBIDDEN_SEMANTIC"
+    },
+    {
+      "id": "BAD008_forbidden_payment_context",
+      "parts": ["This public page says payment changes ", "engine output."],
+      "expected_code": "PSCRG_FORBIDDEN_SEMANTIC"
+    }
+  ]
+}


### PR DESCRIPTION
Adds S44 Public / Sales Claim Registry Guard documentation, claim registry JSON, forbidden semantic rules, CI report format, executable guard, and test fixtures. Enforces exact registered public claims, proof links, fail-closed unknown claims, and boundary-safe coach_16 copy.