### PR TITLE
Add brand feel parameters prompt

### DIFF
--- a/docs/product/BRAND_FEEL_PARAMETERS_v0_PROMPT.md
+++ b/docs/product/BRAND_FEEL_PARAMETERS_v0_PROMPT.md
@@ -1,0 +1,295 @@
+# BRAND_FEEL_PARAMETERS_v0 — Prompt
+
+I need you to create a formal internal product/design reference document called BRAND_FEEL_PARAMETERS_v0 for the Kolosseum ecosystem.
+
+This document must define user-feel, brand experience, UX expectations, role-specific product atmosphere, visual direction, copy boundaries, commercial positioning, and CI-safe language guidance for:
+
+1. Kolosseum
+2. kolosseum.tools
+3. Old Tyme Strength
+
+This is not a marketing document. Do not write brand fluff. Write it as an internal product/design reference for founders, designers, developers, copywriters, compliance reviewers, and future AI agents working on Kolosseum.
+
+## Core brand promise
+
+“Everyone using Kolosseum feels part of a serious performance system.”
+
+## Strategic position
+
+Kolosseum must not feel like a generic fitness app, wellness tracker, motivational habit app, social platform, content community, influencer product, or gimmicky gym app.
+
+Kolosseum must feel:
+
+- serious
+- professional
+- controlled
+- deterministic
+- operator-grade
+- premium
+- legally careful
+- performance-system oriented
+- suitable for serious athletes, coaches, teams, schools, universities, clubs, federations, tactical units, and serious gyms
+
+Kolosseum must not feel:
+
+- playful
+- gamified
+- over-motivational
+- cluttered
+- influencer-led
+- entertainment-led
+- medically suggestive
+- safety-claim driven
+- casual
+- cheap
+- vague
+- overpromising
+
+## Ecosystem positioning
+
+### Kolosseum
+
+The main execution platform. It should feel like a professional performance command system: controlled, structured, factual, premium, and high-trust.
+
+### kolosseum.tools
+
+The public/free utility surface. It should feel fast, useful, credible, simple, and connected to the Kolosseum ecosystem without pretending to be the full platform. It is an acquisition and trust-building layer, not a diluted copy of the platform.
+
+### Old Tyme Strength
+
+The heritage/culture/media/apparel/community-facing strength brand. It should feel traditional, iron-based, disciplined, gritty, and serious, but not fake-vintage, sloppy, gimmicky, or legally risky. It may carry more atmosphere than Kolosseum, but it must not contaminate Kolosseum’s neutral execution identity.
+
+## Role-specific experience requirements
+
+### Athletes
+
+For athletes, Kolosseum should create the feeling of a professional training environment through:
+
+- clear session briefs
+- professional training history
+- declared status and check-in summaries
+- progress reports
+- competition timeline
+- coach oversight visibility
+- clean execution flow
+- no clutter
+- no gimmicks
+
+The athlete should feel:
+
+- “I am part of a serious system.”
+- “My training is organised professionally.”
+- “My coach and organisation can see the right things.”
+- “My history, check-ins, and progress are presented with discipline.”
+- “This is not a toy app.”
+
+### Coaches
+
+For coaches, Kolosseum should create the feeling of operational control through:
+
+- command centre
+- athlete queue
+- programming workflows
+- review workflows
+- alerts
+- accountability
+- AI-assisted admin
+- coach oversight tools
+- reduced admin load without blurred authority
+
+The coach should feel:
+
+- “I can run my coaching operation from here.”
+- “I can see what needs review.”
+- “I can control programming workflows without fighting the interface.”
+- “I have accountability and oversight without chaos.”
+- “Admin is reduced, but authority is not blurred.”
+
+### Teams and organisations
+
+For teams and organisations, Kolosseum should create the feeling of an operating system for performance delivery through:
+
+- role-based dashboards
+- operating standards
+- reporting
+- staff oversight
+- event preparation visibility
+- compliance trails
+- structured review surfaces
+- authority boundaries
+- traceability
+
+Teams and organisations should feel:
+
+- “This is an operating system for performance delivery.”
+- “We can manage standards, staff, sessions, reporting, and oversight.”
+- “We can see declared status, check-ins, event timelines, and preparation visibility at the correct level.”
+- “We have traceability and accountability.”
+- “This system is professional enough for clubs, schools, universities, federations, military units, and serious gyms.”
+
+## Important scope-control instruction
+
+Separate current v0 product feel from future platform direction.
+
+Current v0 should be treated as the first serious coach-operable execution alpha. Keep v0 focused on:
+
+- individual and coach-managed use
+- session briefs
+- session execution
+- factual training history
+- coach assignment
+- coach review surfaces
+- non-binding coach notes
+- basic check-in/declaration views
+- clean professional UI
+- low-clutter execution flow
+
+Treat the following as future/v1/post-v0 direction unless explicitly allowed:
+
+- full organisation dashboards
+- team-wide operating standards
+- compliance exports
+- evidence sealing
+- proof artefacts
+- event readiness dashboards
+- broad reporting systems
+- staff oversight layers
+- cross-entity governance
+- advanced AI administration
+- ranking, scoring, or predictive readiness
+
+## Critical legal/product boundaries
+
+Do not create unsafe, medical, professional-advice, optimisation, suitability, or guarantee claims.
+
+Do not describe Kolosseum as:
+
+- preventing injury
+- reducing risk
+- guaranteeing results
+- optimising people
+- diagnosing readiness
+- prescribing training
+- giving medical advice
+- making safety promises
+- deciding what is best for the user
+- proving athlete suitability
+- replacing coach judgement
+- replacing organisational responsibility
+- predicting performance
+- certifying readiness
+
+Avoid words and ideas such as:
+
+- safe
+- safer
+- safety
+- injury-proof
+- prevent injury
+- reduce risk
+- rehab
+- rehabilitation
+- treatment
+- therapy
+- cure
+- medical
+- clinical
+- readiness guarantee
+- best for you
+- right for you
+- tailored to you
+- optimised
+- optimal
+- proven results
+- guaranteed progress
+- risk-free
+- performance guarantee
+- injury prevention
+- corrective
+- therapeutic
+
+## Important wording distinction
+
+It is acceptable to describe “readiness/check-in summaries” and “event readiness” only when reframed as:
+
+- declared status
+- check-in records
+- operational preparation visibility
+- timeline status
+- completion status
+- factual summaries
+- review status
+- coach oversight visibility
+
+Do not frame readiness as:
+
+- medical readiness
+- safety readiness
+- injury-risk status
+- suitability judgement
+- predictive performance status
+- permission to train
+- proof of preparedness
+
+## Required output structure
+
+1. Executive summary
+2. Core brand promise
+3. Ecosystem positioning
+4. Shared ecosystem design principles
+5. Kolosseum platform feel parameters
+6. kolosseum.tools feel parameters
+7. Old Tyme Strength feel parameters
+8. Athlete experience parameters
+9. Coach experience parameters
+10. Team/organisation experience parameters
+11. v0 versus future platform boundary
+12. Visual direction
+13. UI density, spacing, layout, and motion rules
+14. Copy and tone rules
+15. Approved language examples
+16. Forbidden language examples
+17. Role-based UX examples
+18. Cross-contamination rules between Kolosseum, kolosseum.tools, and Old Tyme Strength
+19. Commercial implications
+20. Implementation checklist for UI, landing pages, dashboards, onboarding, and product copy
+21. CI-safe copy registry candidates
+22. Final operating rule
+
+## CI-safe copy registry candidates
+
+For section 21, provide short approved UI string candidates for:
+
+- athlete surfaces
+- coach surfaces
+- team/organisation surfaces
+- kolosseum.tools surfaces
+- Old Tyme Strength surfaces
+
+The copy candidates must be neutral, factual, professional, and low-risk. They must avoid medical, safety, optimisation, guarantee, suitability, diagnosis, readiness-certification, and predictive claims.
+
+## Commercial sharpness required
+
+Challenge weak assumptions.
+
+Identify where the requested experience is commercially strong.
+
+Identify where the wording risks scope creep, legal ambiguity, overclaiming, or product confusion.
+
+Explain what should stay in v0 and what should be treated as future platform direction.
+
+Do not over-expand teams, organisations, evidence, compliance, dashboards, event readiness, or AI-assisted admin into claims the current product cannot support.
+
+## Tone
+
+Direct, precise, practical, commercially sharp, and implementation-ready.
+
+Do not use generic branding language.
+
+Do not write vague design theory.
+
+Do not produce aspirational slogans unless they are clearly separated from operational UI copy.
+
+Do not make Kolosseum sound like a motivational coaching app.
+
+Write this like a document a serious founder, designer, developer, copywriter, and compliance reviewer could actually use.


### PR DESCRIPTION
Adds a reusable internal product/design prompt for defining Kolosseum, kolosseum.tools, and Old Tyme Strength brand-feel parameters.

This is a product/design instruction document only. It does not define engine behaviour, CI authority, legal authority, registry data, or release scope.

Scope:
- Kolosseum platform user feel
- kolosseum.tools utility positioning
- Old Tyme Strength ecosystem positioning
- v0 versus future-platform boundary
- CI-safe copy guidance
- Role-specific athlete, coach, and organisation UX expectations