### PR TITLE
Add brand feel parameters reference

### DIFF
--- a/docs/product/BRAND_FEEL_PARAMETERS_v0.md
+++ b/docs/product/BRAND_FEEL_PARAMETERS_v0.md
@@ -1,0 +1,1088 @@
+# BRAND_FEEL_PARAMETERS_v0
+
+Document class: product/design reference  
+Status: working reference  
+Authority: non-canonical, engine-inert  
+Scope: Kolosseum ecosystem user feel, visual direction, UX atmosphere, and copy discipline  
+Applies to: Kolosseum, kolosseum.tools, Old Tyme Strength  
+Does not define: engine behaviour, CI authority, legal authority, registry data, release scope, replay, evidence, or execution logic  
+
+## 1. Executive summary
+
+BRAND_FEEL_PARAMETERS_v0 defines how the Kolosseum ecosystem should feel to users, buyers, staff, coaches, athletes, teams, and future product builders.
+
+The core objective is simple: every surface must make the user feel they are inside a serious performance system.
+
+Kolosseum is not a generic fitness application. It must not borrow the emotional pattern of consumer gym apps, wellness trackers, motivational habit tools, social feeds, influencer-led products, or entertainment-first platforms.
+
+The desired experience is controlled, factual, premium, operator-grade, and disciplined. The product should feel built for people who take training operations seriously: athletes, coaches, clubs, schools, universities, federations, tactical units, and serious gyms.
+
+This document is a product/design reference only. It must remain subordinate to all canonical engine, legal, CI, registry, and release-scope documents.
+
+## 2. Core brand promise
+
+"Everyone using Kolosseum feels part of a serious performance system."
+
+This promise is a product-experience direction, not an engine claim.
+
+It means users should feel that their sessions, records, check-ins, coaching oversight, history, events, and workflows are presented with discipline and professional structure.
+
+It does not mean Kolosseum guarantees outcomes, certifies readiness, prevents injury, provides medical advice, replaces coach judgement, or proves user suitability.
+
+## 3. Ecosystem positioning
+
+### 3.1 Kolosseum
+
+Kolosseum is the main execution platform.
+
+It should feel like a professional performance command system: controlled, structured, factual, premium, and high-trust.
+
+Its product role is to organise declarations, sessions, coach-managed workflows, execution records, factual history, and review surfaces.
+
+It should feel serious enough for professional sport, education, tactical populations, and high-standard private coaching, while remaining clean enough for individual athletes.
+
+### 3.2 kolosseum.tools
+
+kolosseum.tools is the public utility surface.
+
+It should feel fast, useful, credible, simple, and connected to Kolosseum without pretending to be the full platform.
+
+Its product role is acquisition, trust-building, search capture, and practical utility. It should give users immediate value through focused tools.
+
+It must not become a diluted platform, a confusing product fork, or a free substitute for the paid system.
+
+### 3.3 Old Tyme Strength
+
+Old Tyme Strength is the heritage, culture, media, apparel, and community-facing strength brand.
+
+It should feel traditional, iron-based, disciplined, gritty, and serious.
+
+It may carry more atmosphere, story, and physical culture than Kolosseum, but it must not contaminate Kolosseum's neutral execution identity.
+
+It should not feel fake-vintage, novelty-led, theatrical, unserious, or legally risky.
+
+## 4. Shared ecosystem design principles
+
+The ecosystem should follow these principles across all surfaces.
+
+Clarity over decoration.
+
+Structure over energy.
+
+Discipline over hype.
+
+Factual status over motivational judgement.
+
+Role visibility over generic dashboards.
+
+Operational usefulness over feature volume.
+
+Premium restraint over visual noise.
+
+Human trust over gamified engagement.
+
+Every screen should answer one of these questions:
+
+What is happening?
+
+What has been declared?
+
+What needs review?
+
+What has been recorded?
+
+What is visible to this role?
+
+What is outside this role's authority?
+
+What is the next permitted action?
+
+If a screen cannot answer one of those questions, it is probably weak scope.
+
+## 5. Kolosseum platform feel parameters
+
+Kolosseum must feel like a high-trust operating surface.
+
+The user should experience:
+
+A controlled dark interface.
+
+Clear hierarchy.
+
+Strong spacing discipline.
+
+Minimal but meaningful accent colour.
+
+No novelty UI.
+
+No social feed energy.
+
+No casual fitness-app copy.
+
+No animated achievement loops.
+
+No vague encouragement.
+
+No over-dense dashboards.
+
+No fake enterprise complexity.
+
+Kolosseum should feel like a platform that could be used by a serious coach, a university strength department, a military PT staff member, a federation administrator, or an individual athlete who wants structured oversight.
+
+The interface should communicate:
+
+This is organised.
+
+This is accountable.
+
+This is factual.
+
+This is role-aware.
+
+This is not entertainment.
+
+## 6. kolosseum.tools feel parameters
+
+kolosseum.tools must feel like the sharp public edge of the ecosystem.
+
+It should be:
+
+Fast.
+
+Clear.
+
+Low-friction.
+
+Single-purpose.
+
+Search-friendly.
+
+Professionally styled.
+
+Useful without onboarding.
+
+Connected to the Kolosseum visual system.
+
+It should not feel like:
+
+A dumping ground for experiments.
+
+A cheap lead magnet.
+
+A separate consumer brand.
+
+A random calculator site.
+
+A soft wellness tool.
+
+A motivational training site.
+
+Each tool should have one obvious job. The page should explain what the tool does, accept the minimum useful input, return a clear result, and provide a clean next step.
+
+Good tool behaviours:
+
+Calculate.
+
+Convert.
+
+Map.
+
+Summarise.
+
+Prepare.
+
+Export.
+
+Open.
+
+Bad tool behaviours:
+
+Diagnose.
+
+Recommend what is best.
+
+Guarantee.
+
+Predict outcomes.
+
+Claim safety.
+
+Imply medical meaning.
+
+## 7. Old Tyme Strength feel parameters
+
+Old Tyme Strength should carry the cultural weight that Kolosseum deliberately avoids.
+
+It can be more atmospheric, more human, and more heritage-led.
+
+It should feel like:
+
+Iron.
+
+Discipline.
+
+Physical culture.
+
+Old methods.
+
+Modern structure.
+
+Strength history.
+
+Work done properly.
+
+It should not feel like:
+
+Fake old-world costume.
+
+Gimmick branding.
+
+Meme strength culture.
+
+Influencer merch.
+
+Magic method claims.
+
+Pseudo-medical training advice.
+
+Old Tyme Strength can support content, apparel, media, education, and community. It should not be used to soften or hype Kolosseum's engine-backed surfaces.
+
+## 8. Athlete experience parameters
+
+For athletes, Kolosseum should create the feeling of a professional training environment.
+
+Athlete-facing surfaces should prioritise:
+
+Clear session briefs.
+
+Clean execution flow.
+
+Professional training history.
+
+Declared status and check-in summaries.
+
+Progress reports framed as factual summaries.
+
+Competition timeline.
+
+Coach oversight visibility.
+
+Simple review status.
+
+Low clutter.
+
+No gimmicks.
+
+The athlete should feel:
+
+"I am part of a serious system."
+
+"My training is organised professionally."
+
+"My coach and organisation can see the right things."
+
+"My history, check-ins, and progress are presented with discipline."
+
+"This is not a toy app."
+
+Athlete surfaces should avoid:
+
+Over-celebration.
+
+Badges.
+
+Streak addiction.
+
+Social comparison.
+
+Readiness certification.
+
+Safety claims.
+
+Performance prediction.
+
+Overloaded charts.
+
+Lifestyle content intrusion.
+
+## 9. Coach experience parameters
+
+For coaches, Kolosseum should create the feeling of operational control.
+
+Coach-facing surfaces should prioritise:
+
+Command centre.
+
+Athlete queue.
+
+Programming workflows.
+
+Review workflows.
+
+Alerts.
+
+Accountability.
+
+Coach oversight tools.
+
+AI-assisted administration where permitted.
+
+Reduced admin load without blurred authority.
+
+The coach should feel:
+
+"I can run my coaching operation from here."
+
+"I can see what needs review."
+
+"I can control programming workflows without fighting the interface."
+
+"I have accountability and oversight without chaos."
+
+"Admin is reduced, but authority is not blurred."
+
+Coach surfaces should avoid:
+
+Unclear authority.
+
+Automated coaching claims.
+
+AI taking responsibility.
+
+Hidden athlete state changes.
+
+Unreviewable changes.
+
+Excessive notification noise.
+
+Generic dashboards that do not support decisions.
+
+## 10. Team and organisation experience parameters
+
+For teams and organisations, Kolosseum should create the feeling of an operating system for performance delivery.
+
+This is largely future-platform direction unless explicitly enabled by the active release scope.
+
+Future team and organisation surfaces may include:
+
+Role-based dashboards.
+
+Operating standards.
+
+Reporting.
+
+Staff oversight.
+
+Event preparation visibility.
+
+Compliance trails.
+
+Structured review surfaces.
+
+Authority boundaries.
+
+Traceability.
+
+Teams and organisations should feel:
+
+"This is an operating system for performance delivery."
+
+"We can manage standards, staff, sessions, reporting, and oversight."
+
+"We can see declared status, check-ins, event timelines, and preparation visibility at the correct level."
+
+"We have traceability and accountability."
+
+"This system is professional enough for clubs, schools, universities, federations, military units, and serious gyms."
+
+Team and organisation surfaces must avoid:
+
+Individual surveillance positioning.
+
+Medical readiness claims.
+
+Pass/fail athlete judgement unless explicitly lawful and factual.
+
+Ranking as default.
+
+Hidden governance power.
+
+Blended coach and organisation authority.
+
+Suggesting the platform replaces professional responsibility.
+
+## 11. v0 versus future platform boundary
+
+This document defines desired feel across the ecosystem, but not all described surfaces belong in v0.
+
+Current v0 should be treated as the first serious coach-operable execution alpha.
+
+v0 product feel should focus on:
+
+Individual and coach-managed use.
+
+Session briefs.
+
+Session execution.
+
+Factual training history.
+
+Coach assignment.
+
+Coach review surfaces.
+
+Non-binding coach notes.
+
+Basic check-in and declaration views.
+
+Clean professional UI.
+
+Low-clutter execution flow.
+
+v0 should not expand into full organisational product complexity.
+
+The following should be treated as v1 or post-v0 direction unless explicitly allowed by the active build target:
+
+Full organisation dashboards.
+
+Team-wide operating standards.
+
+Compliance exports.
+
+Evidence sealing.
+
+Proof artefacts.
+
+Event readiness dashboards.
+
+Broad reporting systems.
+
+Staff oversight layers.
+
+Cross-entity governance.
+
+Advanced AI administration.
+
+Ranking.
+
+Scoring.
+
+Predictive readiness.
+
+The commercial risk is simple: if v0 tries to feel like a full enterprise operating system before the core execution product is coherent, it will become overbuilt, slower to ship, and harder to defend.
+
+## 12. Visual direction
+
+Kolosseum visual direction:
+
+Dark graphite and black base.
+
+Restrained lime-green accent.
+
+Thin borders.
+
+Glassy dark cards.
+
+Controlled glow only around focal state.
+
+Crisp typography.
+
+Strong grid discipline.
+
+Clear role-based navigation.
+
+High spacing discipline.
+
+Operator-grade dashboards.
+
+No bright fitness-app colour palette.
+
+No playful illustration-first design.
+
+No green-washed gaming aesthetic.
+
+kolosseum.tools visual direction:
+
+Same dark ecosystem base.
+
+Simpler layout.
+
+More public-facing clarity.
+
+Larger input areas.
+
+Clear result panels.
+
+Lightweight explanation.
+
+Direct call to action.
+
+Old Tyme Strength visual direction:
+
+Iron black.
+
+Bone or aged-paper neutral.
+
+Muted brass or heritage accent.
+
+Optional restrained green only when linking back to Kolosseum.
+
+Serif, slab, or industrial typography may be used carefully.
+
+Photography and texture may be more prominent.
+
+Do not let heritage styling reduce usability.
+
+## 13. UI density, spacing, layout, and motion rules
+
+Kolosseum UI density:
+
+Medium to medium-high.
+
+Never cramped.
+
+Data surfaces should be compact but readable.
+
+Execution surfaces should be sparse and focused.
+
+Dashboard surfaces should prioritise review order and status.
+
+kolosseum.tools UI density:
+
+Medium-low.
+
+One job per page.
+
+Minimal navigation.
+
+Immediate result visibility.
+
+Old Tyme Strength UI density:
+
+Medium-low.
+
+More room for editorial content, products, media, and heritage atmosphere.
+
+Spacing rules:
+
+Use consistent card rhythm.
+
+Avoid uneven dead space.
+
+Avoid random card heights where comparison matters.
+
+Avoid stuffing multiple jobs into one card.
+
+Keep hierarchy clear between current action, status, history, and reference.
+
+Motion rules:
+
+Motion must indicate state, transition, confirmation, or attention.
+
+Motion must not entertain.
+
+No celebratory animations in Kolosseum execution flows.
+
+No gamified reward loops.
+
+Old Tyme Strength may use more atmospheric motion, but it must remain restrained.
+
+## 14. Copy and tone rules
+
+Kolosseum copy must be:
+
+Neutral.
+
+Factual.
+
+Precise.
+
+Low-emotion.
+
+Role-aware.
+
+Operational.
+
+Short where possible.
+
+Clear where necessary.
+
+Kolosseum copy must not be:
+
+Motivational.
+
+Medical.
+
+Safety-led.
+
+Predictive.
+
+Guarantee-based.
+
+Overconfident.
+
+Coaching-advice disguised as product copy.
+
+kolosseum.tools copy may be more public and helpful, but it must remain factual.
+
+Old Tyme Strength copy may be more cultural and human, but it must not make performance, safety, medical, or guarantee claims.
+
+Preferred verbs:
+
+View.
+
+Record.
+
+Open.
+
+Review.
+
+Assign.
+
+Declare.
+
+Load.
+
+Save.
+
+Export.
+
+Continue.
+
+Complete.
+
+Required.
+
+Not available.
+
+Recorded.
+
+Submitted.
+
+Avoid verbs and phrases that imply judgement or correction unless legally and product-safe.
+
+## 15. Approved language examples
+
+Approved Kolosseum-style language:
+
+Session loaded.
+
+Declaration accepted.
+
+Work recorded.
+
+Check-in recorded.
+
+Review required.
+
+Coach note added.
+
+Assignment updated.
+
+History available.
+
+Status declared.
+
+Timeline updated.
+
+Session complete.
+
+No options are available with the current declarations.
+
+This option is not available with the current setup.
+
+Continue where I left off.
+
+Skip and move on.
+
+Approved kolosseum.tools-style language:
+
+Open calculator.
+
+Enter event date.
+
+Calculate blocks.
+
+Result generated.
+
+Copy result.
+
+Export summary.
+
+Start again.
+
+Use this in Kolosseum.
+
+Approved Old Tyme Strength-style language:
+
+Built for lifters.
+
+Strength culture, recorded properly.
+
+Old methods. Modern discipline.
+
+Iron, records, and work done properly.
+
+Training notes for serious lifters.
+
+## 16. Forbidden language examples
+
+Do not use these as product claims:
+
+Safer training.
+
+Prevent injury.
+
+Reduce injury risk.
+
+Optimised for you.
+
+Best for your body.
+
+Tailored to your needs.
+
+Guaranteed progress.
+
+Proven results.
+
+Train pain-free.
+
+Diagnose readiness.
+
+Ready to train.
+
+Medically informed.
+
+Clinical grade.
+
+Risk-free.
+
+Corrective training.
+
+Therapeutic movement.
+
+Protect your joints.
+
+The safest option.
+
+The right program for you.
+
+This does not mean the words can never appear in internal guardrails or forbidden examples. It means they must not be used as user-facing claims.
+
+## 17. Role-based UX examples
+
+Athlete dashboard v0:
+
+Today's session.
+
+Session brief.
+
+Declared status.
+
+Check-in record.
+
+Coach visibility.
+
+Recent history.
+
+Upcoming event timeline if declared.
+
+Continue session.
+
+Coach dashboard v0:
+
+Athlete queue.
+
+Assigned sessions.
+
+Review required.
+
+Notes.
+
+Recent execution records.
+
+Check-in records.
+
+Assignment status.
+
+Future team dashboard:
+
+Entity overview.
+
+Staff roles.
+
+Team timeline.
+
+Session participation.
+
+Review status.
+
+Operational preparation visibility.
+
+Reporting queue.
+
+Compliance trail where lawful.
+
+## 18. Cross-contamination rules
+
+Kolosseum must not inherit the emotional looseness of Old Tyme Strength.
+
+Old Tyme Strength must not pretend to be the engine.
+
+kolosseum.tools must not look like an unrelated calculator site.
+
+Kolosseum must remain the trust anchor.
+
+kolosseum.tools must remain the utility and acquisition layer.
+
+Old Tyme Strength must remain the culture and heritage layer.
+
+Do not place engine claims inside Old Tyme Strength storytelling.
+
+Do not place heritage slogans inside Kolosseum execution flows.
+
+Do not use kolosseum.tools to imply capabilities that only exist in the paid platform.
+
+Do not use organisation-facing language on v0 athlete surfaces unless it is clearly permitted and role-aware.
+
+## 19. Commercial implications
+
+The strongest commercial idea is that Kolosseum makes every user feel they are operating inside a professional system.
+
+That is valuable because most fitness products feel either casual, consumer-led, motivational, social, or vague.
+
+The defensible position is not "better workouts."
+
+The defensible position is:
+
+Serious execution environment.
+
+Professional training records.
+
+Coach and athlete workflow clarity.
+
+Role-based operational control.
+
+Factual review surfaces.
+
+Trustworthy product boundaries.
+
+The commercial risks are:
+
+Overclaiming readiness.
+
+Turning check-ins into medical or suitability signals.
+
+Expanding v0 into an enterprise platform too early.
+
+Letting Old Tyme Strength make claims Kolosseum avoids.
+
+Letting AI-assisted admin imply autonomous coaching authority.
+
+Creating dashboards before the underlying workflow is valuable.
+
+The better move is to ship a tight v0 that feels serious at small scale, then scale that feeling into teams and organisations later.
+
+## 20. Implementation checklist
+
+For UI:
+
+Use dark premium base.
+
+Use restrained accent colour.
+
+Keep hierarchy obvious.
+
+Make every page role-aware.
+
+Avoid clutter.
+
+Avoid gimmicks.
+
+Avoid gamification.
+
+For landing pages:
+
+State what the surface does.
+
+Avoid outcome claims.
+
+Avoid safety or medical framing.
+
+Separate current product from future vision.
+
+Keep Kolosseum serious and direct.
+
+For dashboards:
+
+Prioritise status, queue, review, and history.
+
+Avoid vanity metrics.
+
+Avoid default ranking.
+
+Avoid predictive readiness.
+
+Avoid unclear authority.
+
+For onboarding:
+
+Capture declarations cleanly.
+
+Explain what is being recorded.
+
+Do not imply advice.
+
+Do not imply suitability.
+
+Make consent and role boundaries clear.
+
+For copy:
+
+Use approved factual language.
+
+Avoid banned claim patterns.
+
+Keep emotional copy out of execution flows.
+
+Keep Old Tyme Strength atmosphere away from engine surfaces.
+
+For future AI agents:
+
+Treat this as product/design reference only.
+
+Do not use this document to define engine behaviour.
+
+Do not infer permissions from brand ambition.
+
+Do not expand v0 scope from future-facing sections.
+
+## 21. CI-safe copy registry candidates
+
+### Athlete surfaces
+
+Session loaded.
+
+Session brief available.
+
+Check-in recorded.
+
+Declared status updated.
+
+Training history available.
+
+Coach note available.
+
+Coach review pending.
+
+Timeline updated.
+
+Work recorded.
+
+Session complete.
+
+Continue session.
+
+Open history.
+
+### Coach surfaces
+
+Athlete queue.
+
+Review required.
+
+Assignment updated.
+
+Coach note added.
+
+Session record available.
+
+Check-in record available.
+
+Programming workflow open.
+
+Review complete.
+
+Athlete list updated.
+
+Open athlete record.
+
+No review items.
+
+### Team and organisation surfaces
+
+Entity overview.
+
+Staff view.
+
+Timeline status.
+
+Reporting queue.
+
+Review status.
+
+Participation summary.
+
+Operating standard recorded.
+
+Compliance trail available.
+
+Role access updated.
+
+Entity record available.
+
+### kolosseum.tools surfaces
+
+Open tool.
+
+Enter details.
+
+Calculate result.
+
+Result generated.
+
+Copy result.
+
+Export summary.
+
+Reset tool.
+
+Use in Kolosseum.
+
+Tool unavailable.
+
+Input required.
+
+### Old Tyme Strength surfaces
+
+Open journal.
+
+View article.
+
+Training notes.
+
+Equipment notes.
+
+Strength archive.
+
+Old Tyme Strength shop.
+
+Iron records.
+
+Community update.
+
+Heritage series.
+
+Read more.
+
+## 22. Final operating rule
+
+Kolosseum must make users feel they are part of a serious performance system without pretending to coach, diagnose, protect, optimise, certify, or guarantee anything.
+
+The product should feel professional before it feels large.
+
+The interface should feel controlled before it feels impressive.
+
+The copy should be factual before it is persuasive.
+
+The ecosystem should be ambitious, but v0 must remain tight.


### PR DESCRIPTION
Adds BRAND_FEEL_PARAMETERS_v0 as a non-canonical product/design reference for the Kolosseum ecosystem.

This document defines:
- Kolosseum platform user feel
- kolosseum.tools utility positioning
- Old Tyme Strength ecosystem positioning
- athlete, coach, and future team/organisation UX atmosphere
- v0 versus future-platform boundary
- visual, layout, motion, and copy principles
- CI-safe copy registry candidates

This is product/design guidance only. It does not define engine behaviour, CI authority, legal authority, registry data, or release scope.