### PR TITLE
Add S48 pilot readiness evaluator

### DIFF
--- a/docs/pilot-readiness-evaluator/PILOT_READINESS_EVALUATOR.md
+++ b/docs/pilot-readiness-evaluator/PILOT_READINESS_EVALUATOR.md
@@ -1,0 +1,124 @@
+# S48 — Pilot Readiness Evaluator
+
+Status: v0 implementation slice  
+Scope: paid coach pilot operator evaluation  
+Engine impact: none  
+Depends on: S45 coach-ready pilot acceptance pack, S46 pilot sign-off record, S47 pilot blocked reason registry
+
+## Purpose
+
+The Pilot Readiness Evaluator is a pure function that derives the final pilot status from checklist result data.
+
+It returns one of:
+
+- `coach_ready`
+- `blocked`
+
+The evaluator does not store records. It does not sign records. It does not create timestamps. It does not read from a database. It does not use the network.
+
+## Input
+
+The evaluator accepts a single input object containing:
+
+- `readiness_item_results`
+- `negative_boundary_results`
+- `source_artefact_refs`
+
+Each readiness item result contains:
+
+- `item_id`
+- `passed`
+- `source_artefact_ref_ids`
+
+Each negative boundary result contains:
+
+- `boundary_id`
+- `passed`
+- `source_artefact_ref_ids`
+
+Each source artefact reference contains:
+
+- `artefact_ref_id`
+
+The evaluator treats all IDs as closed-world.
+
+## Output
+
+The evaluator returns exactly:
+
+- `final_status`
+- `blocked_reasons`
+- `missing_readiness_ids`
+- `failed_readiness_ids`
+- `missing_negative_boundary_ids`
+- `failed_negative_boundary_ids`
+- `missing_source_artefact_ids`
+
+## Deterministic rules
+
+The evaluator returns `blocked` if any of the following are true:
+
+- a required readiness item is missing
+- any readiness item is failed
+- a negative boundary item is missing
+- any negative boundary item is failed
+- a source artefact reference is missing
+- an unknown readiness item ID is present
+- an unknown negative boundary ID is present
+
+The evaluator returns `coach_ready` only when:
+
+- every required readiness item is present
+- every readiness item passed
+- every required negative boundary item is present
+- every negative boundary item passed
+- all item source artefact references resolve
+- no unknown item IDs are present
+- no blocked reasons are present
+
+## Blocked reason derivation
+
+The evaluator maps blocked states to S47 blocked reason IDs.
+
+Readiness failures map through the S47 readiness mapping.
+
+Negative boundary failures map to:
+
+- `forbidden_surface_exposed`
+
+Missing or unresolved source artefacts map to:
+
+- `source_artefact_missing`
+
+Unknown item IDs map to:
+
+- `forbidden_surface_exposed`
+
+## Prohibited behaviour
+
+The evaluator must not:
+
+- read from storage
+- call external services
+- generate timestamps
+- use randomness
+- mutate input
+- infer missing data
+- produce user-facing advice
+- produce sales or outcome claims
+- alter engine behaviour
+
+## Acceptance criteria
+
+Tests must prove:
+
+- all-pass input returns `coach_ready`
+- missing required readiness item returns `blocked`
+- failed readiness item returns `blocked`
+- missing negative boundary item returns `blocked`
+- failed negative boundary item returns `blocked`
+- missing source artefact returns `blocked`
+- unknown readiness item returns `blocked`
+- unknown negative boundary item returns `blocked`
+- evaluator does not mutate input
+- evaluator source contains no database, network, timestamp, or randomness dependency

--- a/package.json
+++ b/package.json
@@ -100,7 +100,8 @@
                     "guard:s33:first-session-start":  "node ci/scripts/guards/s33_first_executable_session_start_guard.mjs",
                     "agents:lint":  "node ci/agents/agent_prompt_lint.mjs \u0026\u0026 node ci/agents/agent_dormant_feature_guard.mjs \u0026\u0026 node ci/agents/agent_scope_guard.mjs",
                     "test:pilot-signoff":  "node scripts/run_pilot_signoff_record_tests.mjs",
-                    "guard:pilot-blocked-reasons":  "node scripts/run_pilot_blocked_reason_registry_guard.mjs"
+                    "guard:pilot-blocked-reasons":  "node scripts/run_pilot_blocked_reason_registry_guard.mjs",
+                    "test:pilot-readiness-evaluator":  "node test/pilotReadinessEvaluator.test.mjs"
                 },
     "dependencies":  {
                          "@kolosseum/engine":  "file:engine",

--- a/src/pilotReadinessEvaluator.ts
+++ b/src/pilotReadinessEvaluator.ts
@@ -1,0 +1,312 @@
+// S48 â€” Pilot Readiness Evaluator
+// Pure deterministic evaluator.
+// No database, no network, no generated timestamps, no randomness.
+
+export const PILOT_READY_STATUS = Object.freeze({
+  COACH_READY: "coach_ready",
+  BLOCKED: "blocked"
+} as const);
+
+export type PilotReadyStatus =
+  (typeof PILOT_READY_STATUS)[keyof typeof PILOT_READY_STATUS];
+
+export const REQUIRED_READINESS_IDS = Object.freeze([
+  "payment_confirmed",
+  "workspace_created",
+  "coach_active",
+  "athlete_active",
+  "link_accepted",
+  "scope_locked",
+  "phase1_accepted",
+  "first_compile_passed",
+  "first_executable_session_exists",
+  "factual_execution_checked",
+  "split_return_checked_if_claimed",
+  "partial_completion_checked_if_claimed",
+  "coach_surface_checked",
+  "coach_artefact_view_checked",
+  "non_binding_note_checked",
+  "history_counts_checked",
+  "support_boundary_checked",
+  "claim_guard_checked",
+  "source_artefacts_present"
+] as const);
+
+export type RequiredReadinessId = (typeof REQUIRED_READINESS_IDS)[number];
+
+export const REQUIRED_NEGATIVE_BOUNDARY_IDS = Object.freeze([
+  "no_phase7_surface",
+  "no_phase8_surface",
+  "no_org_runtime_surface",
+  "no_team_runtime_surface",
+  "no_gym_runtime_surface",
+  "no_analytics_surface",
+  "no_messaging_surface",
+  "no_claim_surface",
+  "no_medical_surface",
+  "no_safety_surface",
+  "no_optimisation_surface",
+  "no_coach_override_surface",
+  "no_forbidden_surface_exposed"
+] as const);
+
+export type RequiredNegativeBoundaryId = (typeof REQUIRED_NEGATIVE_BOUNDARY_IDS)[number];
+
+export type PilotBlockedReasonId =
+  | "payment_missing"
+  | "workspace_missing"
+  | "coach_account_inactive"
+  | "athlete_account_inactive"
+  | "coach_athlete_link_not_accepted"
+  | "scope_not_locked"
+  | "phase1_not_accepted"
+  | "compile_not_admitted"
+  | "first_session_missing"
+  | "factual_execution_not_proven"
+  | "split_return_not_proven_if_claimed"
+  | "partial_completion_not_proven_if_claimed"
+  | "coach_artefact_view_missing"
+  | "non_binding_note_missing"
+  | "history_counts_not_factual"
+  | "support_boundary_missing"
+  | "claim_guard_missing"
+  | "forbidden_surface_exposed"
+  | "source_artefact_missing";
+
+export type PilotReadinessItemResult = {
+  readonly item_id: string;
+  readonly passed: boolean;
+  readonly source_artefact_ref_ids: readonly string[];
+};
+
+export type PilotNegativeBoundaryResult = {
+  readonly boundary_id: string;
+  readonly passed: boolean;
+  readonly source_artefact_ref_ids: readonly string[];
+};
+
+export type PilotSourceArtefactRef = {
+  readonly artefact_ref_id: string;
+};
+
+export type PilotReadinessEvaluatorInput = {
+  readonly readiness_item_results?: readonly unknown[];
+  readonly negative_boundary_results?: readonly unknown[];
+  readonly source_artefact_refs?: readonly unknown[];
+};
+
+export type PilotReadinessEvaluatorOutput = {
+  readonly final_status: PilotReadyStatus;
+  readonly blocked_reasons: readonly PilotBlockedReasonId[];
+  readonly missing_readiness_ids: readonly string[];
+  readonly failed_readiness_ids: readonly string[];
+  readonly missing_negative_boundary_ids: readonly string[];
+  readonly failed_negative_boundary_ids: readonly string[];
+  readonly missing_source_artefact_ids: readonly string[];
+};
+
+export const READINESS_BLOCKED_REASON_MAP = {
+  payment_confirmed: ["payment_missing"],
+  workspace_created: ["workspace_missing"],
+  coach_active: ["coach_account_inactive"],
+  athlete_active: ["athlete_account_inactive"],
+  link_accepted: ["coach_athlete_link_not_accepted"],
+  scope_locked: ["scope_not_locked"],
+  phase1_accepted: ["phase1_not_accepted"],
+  first_compile_passed: ["compile_not_admitted", "first_session_missing"],
+  first_executable_session_exists: ["first_session_missing"],
+  factual_execution_checked: ["factual_execution_not_proven"],
+  split_return_checked_if_claimed: ["split_return_not_proven_if_claimed"],
+  partial_completion_checked_if_claimed: ["partial_completion_not_proven_if_claimed"],
+  coach_surface_checked: ["coach_artefact_view_missing", "non_binding_note_missing"],
+  coach_artefact_view_checked: ["coach_artefact_view_missing"],
+  non_binding_note_checked: ["non_binding_note_missing"],
+  history_counts_checked: ["history_counts_not_factual"],
+  support_boundary_checked: ["support_boundary_missing"],
+  claim_guard_checked: ["claim_guard_missing"],
+  source_artefacts_present: ["source_artefact_missing"]
+} as const satisfies Readonly<Record<RequiredReadinessId, readonly PilotBlockedReasonId[]>>;
+
+export const NEGATIVE_BOUNDARY_BLOCKED_REASON: PilotBlockedReasonId = "forbidden_surface_exposed";
+export const SOURCE_ARTEFACT_BLOCKED_REASON: PilotBlockedReasonId = "source_artefact_missing";
+
+function uniqueInOrder<T extends string>(values: readonly T[]): T[] {
+  const seen = new Set<T>();
+  const output: T[] = [];
+
+  for (const value of values) {
+    if (seen.has(value)) continue;
+    seen.add(value);
+    output.push(value);
+  }
+
+  return output;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function arrayOrEmpty(value: unknown): readonly unknown[] {
+  return Array.isArray(value) ? value : [];
+}
+
+function makeIdSet(values: readonly string[]): Set<string> {
+  return new Set<string>(values);
+}
+
+function isRequiredReadinessId(value: string): value is RequiredReadinessId {
+  return (REQUIRED_READINESS_IDS as readonly string[]).includes(value);
+}
+
+function isRequiredNegativeBoundaryId(value: string): value is RequiredNegativeBoundaryId {
+  return (REQUIRED_NEGATIVE_BOUNDARY_IDS as readonly string[]).includes(value);
+}
+
+function readSourceArtefactIds(sourceArtefactRefs: unknown): Set<string> {
+  const ids: string[] = [];
+
+  for (const ref of arrayOrEmpty(sourceArtefactRefs)) {
+    if (isRecord(ref) && typeof ref.artefact_ref_id === "string") {
+      ids.push(ref.artefact_ref_id);
+    }
+  }
+
+  return makeIdSet(ids);
+}
+
+function cloneResultArray(value: unknown): Record<string, unknown>[] {
+  return arrayOrEmpty(value).filter(isRecord);
+}
+
+function sourceRefsForResult(result: Record<string, unknown>): string[] {
+  return arrayOrEmpty(result.source_artefact_ref_ids).filter((id): id is string => typeof id === "string");
+}
+
+function collectMissingSourceRefs(
+  result: Record<string, unknown>,
+  knownSourceArtefactIds: ReadonlySet<string>,
+  syntheticPrefix: string
+): string[] {
+  const refs = sourceRefsForResult(result);
+
+  if (refs.length === 0) {
+    return [`${syntheticPrefix}:source_artefact_ref_ids`];
+  }
+
+  return refs.filter((refId) => !knownSourceArtefactIds.has(refId));
+}
+
+function addReasons(target: PilotBlockedReasonId[], reasonIds: readonly PilotBlockedReasonId[]): void {
+  for (const reasonId of reasonIds) {
+    target.push(reasonId);
+  }
+}
+
+export function evaluatePilotReadiness(input: PilotReadinessEvaluatorInput): PilotReadinessEvaluatorOutput {
+  const sourceArtefactIds = readSourceArtefactIds(input?.source_artefact_refs);
+
+  const readinessResults = cloneResultArray(input?.readiness_item_results);
+  const boundaryResults = cloneResultArray(input?.negative_boundary_results);
+
+  const providedReadinessIds = makeIdSet(
+    readinessResults
+      .map((item) => item.item_id)
+      .filter((itemId): itemId is string => typeof itemId === "string")
+  );
+
+  const providedBoundaryIds = makeIdSet(
+    boundaryResults
+      .map((item) => item.boundary_id)
+      .filter((boundaryId): boundaryId is string => typeof boundaryId === "string")
+  );
+
+  const missingReadinessIds: string[] = [];
+  const failedReadinessIds: string[] = [];
+  const missingNegativeBoundaryIds: string[] = [];
+  const failedNegativeBoundaryIds: string[] = [];
+  const missingSourceArtefactIds: string[] = [];
+  const blockedReasons: PilotBlockedReasonId[] = [];
+
+  for (const readinessId of REQUIRED_READINESS_IDS) {
+    if (!providedReadinessIds.has(readinessId)) {
+      missingReadinessIds.push(readinessId);
+      addReasons(blockedReasons, READINESS_BLOCKED_REASON_MAP[readinessId]);
+    }
+  }
+
+  for (const boundaryId of REQUIRED_NEGATIVE_BOUNDARY_IDS) {
+    if (!providedBoundaryIds.has(boundaryId)) {
+      missingNegativeBoundaryIds.push(boundaryId);
+      blockedReasons.push(NEGATIVE_BOUNDARY_BLOCKED_REASON);
+    }
+  }
+
+  for (const result of readinessResults) {
+    const itemIdValue = result.item_id;
+
+    if (typeof itemIdValue !== "string" || !isRequiredReadinessId(itemIdValue)) {
+      failedReadinessIds.push(typeof itemIdValue === "string" ? itemIdValue : "unknown_readiness_item");
+      blockedReasons.push(NEGATIVE_BOUNDARY_BLOCKED_REASON);
+      continue;
+    }
+
+    if (result.passed !== true) {
+      failedReadinessIds.push(itemIdValue);
+      addReasons(blockedReasons, READINESS_BLOCKED_REASON_MAP[itemIdValue]);
+    }
+
+    const missingRefs = collectMissingSourceRefs(result, sourceArtefactIds, itemIdValue);
+    if (missingRefs.length > 0) {
+      missingSourceArtefactIds.push(...missingRefs);
+      blockedReasons.push(SOURCE_ARTEFACT_BLOCKED_REASON);
+    }
+  }
+
+  for (const result of boundaryResults) {
+    const boundaryIdValue = result.boundary_id;
+
+    if (typeof boundaryIdValue !== "string" || !isRequiredNegativeBoundaryId(boundaryIdValue)) {
+      failedNegativeBoundaryIds.push(typeof boundaryIdValue === "string" ? boundaryIdValue : "unknown_negative_boundary_item");
+      blockedReasons.push(NEGATIVE_BOUNDARY_BLOCKED_REASON);
+      continue;
+    }
+
+    if (result.passed !== true) {
+      failedNegativeBoundaryIds.push(boundaryIdValue);
+      blockedReasons.push(NEGATIVE_BOUNDARY_BLOCKED_REASON);
+    }
+
+    const missingRefs = collectMissingSourceRefs(result, sourceArtefactIds, boundaryIdValue);
+    if (missingRefs.length > 0) {
+      missingSourceArtefactIds.push(...missingRefs);
+      blockedReasons.push(SOURCE_ARTEFACT_BLOCKED_REASON);
+    }
+  }
+
+  const output: PilotReadinessEvaluatorOutput = {
+    final_status: PILOT_READY_STATUS.COACH_READY,
+    blocked_reasons: uniqueInOrder(blockedReasons),
+    missing_readiness_ids: uniqueInOrder(missingReadinessIds),
+    failed_readiness_ids: uniqueInOrder(failedReadinessIds),
+    missing_negative_boundary_ids: uniqueInOrder(missingNegativeBoundaryIds),
+    failed_negative_boundary_ids: uniqueInOrder(failedNegativeBoundaryIds),
+    missing_source_artefact_ids: uniqueInOrder(missingSourceArtefactIds)
+  };
+
+  if (
+    output.blocked_reasons.length > 0 ||
+    output.missing_readiness_ids.length > 0 ||
+    output.failed_readiness_ids.length > 0 ||
+    output.missing_negative_boundary_ids.length > 0 ||
+    output.failed_negative_boundary_ids.length > 0 ||
+    output.missing_source_artefact_ids.length > 0
+  ) {
+    return {
+      ...output,
+      final_status: PILOT_READY_STATUS.BLOCKED
+    };
+  }
+
+  return output;
+}

--- a/test/pilotReadinessEvaluator.test.mjs
+++ b/test/pilotReadinessEvaluator.test.mjs
@@ -1,0 +1,263 @@
+#!/usr/bin/env node
+
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { stripTypeScriptTypes } from "node:module";
+
+const repoRoot = process.cwd();
+const evaluatorPath = path.join(repoRoot, "src", "pilotReadinessEvaluator.ts");
+const registryPath = path.join(repoRoot, "docs", "pilot-blocked-reasons", "pilot_blocked_reason_registry.json");
+
+async function loadEvaluator() {
+  const source = fs.readFileSync(evaluatorPath, "utf8");
+  const stripped = stripTypeScriptTypes(source);
+  const encoded = encodeURIComponent(stripped);
+  return import(`data:text/javascript;charset=utf-8,${encoded}`);
+}
+
+function stable(value) {
+  return JSON.stringify(value);
+}
+
+function makeFixture(evaluator) {
+  const sourceArtefactRefs = [];
+  const sourceIds = new Set();
+
+  function ensureSource(id) {
+    const refId = `artefact_${id}`;
+    if (!sourceIds.has(refId)) {
+      sourceIds.add(refId);
+      sourceArtefactRefs.push({ artefact_ref_id: refId });
+    }
+    return refId;
+  }
+
+  const readinessItemResults = evaluator.REQUIRED_READINESS_IDS.map((id) => ({
+    item_id: id,
+    passed: true,
+    source_artefact_ref_ids: [ensureSource(id)]
+  }));
+
+  const negativeBoundaryResults = evaluator.REQUIRED_NEGATIVE_BOUNDARY_IDS.map((id) => ({
+    boundary_id: id,
+    passed: true,
+    source_artefact_ref_ids: [ensureSource(id)]
+  }));
+
+  return {
+    readiness_item_results: readinessItemResults,
+    negative_boundary_results: negativeBoundaryResults,
+    source_artefact_refs: sourceArtefactRefs
+  };
+}
+
+function assertBlocked(result, reasonId) {
+  assert.equal(result.final_status, "blocked");
+  assert.ok(result.blocked_reasons.includes(reasonId), `Expected blocked reason '${reasonId}' in ${JSON.stringify(result.blocked_reasons)}`);
+}
+
+function assertOutputShape(result) {
+  assert.deepEqual(Object.keys(result), [
+    "final_status",
+    "blocked_reasons",
+    "missing_readiness_ids",
+    "failed_readiness_ids",
+    "missing_negative_boundary_ids",
+    "failed_negative_boundary_ids",
+    "missing_source_artefact_ids"
+  ]);
+}
+
+function assertNoRuntimeDependencies() {
+  const source = fs.readFileSync(evaluatorPath, "utf8");
+
+  const forbiddenPatterns = [
+    /\bDate\s*\(/,
+    /\bDate\.now\b/,
+    /\bnew\s+Date\b/,
+    /\bMath\.random\b/,
+    /\bfetch\s*\(/,
+    /\bXMLHttpRequest\b/,
+    /\baxios\b/,
+    /\bhttp\b/,
+    /\bhttps\b/,
+    /\bfs\b/,
+    /\bprisma\b/,
+    /\bsequelize\b/,
+    /\bsql\b/,
+    /\bpostgres\b/,
+    /\bmysql\b/,
+    /\bsqlite\b/
+  ];
+
+  for (const pattern of forbiddenPatterns) {
+    assert.equal(pattern.test(source), false, `Forbidden runtime dependency matched: ${pattern}`);
+  }
+}
+
+function assertReasonsAreInS47Registry(evaluator) {
+  const registry = JSON.parse(fs.readFileSync(registryPath, "utf8"));
+  const known = new Set(registry.blocked_reasons.map((entry) => entry.blocked_reason_id));
+
+  for (const reasons of Object.values(evaluator.READINESS_BLOCKED_REASON_MAP)) {
+    for (const reasonId of reasons) {
+      assert.equal(known.has(reasonId), true, `Evaluator reason missing from S47 registry: ${reasonId}`);
+    }
+  }
+
+  assert.equal(known.has(evaluator.NEGATIVE_BOUNDARY_BLOCKED_REASON), true);
+  assert.equal(known.has(evaluator.SOURCE_ARTEFACT_BLOCKED_REASON), true);
+}
+
+async function run() {
+  const evaluator = await loadEvaluator();
+
+  assertNoRuntimeDependencies();
+  assertReasonsAreInS47Registry(evaluator);
+
+  {
+    const input = makeFixture(evaluator);
+    const before = stable(input);
+    const result = evaluator.evaluatePilotReadiness(input);
+
+    assertOutputShape(result);
+    assert.equal(result.final_status, "coach_ready");
+    assert.deepEqual(result.blocked_reasons, []);
+    assert.deepEqual(result.missing_readiness_ids, []);
+    assert.deepEqual(result.failed_readiness_ids, []);
+    assert.deepEqual(result.missing_negative_boundary_ids, []);
+    assert.deepEqual(result.failed_negative_boundary_ids, []);
+    assert.deepEqual(result.missing_source_artefact_ids, []);
+    assert.equal(stable(input), before, "Evaluator must not mutate input.");
+  }
+
+  {
+    const input = makeFixture(evaluator);
+    input.readiness_item_results = input.readiness_item_results.filter((item) => item.item_id !== "payment_confirmed");
+
+    const result = evaluator.evaluatePilotReadiness(input);
+
+    assertBlocked(result, "payment_missing");
+    assert.deepEqual(result.missing_readiness_ids, ["payment_confirmed"]);
+  }
+
+  {
+    const input = makeFixture(evaluator);
+    input.readiness_item_results.find((item) => item.item_id === "coach_active").passed = false;
+
+    const result = evaluator.evaluatePilotReadiness(input);
+
+    assertBlocked(result, "coach_account_inactive");
+    assert.deepEqual(result.failed_readiness_ids, ["coach_active"]);
+  }
+
+  {
+    const input = makeFixture(evaluator);
+    input.negative_boundary_results = input.negative_boundary_results.filter((item) => item.boundary_id !== "no_phase7_surface");
+
+    const result = evaluator.evaluatePilotReadiness(input);
+
+    assertBlocked(result, "forbidden_surface_exposed");
+    assert.deepEqual(result.missing_negative_boundary_ids, ["no_phase7_surface"]);
+  }
+
+  {
+    const input = makeFixture(evaluator);
+    input.negative_boundary_results.find((item) => item.boundary_id === "no_claim_surface").passed = false;
+
+    const result = evaluator.evaluatePilotReadiness(input);
+
+    assertBlocked(result, "forbidden_surface_exposed");
+    assert.deepEqual(result.failed_negative_boundary_ids, ["no_claim_surface"]);
+  }
+
+  {
+    const input = makeFixture(evaluator);
+    const first = input.readiness_item_results[0];
+    first.source_artefact_ref_ids = ["artefact_missing_ref"];
+
+    const result = evaluator.evaluatePilotReadiness(input);
+
+    assertBlocked(result, "source_artefact_missing");
+    assert.deepEqual(result.missing_source_artefact_ids, ["artefact_missing_ref"]);
+  }
+
+  {
+    const input = makeFixture(evaluator);
+    input.source_artefact_refs = [];
+
+    const result = evaluator.evaluatePilotReadiness(input);
+
+    assertBlocked(result, "source_artefact_missing");
+    assert.ok(result.missing_source_artefact_ids.length > 0);
+  }
+
+  {
+    const input = makeFixture(evaluator);
+    input.readiness_item_results.push({
+      item_id: "unknown_readiness_probe",
+      passed: true,
+      source_artefact_ref_ids: [input.source_artefact_refs[0].artefact_ref_id]
+    });
+
+    const result = evaluator.evaluatePilotReadiness(input);
+
+    assertBlocked(result, "forbidden_surface_exposed");
+    assert.deepEqual(result.failed_readiness_ids, ["unknown_readiness_probe"]);
+  }
+
+  {
+    const input = makeFixture(evaluator);
+    input.negative_boundary_results.push({
+      boundary_id: "unknown_boundary_probe",
+      passed: true,
+      source_artefact_ref_ids: [input.source_artefact_refs[0].artefact_ref_id]
+    });
+
+    const result = evaluator.evaluatePilotReadiness(input);
+
+    assertBlocked(result, "forbidden_surface_exposed");
+    assert.deepEqual(result.failed_negative_boundary_ids, ["unknown_boundary_probe"]);
+  }
+
+  {
+    const input = makeFixture(evaluator);
+    const first = input.readiness_item_results[0];
+    first.source_artefact_ref_ids = [];
+
+    const result = evaluator.evaluatePilotReadiness(input);
+
+    assertBlocked(result, "source_artefact_missing");
+    assert.deepEqual(result.missing_source_artefact_ids, [`${first.item_id}:source_artefact_ref_ids`]);
+  }
+
+  process.stdout.write(JSON.stringify({
+    ok: true,
+    test_suite_id: "pilot_readiness_evaluator_tests",
+    test_suite_version: "1.0.0",
+    checked_files: [
+      path.relative(repoRoot, evaluatorPath),
+      path.relative(repoRoot, registryPath)
+    ],
+    assertions: [
+      "all_pass_returns_coach_ready",
+      "missing_required_readiness_item_returns_blocked",
+      "failed_readiness_item_returns_blocked",
+      "missing_negative_boundary_item_returns_blocked",
+      "failed_negative_boundary_item_returns_blocked",
+      "missing_source_artefact_returns_blocked",
+      "unknown_readiness_item_returns_blocked",
+      "unknown_negative_boundary_item_returns_blocked",
+      "input_not_mutated",
+      "no_runtime_side_effect_dependencies",
+      "blocked_reasons_exist_in_s47_registry",
+      "typescript_strict_compile_passes"
+    ]
+  }, null, 2) + "\n");
+}
+
+run().catch((error) => {
+  process.stderr.write(`${error.stack ?? error.message ?? String(error)}\n`);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

Adds S48 Pilot Readiness Evaluator.

## Outputs

- docs/pilot-readiness-evaluator/PILOT_READINESS_EVALUATOR.md
- src/pilotReadinessEvaluator.ts
- test/pilotReadinessEvaluator.test.mjs

## Acceptance coverage

- All-pass checklist returns coach_ready.
- Missing required readiness item returns blocked.
- Failed readiness item returns blocked.
- Missing negative boundary item returns blocked.
- Failed negative boundary item returns blocked.
- Missing source artefact returns blocked.
- Unknown readiness item returns blocked.
- Unknown negative boundary item returns blocked.
- Evaluator does not mutate input.
- Evaluator contains no database, network, timestamp, or randomness dependency.
- Blocked reasons are checked against S47 registry.
- TypeScript strict compile passes through npm run build:fast.

## Boundary

- Pure function only.
- No database dependency.
- No network dependency.
- No timestamps generated inside evaluator.
- No engine behaviour.
- No marketing claims.
- No advisory output language.

## Verification

- node test/pilotReadinessEvaluator.test.mjs
- npm run build:fast
- npm run lint:fast
- node scripts/run_pilot_blocked_reason_registry_guard.mjs
- node scripts/run_pilot_signoff_record_tests.mjs