### PR TITLE
Add S45 coach-ready pilot acceptance pack

### DIFF
--- a/ci/scripts/run_coach_ready_pilot_acceptance_pack_guard.mjs
+++ b/ci/scripts/run_coach_ready_pilot_acceptance_pack_guard.mjs
@@ -1,0 +1,173 @@
+import fs from "node:fs";
+import path from "node:path";
+
+const REQUIRED_READINESS_IDS = [
+  "CRP-001",
+  "CRP-002",
+  "CRP-003",
+  "CRP-004",
+  "CRP-005",
+  "CRP-006",
+  "CRP-007",
+  "CRP-008",
+  "CRP-009",
+  "CRP-010",
+  "CRP-011",
+  "CRP-012",
+  "CRP-013",
+  "CRP-014",
+  "CRP-015",
+  "CRP-016",
+  "CRP-017",
+  "CRP-018"
+];
+
+const REQUIRED_NEGATIVE_IDS = [
+  "CRP-N-001",
+  "CRP-N-002",
+  "CRP-N-003",
+  "CRP-N-004",
+  "CRP-N-005",
+  "CRP-N-006",
+  "CRP-N-007",
+  "CRP-N-008",
+  "CRP-N-009",
+  "CRP-N-010",
+  "CRP-N-011",
+  "CRP-N-012",
+  "CRP-N-013"
+];
+
+const REQUIRED_MD_HEADINGS = [
+  "# COACH-READY PILOT ACCEPTANCE PACK",
+  "## 1. Purpose",
+  "## 2. v0 boundary",
+  "## 3. Pass definition",
+  "## 4. Evidence-of-readiness matrix",
+  "## 5. Required checklist",
+  "## 6. Negative boundary checklist",
+  "## 7. Operator sign-off flow",
+  "## 9. Fail-closed rules",
+  "## 10. Final lock"
+];
+
+function fail(message) {
+  throw new Error(message);
+}
+
+function assert(condition, message) {
+  if (!condition) fail(message);
+}
+
+function readJson(filePath) {
+  return JSON.parse(fs.readFileSync(filePath, "utf8"));
+}
+
+function arraysEqual(a, b) {
+  return Array.isArray(a) &&
+    Array.isArray(b) &&
+    a.length === b.length &&
+    a.every((value, index) => value === b[index]);
+}
+
+function hasUniqueValues(values) {
+  return new Set(values).size === values.length;
+}
+
+export function verifyCoachReadyPilotAcceptancePack({
+  repoRoot = process.cwd(),
+  markdownPath = "docs/pilot/COACH_READY_PILOT_ACCEPTANCE_PACK.md",
+  checklistPath = "docs/pilot/coach_ready_pilot_acceptance_checklist.json"
+} = {}) {
+  const mdFullPath = path.join(repoRoot, markdownPath);
+  const jsonFullPath = path.join(repoRoot, checklistPath);
+
+  assert(fs.existsSync(mdFullPath), `missing markdown pack: ${markdownPath}`);
+  assert(fs.existsSync(jsonFullPath), `missing checklist json: ${checklistPath}`);
+
+  const markdown = fs.readFileSync(mdFullPath, "utf8");
+  const checklist = readJson(jsonFullPath);
+
+  for (const heading of REQUIRED_MD_HEADINGS) {
+    assert(markdown.includes(heading), `markdown missing heading: ${heading}`);
+  }
+
+  assert(checklist.checklist_id === "coach_ready_pilot_acceptance_checklist", "unexpected checklist_id");
+  assert(checklist.slice_id === "S45", "unexpected slice_id");
+  assert(checklist.scope === "kolosseum_v0_deterministic_execution_alpha", "unexpected scope");
+  assert(checklist.pass_rule?.mode === "fail_closed", "pass rule must fail closed");
+  assert(checklist.pass_rule?.required_readiness_items === "all_must_pass", "all readiness items must pass");
+  assert(checklist.pass_rule?.negative_boundary_items === "all_must_pass", "all negative boundary items must pass");
+  assert(checklist.pass_rule?.source_artefacts === "each_required_item_must_have_at_least_one", "source artefact rule missing");
+  assert(checklist.pass_rule?.manual_override_allowed === false, "manual override must be false");
+  assert(checklist.pass_rule?.partial_pass_allowed === false, "partial pass must be false");
+  assert(checklist.pass_rule?.warnings_allowed_to_pass === false, "warnings must not pass");
+
+  assert(arraysEqual(checklist.v0_boundary?.actors, ["individual_user", "coach"]), "v0 actors drifted");
+  assert(arraysEqual(checklist.v0_boundary?.execution_scopes, ["individual", "coach_managed"]), "v0 execution scopes drifted");
+  assert(arraysEqual(checklist.v0_boundary?.activities, ["powerlifting", "rugby_union", "general_strength"]), "v0 activities drifted");
+  assert(arraysEqual(checklist.v0_boundary?.engine_phases, ["phase_1", "phase_2", "phase_3", "phase_4", "phase_5", "phase_6"]), "v0 phase boundary drifted");
+  assert(checklist.v0_boundary?.coach_authority === "observational_only", "coach authority must remain observational only");
+  assert(checklist.v0_boundary?.payment_effect === "access_only", "payment effect must remain access only");
+
+  const readinessItems = checklist.required_readiness_items;
+  assert(Array.isArray(readinessItems), "required_readiness_items must be array");
+  const readinessIds = readinessItems.map((item) => item.id);
+  assert(arraysEqual(readinessIds, REQUIRED_READINESS_IDS), "required readiness IDs/order drifted");
+  assert(hasUniqueValues(readinessIds), "duplicate readiness IDs");
+
+  for (const item of readinessItems) {
+    assert(item.required === true, `${item.id} must be required`);
+    assert(Array.isArray(item.source_artefacts) && item.source_artefacts.length > 0, `${item.id} missing source artefacts`);
+    assert(typeof item.pass_condition === "string" && item.pass_condition.length > 0, `${item.id} missing pass condition`);
+    assert(typeof item.fail_condition === "string" && item.fail_condition.length > 0, `${item.id} missing fail condition`);
+  }
+
+  const negativeItems = checklist.negative_boundary_checklist;
+  assert(Array.isArray(negativeItems), "negative_boundary_checklist must be array");
+  const negativeIds = negativeItems.map((item) => item.id);
+  assert(arraysEqual(negativeIds, REQUIRED_NEGATIVE_IDS), "negative boundary IDs/order drifted");
+  assert(hasUniqueValues(negativeIds), "duplicate negative boundary IDs");
+
+  for (const item of negativeItems) {
+    assert(typeof item.excluded_surface === "string" && item.excluded_surface.length > 0, `${item.id} missing excluded surface`);
+    assert(typeof item.negative_check === "string" && item.negative_check.length > 0, `${item.id} missing negative check`);
+  }
+
+  const signoff = checklist.operator_signoff_flow;
+  assert(Array.isArray(signoff) && signoff.length === 5, "operator signoff flow must contain exactly five steps");
+  assert(arraysEqual(signoff.map((step) => step.step_id), ["SIGN-001", "SIGN-002", "SIGN-003", "SIGN-004", "SIGN-005"]), "operator signoff step order drifted");
+  assert(signoff[1].not_applicable_allowed === false, "required readiness items must not allow not-applicable");
+  assert(signoff[2].not_applicable_allowed === false, "negative boundary items must not allow not-applicable");
+  assert(arraysEqual(signoff[4].allowed_final_statuses, ["coach_ready", "blocked"]), "final statuses drifted");
+  assert(signoff[4].coach_ready_requires?.includes("all_required_readiness_items_passed"), "coach_ready missing all-required pass rule");
+  assert(signoff[4].coach_ready_requires?.includes("all_negative_boundary_items_passed"), "coach_ready missing negative boundary pass rule");
+  assert(signoff[4].coach_ready_requires?.includes("source_artefact_coverage_complete"), "coach_ready missing source artefact pass rule");
+  assert(signoff[4].coach_ready_requires?.includes("no_forbidden_surface_exposed"), "coach_ready missing forbidden surface pass rule");
+  assert(signoff[4].coach_ready_requires?.includes("v0_boundary_preserved"), "coach_ready missing v0 boundary pass rule");
+
+  const forbiddenClaims = checklist.forbidden_acceptance_claims;
+  assert(Array.isArray(forbiddenClaims) && forbiddenClaims.length === 11, "forbidden acceptance claims must contain exactly 11 entries");
+
+  assert(markdown.includes("Payment confirms access only."), "markdown must state payment access-only rule");
+  assert(markdown.includes("Coach Ready passes only when every required readiness item is passed."), "markdown must state all-items pass rule");
+  assert(markdown.includes("A single failed negative check blocks Coach Ready."), "markdown must state negative-check fail rule");
+  assert(markdown.includes("It must not be used as marketing copy."), "markdown must forbid marketing use");
+
+  return {
+    ok: true,
+    checklist_id: checklist.checklist_id,
+    readiness_count: readinessItems.length,
+    negative_boundary_count: negativeItems.length,
+    signoff_step_count: signoff.length
+  };
+}
+
+export function main() {
+  const result = verifyCoachReadyPilotAcceptancePack();
+  process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/docs/pilot/COACH_READY_PILOT_ACCEPTANCE_PACK.md
+++ b/docs/pilot/COACH_READY_PILOT_ACCEPTANCE_PACK.md
@@ -1,0 +1,217 @@
+# COACH-READY PILOT ACCEPTANCE PACK
+
+Document status: v0 acceptance artefact  
+Slice: S45 — Coach-Ready Pilot Acceptance Pack  
+Scope: Kolosseum v0 Deterministic Execution Alpha  
+Audience: founder, operator, coach pilot lead, support operator  
+Rewrite policy: rewrite-only  
+Acceptance mode: fail closed
+
+## 1. Purpose
+
+This pack defines the acceptance boundary for declaring a paid coach pilot operationally coach-ready inside Kolosseum v0.
+
+Coach Ready means the paid pilot has enough verified platform, declaration, compile, execution, coach-view, support, and claim-control evidence to operate a first coach-managed v0 pilot without widening into post-v0 capability.
+
+This pack does not prove evidence-complete execution. It does not prove v1 readiness. It does not activate organisational, team, unit, gym, export, proof, replay-envelope, or analytics capability.
+
+## 2. v0 boundary
+
+The acceptance boundary is limited to:
+
+- individual_user and coach actors only
+- individual and coach_managed execution scopes only
+- powerlifting, rugby_union, and general_strength only
+- Phase 1 through Phase 6 only
+- paid access confirmation as platform access only
+- workspace, coach account, athlete account, accepted coach-athlete link, locked scope, accepted Phase 1 declaration, first compile admission, first executable session, factual execution, factual artefact viewing, non-binding coach note, and factual history counts
+
+The following are outside this acceptance boundary and must remain absent or negatively checked:
+
+- Phase 7
+- Phase 8
+- evidence envelope
+- export proof
+- organisation runtime
+- team runtime
+- gym runtime
+- analytics or dashboard claims
+- messaging
+- readiness
+- safety or medical language
+- optimisation
+- coach override
+
+## 3. Pass definition
+
+Coach Ready passes only when every required readiness item is passed.
+
+There is no partial pass. There is no warning-state pass. There is no manual override. If a required item is missing, blocked, unproven, or mapped to an out-of-scope artefact, Coach Ready fails.
+
+Payment confirms access only. Payment does not change engine legality, compile admission, deterministic output, substitution behaviour, runtime state, evidence, replay, or user authority.
+
+## 4. Evidence-of-readiness matrix
+
+| ID | Acceptance item | Required proof | Source artefact class | Pass condition | Fail condition |
+|---|---|---|---|---|---|
+| CRP-001 | payment/access confirmed | Paid pilot access state exists | commercial/platform state | Payment/access status is confirmed before pilot operation | Payment missing, ambiguous, disputed, or treated as engine authority |
+| CRP-002 | workspace exists | Workspace record exists | pilot/operator state | Workspace is provisioned and addressable by operator | Workspace missing or inferred |
+| CRP-003 | coach account active | Coach account exists and is active | account/platform state | Coach can authenticate or is marked active by platform control | Coach invited only, inactive, missing, or inferred |
+| CRP-004 | athlete account active | Athlete account exists and is active | account/platform state | Athlete can authenticate or is marked active by platform control | Athlete invited only, inactive, missing, or inferred |
+| CRP-005 | coach-athlete link accepted | Explicit accepted link exists | link truth model | Link status is accepted and not revoked, rejected, expired, or inferred | Link missing, pending, revoked, rejected, expired, or inferred |
+| CRP-006 | scope locked | v0 pilot scope is locked | scope/operator state | Supported actor, execution scope, activity, and Phase 1-6 boundary are confirmed | Scope missing, broad, org/team/gym-based, or undefined |
+| CRP-007 | Phase 1 accepted | Accepted immutable declaration exists | Phase 1 acceptance record | Declaration is accepted, current, version-pinned, and hash-valid | Missing, unaccepted, superseded, mutable, mismatched, or inferred declaration |
+| CRP-008 | first compile admitted | Compile admission gate passed | compile gate record | Compile is admitted only after accepted Phase 1 and valid scope/link preconditions | Compile admitted without required preconditions |
+| CRP-009 | first executable session exists | Session compile output exists | session execution artefact | First executable session exists and is tied to lawful compile output | Session missing, unbound, generated outside v0, or proof-layer dependent |
+| CRP-010 | session can be executed factually | Runtime event path works | Phase 6 runtime state | Start, work event, and terminal/factual state path are available | Execution requires coaching judgement, readiness, safety, optimisation, or messaging |
+| CRP-011 | split/return works if included | Split/return runtime path works | Phase 6 runtime tests | If pilot includes split/return, RETURN_CONTINUE and/or RETURN_SKIP behaviour is factual and deterministic | Split/return claims exist without tested path |
+| CRP-012 | partial completion works if included | Partial completion runtime path works | Phase 6 runtime tests | If pilot includes partial completion, factual amount is recorded without altering planned truth | Partial completion changes engine legality or future decisions |
+| CRP-013 | coach can view factual artefact | Coach artefact viewer exists | coach surface | Coach can view factual execution artefact for linked athlete | Coach sees unlinked athlete, aggregate org data, evidence, export, or advisory data |
+| CRP-014 | coach can write non-binding note | Coach note surface exists | coach notes surface | Coach note is stored/displayed as non-binding comment only | Note changes engine truth, legality, substitution, progression, or runtime state |
+| CRP-015 | history counts show factual data only | Counts-only history surface exists | history read model | History shows counts/factual summaries only | History includes scoring, ranking, analytics, readiness, safety, or optimisation |
+| CRP-016 | support boundaries exist | Support templates and escalation boundary exist | support boundary pack | Support copy refuses out-of-scope asks safely and factually | Support implies future delivery, hidden capability, or unsupported operation |
+| CRP-017 | sales/public claims are guarded | Sales/public claim guard exists | claim registry/guard | Public claims are exact-match, proof-linked, and fail closed | Claims mention outcome, safety, readiness, optimisation, evidence, org runtime, or coach override |
+| CRP-018 | no illegal v0 surface exposed | Negative boundary checklist passes | boundary guard | Every excluded surface has a negative check and no exposed route/copy/surface contradicts v0 | Any forbidden surface is reachable, claimed, or treated as current v0 |
+
+## 5. Required checklist
+
+The operator must complete the following in order.
+
+1. Confirm paid access state exists for the pilot.
+2. Confirm workspace exists.
+3. Confirm coach account is active.
+4. Confirm athlete account is active.
+5. Confirm coach-athlete link is accepted.
+6. Confirm pilot scope is locked to v0.
+7. Confirm accepted Phase 1 declaration exists.
+8. Confirm first compile admission passes.
+9. Confirm first executable session exists.
+10. Confirm factual session execution path works.
+11. Confirm split/return path if included in the pilot.
+12. Confirm partial completion path if included in the pilot.
+13. Confirm coach can view factual artefact for linked athlete.
+14. Confirm coach can write non-binding note.
+15. Confirm history counts expose factual data only.
+16. Confirm support boundaries exist.
+17. Confirm sales/public claim guard passes.
+18. Confirm no forbidden v0 surface is exposed.
+
+## 6. Negative boundary checklist
+
+The operator must verify each excluded surface remains absent, unreachable, or explicitly refused.
+
+| ID | Excluded surface | Required negative check |
+|---|---|---|
+| CRP-N-001 | Phase 7 | No Phase 7 route, UI, acceptance requirement, pilot claim, or operator step is required for Coach Ready |
+| CRP-N-002 | Phase 8 | No Phase 8 route, UI, acceptance requirement, pilot claim, or operator step is required for Coach Ready |
+| CRP-N-003 | evidence envelope | No evidence envelope is required, generated, exported, or claimed as part of v0 Coach Ready |
+| CRP-N-004 | export proof | No proof export, audit export, or downloadable proof artefact is required or claimed |
+| CRP-N-005 | organisation runtime | No organisation-managed execution surface is exposed as current v0 |
+| CRP-N-006 | team runtime | No team-managed execution surface is exposed as current v0 |
+| CRP-N-007 | gym runtime | No gym/facility runtime surface is exposed as current v0 |
+| CRP-N-008 | analytics/dashboard claims | No analytics, ranking, trend dashboard, or outcome dashboard is claimed as current v0 capability |
+| CRP-N-009 | messaging | No coach-athlete messaging surface is required or claimed |
+| CRP-N-010 | readiness | No readiness score, readiness state, return-to-play judgement, or competition-ready claim is present |
+| CRP-N-011 | safety/medical | No medical, injury-prevention, safer-training, rehabilitation, or risk-reduction claim is present |
+| CRP-N-012 | optimisation | No optimisation, performance improvement, auto-progression, or best-plan claim is present |
+| CRP-N-013 | coach override | Coach cannot override engine decisions, legality, Phase 1 declarations, substitutions, progression, registries, or runtime truth |
+
+A single failed negative check blocks Coach Ready.
+
+## 7. Operator sign-off flow
+
+The sign-off flow is factual and manual.
+
+### Step 1 — Prepare pilot record
+
+Operator records:
+
+- pilot_id
+- workspace_id
+- coach_user_id
+- athlete_user_id
+- coach_athlete_link_id
+- accepted_phase1_declaration_id
+- first_compile_id
+- first_session_id
+- checklist_version
+- signoff_operator_id
+- signoff_timestamp_utc
+
+### Step 2 — Verify required readiness items
+
+Operator marks each CRP-001 through CRP-018 as one of:
+
+- passed
+- failed
+
+No not-applicable state is allowed for required items.
+
+For conditional behaviours:
+
+- split/return may be marked passed because included and tested, or passed because excluded from this pilot and not claimed
+- partial completion may be marked passed because included and tested, or passed because excluded from this pilot and not claimed
+
+### Step 3 — Verify negative boundary items
+
+Operator marks each CRP-N-001 through CRP-N-013 as one of:
+
+- passed
+- failed
+
+No not-applicable state is allowed.
+
+### Step 4 — Confirm source artefacts
+
+Every required precondition must have at least one source artefact. A source artefact may be a contract, guard, test, operator record, platform record, or support/claim registry.
+
+An item with no source artefact fails.
+
+### Step 5 — Final decision
+
+Coach Ready may be signed only if:
+
+- every required readiness item is passed
+- every negative boundary item is passed
+- every required item has source artefact coverage
+- no forbidden surface is exposed
+- the pilot remains inside v0 boundaries
+
+If any condition fails, final status is blocked.
+
+### Step 6 — Sign-off record
+
+The operator records one final status:
+
+- coach_ready
+- blocked
+
+The status coach_ready means the paid coach pilot can be operated inside v0 boundaries. It does not mean evidence-complete, organisation-ready, team-ready, gym-ready, analytics-ready, medically validated, or outcome-proven.
+
+## 8. Founder/operator use
+
+This pack is usable as a founder/operator checklist for deciding whether a paid coach pilot can begin.
+
+It must not be used as marketing copy. It must not be used to claim outcomes. It must not be used to imply current v1 proof-layer capability.
+
+## 9. Fail-closed rules
+
+Coach Ready fails if:
+
+- a required item is missing
+- a source artefact is missing
+- a negative boundary check is missing
+- any excluded surface is exposed or claimed
+- payment is treated as engine authority
+- coach authority is described as decision-making authority
+- support copy implies unsupported capability
+- public copy outruns the claim guard
+- evidence/export/org/team/gym/analytics/messaging/readiness/safety/medical/optimisation capability is implied as current v0
+
+## 10. Final lock
+
+S45 accepts only a narrow v0 coach-ready pilot.
+
+The acceptance pack proves operational readiness for a paid coach pilot inside v0 boundaries only.
+
+It does not prove v1, evidence sealing, export, organisation runtime, team runtime, gym runtime, analytics, messaging, readiness, safety, medical suitability, optimisation, or coach override.

--- a/docs/pilot/S45_IMPLEMENTATION_PROMPT.md
+++ b/docs/pilot/S45_IMPLEMENTATION_PROMPT.md
@@ -1,0 +1,15 @@
+# S45 IMPLEMENTATION PROMPT
+
+Use this prompt to recreate or review S45 in a separate ChatGPT session.
+
+You are creating S45 — Coach-Ready Pilot Acceptance Pack for Kolosseum v0.
+
+Create a fail-closed acceptance pack proving a paid coach pilot can operate end-to-end inside v0 boundaries only. Produce COACH_READY_PILOT_ACCEPTANCE_PACK.md and coach_ready_pilot_acceptance_checklist.json.
+
+The pack must prove payment/access confirmed, workspace exists, coach account active, athlete account active, coach-athlete link accepted, scope locked, Phase 1 accepted, first compile admitted, first executable session exists, factual execution works, split/return works if included, partial completion works if included, coach can view factual artefact, coach can write non-binding note, history counts show factual data only, support boundaries exist, sales/public claims are guarded, and no illegal v0 surface is exposed.
+
+Every required precondition must have at least one source artefact. Every excluded surface must have a negative check. Coach Ready must not pass with a missing item.
+
+Forbidden: Phase 7, Phase 8, evidence envelope, export proof, org/team/gym runtime, analytics/dashboard claims, messaging, readiness, safety/medical, optimisation, and coach override.
+
+Use no marketing claims. Keep language founder/operator usable, factual, and v0-bound.

--- a/docs/pilot/coach_ready_pilot_acceptance_checklist.json
+++ b/docs/pilot/coach_ready_pilot_acceptance_checklist.json
@@ -1,0 +1,304 @@
+{
+  "checklist_id": "coach_ready_pilot_acceptance_checklist",
+  "slice_id": "S45",
+  "title": "Coach-Ready Pilot Acceptance Checklist",
+  "version": "1.0.0",
+  "status": "authoritative",
+  "scope": "kolosseum_v0_deterministic_execution_alpha",
+  "rewrite_policy": "rewrite_only",
+  "pass_rule": {
+    "mode": "fail_closed",
+    "required_readiness_items": "all_must_pass",
+    "negative_boundary_items": "all_must_pass",
+    "source_artefacts": "each_required_item_must_have_at_least_one",
+    "manual_override_allowed": false,
+    "partial_pass_allowed": false,
+    "warnings_allowed_to_pass": false
+  },
+  "v0_boundary": {
+    "actors": ["individual_user", "coach"],
+    "execution_scopes": ["individual", "coach_managed"],
+    "activities": ["powerlifting", "rugby_union", "general_strength"],
+    "engine_phases": ["phase_1", "phase_2", "phase_3", "phase_4", "phase_5", "phase_6"],
+    "coach_authority": "observational_only",
+    "payment_effect": "access_only"
+  },
+  "required_readiness_items": [
+    {
+      "id": "CRP-001",
+      "name": "payment/access confirmed",
+      "required": true,
+      "source_artefacts": ["commercial_access_record", "pilot_operator_state"],
+      "pass_condition": "paid pilot access state is confirmed before operation",
+      "fail_condition": "payment is missing, ambiguous, disputed, or treated as engine authority"
+    },
+    {
+      "id": "CRP-002",
+      "name": "workspace exists",
+      "required": true,
+      "source_artefacts": ["workspace_record", "pilot_operator_state"],
+      "pass_condition": "workspace is provisioned and addressable",
+      "fail_condition": "workspace is missing or inferred"
+    },
+    {
+      "id": "CRP-003",
+      "name": "coach account active",
+      "required": true,
+      "source_artefacts": ["coach_account_record", "pilot_operator_state"],
+      "pass_condition": "coach account is active",
+      "fail_condition": "coach account is invited-only, inactive, missing, or inferred"
+    },
+    {
+      "id": "CRP-004",
+      "name": "athlete account active",
+      "required": true,
+      "source_artefacts": ["athlete_account_record", "pilot_operator_state"],
+      "pass_condition": "athlete account is active",
+      "fail_condition": "athlete account is invited-only, inactive, missing, or inferred"
+    },
+    {
+      "id": "CRP-005",
+      "name": "coach-athlete link accepted",
+      "required": true,
+      "source_artefacts": ["coach_athlete_link_record", "coach_athlete_link_api_contract"],
+      "pass_condition": "link status is accepted and not revoked, rejected, expired, or inferred",
+      "fail_condition": "link is missing, pending, revoked, rejected, expired, or inferred"
+    },
+    {
+      "id": "CRP-006",
+      "name": "scope locked",
+      "required": true,
+      "source_artefacts": ["v0_scope_lock", "pilot_scope_record"],
+      "pass_condition": "pilot scope is locked to supported actor, execution scope, activity, and phase boundary",
+      "fail_condition": "scope is missing, broad, org/team/gym-based, or undefined"
+    },
+    {
+      "id": "CRP-007",
+      "name": "Phase 1 accepted",
+      "required": true,
+      "source_artefacts": ["phase1_acceptance_record", "phase1_acceptance_tests"],
+      "pass_condition": "current accepted immutable version-pinned Phase 1 declaration exists",
+      "fail_condition": "Phase 1 declaration is missing, unaccepted, superseded, mutable, mismatched, or inferred"
+    },
+    {
+      "id": "CRP-008",
+      "name": "first compile admitted",
+      "required": true,
+      "source_artefacts": ["first_compile_gate", "compile_admission_tests"],
+      "pass_condition": "compile admission passes only after accepted Phase 1 and valid scope/link preconditions",
+      "fail_condition": "compile is admitted without required preconditions"
+    },
+    {
+      "id": "CRP-009",
+      "name": "first executable session exists",
+      "required": true,
+      "source_artefacts": ["first_executable_session_record", "session_execution_contract"],
+      "pass_condition": "first executable session exists and is tied to lawful compile output",
+      "fail_condition": "session is missing, unbound, generated outside v0, or proof-layer dependent"
+    },
+    {
+      "id": "CRP-010",
+      "name": "session can be executed factually",
+      "required": true,
+      "source_artefacts": ["phase6_runtime_tests", "session_runtime_contract"],
+      "pass_condition": "start, work event, and terminal/factual state path are available",
+      "fail_condition": "execution requires coaching judgement, readiness, safety, optimisation, or messaging"
+    },
+    {
+      "id": "CRP-011",
+      "name": "split/return works if included",
+      "required": true,
+      "source_artefacts": ["split_return_runtime_tests", "runtime_trace_return_gate_contract"],
+      "pass_condition": "included split/return behaviour is factual and deterministic, or excluded and not claimed",
+      "fail_condition": "split/return is claimed without tested path"
+    },
+    {
+      "id": "CRP-012",
+      "name": "partial completion works if included",
+      "required": true,
+      "source_artefacts": ["partial_completion_runtime_tests", "partial_completion_truth_model"],
+      "pass_condition": "included partial completion records factual amount without altering planned truth, or excluded and not claimed",
+      "fail_condition": "partial completion changes engine legality or future decisions"
+    },
+    {
+      "id": "CRP-013",
+      "name": "coach can view factual artefact",
+      "required": true,
+      "source_artefacts": ["coach_artefact_viewer_contract", "linked_athlete_permission_check"],
+      "pass_condition": "coach can view factual execution artefact for linked athlete",
+      "fail_condition": "coach sees unlinked athlete, aggregate org data, evidence, export, or advisory data"
+    },
+    {
+      "id": "CRP-014",
+      "name": "coach can write non-binding note",
+      "required": true,
+      "source_artefacts": ["coach_notes_contract", "non_binding_note_boundary_tests"],
+      "pass_condition": "coach note is stored or displayed as non-binding comment only",
+      "fail_condition": "note changes engine truth, legality, substitution, progression, or runtime state"
+    },
+    {
+      "id": "CRP-015",
+      "name": "history counts show factual data only",
+      "required": true,
+      "source_artefacts": ["history_counts_contract", "counts_only_history_tests"],
+      "pass_condition": "history shows counts or factual summaries only",
+      "fail_condition": "history includes scoring, ranking, analytics, readiness, safety, or optimisation"
+    },
+    {
+      "id": "CRP-016",
+      "name": "support boundaries exist",
+      "required": true,
+      "source_artefacts": ["support_boundary_templates", "support_boundary_picker_contract"],
+      "pass_condition": "support copy refuses out-of-scope asks safely and factually",
+      "fail_condition": "support implies future delivery, hidden capability, or unsupported operation"
+    },
+    {
+      "id": "CRP-017",
+      "name": "sales/public claims are guarded",
+      "required": true,
+      "source_artefacts": ["public_sales_claim_registry_guard", "claim_proof_registry"],
+      "pass_condition": "public claims are exact-match, proof-linked, and fail closed",
+      "fail_condition": "claims mention outcome, safety, readiness, optimisation, evidence, org runtime, or coach override"
+    },
+    {
+      "id": "CRP-018",
+      "name": "no illegal v0 surface exposed",
+      "required": true,
+      "source_artefacts": ["v0_boundary_claim_consistency_guard", "negative_boundary_checklist"],
+      "pass_condition": "every excluded surface has a negative check and no exposed route/copy/surface contradicts v0",
+      "fail_condition": "any forbidden surface is reachable, claimed, or treated as current v0"
+    }
+  ],
+  "negative_boundary_checklist": [
+    {
+      "id": "CRP-N-001",
+      "excluded_surface": "Phase 7",
+      "negative_check": "No Phase 7 route, UI, acceptance requirement, pilot claim, or operator step is required for Coach Ready."
+    },
+    {
+      "id": "CRP-N-002",
+      "excluded_surface": "Phase 8",
+      "negative_check": "No Phase 8 route, UI, acceptance requirement, pilot claim, or operator step is required for Coach Ready."
+    },
+    {
+      "id": "CRP-N-003",
+      "excluded_surface": "evidence envelope",
+      "negative_check": "No evidence envelope is required, generated, exported, or claimed as part of v0 Coach Ready."
+    },
+    {
+      "id": "CRP-N-004",
+      "excluded_surface": "export proof",
+      "negative_check": "No proof export, audit export, or downloadable proof artefact is required or claimed."
+    },
+    {
+      "id": "CRP-N-005",
+      "excluded_surface": "organisation runtime",
+      "negative_check": "No organisation-managed execution surface is exposed as current v0."
+    },
+    {
+      "id": "CRP-N-006",
+      "excluded_surface": "team runtime",
+      "negative_check": "No team-managed execution surface is exposed as current v0."
+    },
+    {
+      "id": "CRP-N-007",
+      "excluded_surface": "gym runtime",
+      "negative_check": "No gym/facility runtime surface is exposed as current v0."
+    },
+    {
+      "id": "CRP-N-008",
+      "excluded_surface": "analytics/dashboard claims",
+      "negative_check": "No analytics, ranking, trend dashboard, or outcome dashboard is claimed as current v0 capability."
+    },
+    {
+      "id": "CRP-N-009",
+      "excluded_surface": "messaging",
+      "negative_check": "No coach-athlete messaging surface is required or claimed."
+    },
+    {
+      "id": "CRP-N-010",
+      "excluded_surface": "readiness",
+      "negative_check": "No readiness score, readiness state, return-to-play judgement, or competition-ready claim is present."
+    },
+    {
+      "id": "CRP-N-011",
+      "excluded_surface": "safety/medical",
+      "negative_check": "No medical, injury-prevention, safer-training, rehabilitation, or risk-reduction claim is present."
+    },
+    {
+      "id": "CRP-N-012",
+      "excluded_surface": "optimisation",
+      "negative_check": "No optimisation, performance improvement, auto-progression, or best-plan claim is present."
+    },
+    {
+      "id": "CRP-N-013",
+      "excluded_surface": "coach override",
+      "negative_check": "Coach cannot override engine decisions, legality, Phase 1 declarations, substitutions, progression, registries, or runtime truth."
+    }
+  ],
+  "operator_signoff_flow": [
+    {
+      "step_id": "SIGN-001",
+      "name": "prepare_pilot_record",
+      "required_fields": [
+        "pilot_id",
+        "workspace_id",
+        "coach_user_id",
+        "athlete_user_id",
+        "coach_athlete_link_id",
+        "accepted_phase1_declaration_id",
+        "first_compile_id",
+        "first_session_id",
+        "checklist_version",
+        "signoff_operator_id",
+        "signoff_timestamp_utc"
+      ]
+    },
+    {
+      "step_id": "SIGN-002",
+      "name": "verify_required_readiness_items",
+      "allowed_item_statuses": ["passed", "failed"],
+      "not_applicable_allowed": false
+    },
+    {
+      "step_id": "SIGN-003",
+      "name": "verify_negative_boundary_items",
+      "allowed_item_statuses": ["passed", "failed"],
+      "not_applicable_allowed": false
+    },
+    {
+      "step_id": "SIGN-004",
+      "name": "confirm_source_artefacts",
+      "rule": "every required readiness item must have at least one source artefact"
+    },
+    {
+      "step_id": "SIGN-005",
+      "name": "final_decision",
+      "allowed_final_statuses": ["coach_ready", "blocked"],
+      "coach_ready_requires": [
+        "all_required_readiness_items_passed",
+        "all_negative_boundary_items_passed",
+        "source_artefact_coverage_complete",
+        "no_forbidden_surface_exposed",
+        "v0_boundary_preserved"
+      ]
+    }
+  ],
+  "forbidden_acceptance_claims": [
+    "Phase 7",
+    "Phase 8",
+    "evidence envelope",
+    "export proof",
+    "org/team/gym runtime",
+    "analytics/dashboard claims",
+    "messaging",
+    "readiness",
+    "safety/medical",
+    "optimisation",
+    "coach override"
+  ],
+  "final_status_meaning": {
+    "coach_ready": "Paid coach pilot can be operated inside v0 boundaries only.",
+    "blocked": "One or more readiness or negative boundary checks failed."
+  }
+}

--- a/test/s45_coach_ready_pilot_acceptance_pack.test.mjs
+++ b/test/s45_coach_ready_pilot_acceptance_pack.test.mjs
@@ -1,0 +1,12 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { verifyCoachReadyPilotAcceptancePack } from "../ci/scripts/run_coach_ready_pilot_acceptance_pack_guard.mjs";
+
+test("S45 coach-ready pilot acceptance pack passes closed-world guard", () => {
+  const result = verifyCoachReadyPilotAcceptancePack();
+  assert.equal(result.ok, true);
+  assert.equal(result.checklist_id, "coach_ready_pilot_acceptance_checklist");
+  assert.equal(result.readiness_count, 18);
+  assert.equal(result.negative_boundary_count, 13);
+  assert.equal(result.signoff_step_count, 5);
+});


### PR DESCRIPTION
## Summary
Adds S45 Coach-Ready Pilot Acceptance Pack for Kolosseum v0.

## Added
- COACH_READY_PILOT_ACCEPTANCE_PACK.md
- coach_ready_pilot_acceptance_checklist.json
- S45 implementation prompt
- closed-world S45 guard
- S45 guard test

## Boundary
This pack proves coach-ready pilot operation inside v0 only. It does not claim Phase 7, Phase 8, evidence envelopes, export proof, org/team/gym runtime, analytics, messaging, readiness, safety/medical, optimisation, or coach override.

## Local verification
- S45 guard passed
- S45 test passed
- lint:fast passed
- test:ci passed
- test:ci:integration passed after DATABASE_URL load
- e2e:golden passed