### PR TITLE
Add current project docs status

### DIFF
--- a/docs/product/CURRENT_PROJECT_DOCS_STATUS.md
+++ b/docs/product/CURRENT_PROJECT_DOCS_STATUS.md
@@ -1,0 +1,235 @@
+# CURRENT_PROJECT_DOCS_STATUS
+
+Document class: product/docs currency reference
+Status: working reference
+Authority: non-canonical, engine-inert
+Scope: current project document currency against completed repository work
+Applies to: Kolosseum v0 docs, product docs, pilot docs, brand-feel docs
+Does not define: engine behaviour, CI authority, legal authority, registry data, release scope, replay, evidence, or runtime execution logic
+
+## 1. Purpose
+
+This document records whether the current project documentation set is aligned with completed repository work.
+
+It exists to prevent stale attached docs, older project notes, and future prompts from being mistaken for the current product state.
+
+This is a docs-status reference only. Canonical engine, legal, CI, registry, and release-scope documents remain authoritative above this file.
+
+## 2. Current repo baseline
+
+Current main includes work through:
+
+- PR #629 — Add brand feel parameters reference
+- PR #628 — Add brand feel parameters prompt
+- PR #627 — S48 pilot readiness evaluator
+- PR #626 — S47 pilot blocked reason registry
+- PR #625 — S46 pilot sign-off record
+- PR #624 — S45 coach-ready pilot acceptance pack
+- PR #623 — S44 public sales claim registry guard
+- PR #622 — S43 support boundary templates
+- PR #621 — S42 pilot state machine enforcement
+- PR #620 — S41 operator pilot dashboard
+- PR #619 — S40 history counts only
+- PR #618 — S39 coach assignment within limits
+- PR #617 — Kolosseum v0 agent operating system
+- PR #616 — S38 non-binding coach notes
+- PR #615 — S37 session artefact viewer
+- PR #614 — S36 extra work / deviation event capture
+- PR #613 — public UI diagnostics fence
+
+## 3. Attached docs currency verdict
+
+The attached v0 redefinition documents are directionally current for the v0/v1 boundary.
+
+They correctly preserve the main boundary:
+
+- v0 is the Deterministic Execution Alpha
+- v0 is individual and coach-managed only
+- v0 is Phase 1 through Phase 6 only
+- v0 excludes Phase 7 truth projection
+- v0 excludes Phase 8 evidence sealing
+- v0 excludes evidence envelopes and export
+- v0 excludes org, team, unit, and gym execution
+- v0 excludes dashboards, analytics, rankings, messaging, readiness scoring, outcome evaluation, and medical/safety claims
+
+However, the attached docs are not complete against current repo progress.
+
+They do not fully reflect the completed S36-S48 implementation/documentation slices or the new brand-feel prompt/reference work.
+
+## 4. Current completed work not fully reflected in older attached docs
+
+The following completed surfaces must be treated as current repo reality:
+
+### S36 — extra work / deviation event capture
+
+Factual append-only runtime deviation events exist as a v0 slice.
+
+These events are engine-inert and must not mutate Phase 5, future compilation, constraints, progression, or registries.
+
+### S37 — session artefact viewer
+
+A read-only factual session artefact viewer exists as a v0 slice.
+
+Access is limited to the athlete and linked coach where permitted.
+
+It does not create edit, override, Phase 1 mutation, or authority paths.
+
+### S38 — non-binding coach notes
+
+Coach notes exist as observational platform metadata.
+
+They are non-binding, non-authoritative, and engine-inert.
+
+They must not influence execution, artefacts, replay, or evidence.
+
+### S39 — coach assignment within limits
+
+Coach assignment exists as platform visibility/access control only.
+
+It must not mutate engine output, Phase 1, substitutions, progression, registries, compilation, or history truth.
+
+### S40 — history counts only
+
+Factual history count surfaces exist for athlete and linked coach views.
+
+These are counts only and must not become analytics, scoring, ranking, readiness, or outcome evaluation.
+
+### S41 — operator pilot dashboard
+
+A factual/operator-only pilot dashboard exists.
+
+It must fail closed on unknown source state and only allow Coach Ready when source-record preconditions are true.
+
+### S42 — pilot state machine enforcement
+
+A pilot state machine exists for legal pilot transitions.
+
+It uses terminal fail-closed behaviour, unknown-state refusal, Coach Ready preconditions, and Active activation requirements.
+
+### S43 — support boundary templates
+
+Support boundary templates exist as factual, boundary-safe app documentation and JSON templates.
+
+They avoid unsupported v0 capability claims.
+
+### S44 — public/sales claim registry guard
+
+A public/sales claim registry guard exists.
+
+Public claims must be registered, proof-linked, fail closed if unknown, and boundary-safe.
+
+### S45 — coach-ready pilot acceptance pack
+
+A coach-ready pilot acceptance pack exists.
+
+It proves coach-ready acceptance only for the permitted pilot slice.
+
+It does not expand v0 into organisation, team, gym, proof, or evidence capability.
+
+### S46 — pilot sign-off record
+
+A pilot sign-off record exists as a platform operator record.
+
+It stores coach_ready or blocked outcomes, uses source artefact references, and remains append-only.
+
+It is not an engine input, engine output, pricing claim, public claim surface, or coach authority surface.
+
+### S47 — pilot blocked reason registry
+
+A closed-world pilot blocked reason registry exists.
+
+Operators must use controlled blocked reason IDs only.
+
+No free-text blocked reasons are permitted for this surface.
+
+### S48 — pilot readiness evaluator
+
+A pure pilot readiness evaluator exists.
+
+It returns coach_ready or blocked from checklist and boundary inputs.
+
+It does not store records, sign records, create timestamps, read a database, use a network, infer missing data, produce advice, or alter engine behaviour.
+
+### Brand-feel prompt and reference
+
+The repo now includes:
+
+- docs/product/BRAND_FEEL_PARAMETERS_v0_PROMPT.md
+- docs/product/BRAND_FEEL_PARAMETERS_v0.md
+
+These are product/design references only.
+
+They do not define engine behaviour, CI authority, legal authority, registry data, or release scope.
+
+## 5. Docs that should be treated as current
+
+The following repo docs should be treated as current product/design references:
+
+- docs/product/BRAND_FEEL_PARAMETERS_v0.md
+- docs/product/BRAND_FEEL_PARAMETERS_v0_PROMPT.md
+
+The following project attached docs should still be treated as valid for v0 boundary direction:
+
+- Kolosseum_v0_redefinition.docx
+- Kolosseum_v0_redefinition_summary.txt
+
+But they should be read with this update:
+
+They predate S36-S48 and do not fully describe current pilot, support-boundary, public-claim, and brand-feel documentation surfaces.
+
+## 6. Docs that need future review
+
+Review older docs for these stale-risk terms:
+
+- build-complete v0
+- proof-complete v0
+- Phase 7 as v0
+- Phase 8 as v0
+- evidence envelope as v0
+- export as v0
+- organisation runtime as v0
+- team runtime as v0
+- gym runtime as v0
+- dashboards as v0
+- analytics as v0
+- readiness scoring
+- outcome evaluation
+- medical or safety claims
+- optimisation claims
+- best for you
+- tailored to you
+- guaranteed progress
+
+Any current-facing doc using these terms as active v0 capability should be updated or demoted.
+
+## 7. Current interpretation rule
+
+If an older attached doc conflicts with completed repo work or active repo docs, use this order for product planning:
+
+1. Canonical engine, legal, CI, registry, and release-scope documents
+2. Current repo docs on main
+3. This current docs status reference
+4. Older attached project docs
+5. Chat notes and prompts
+
+Older attached docs remain useful context, but they are not enough to describe the current repo state.
+
+## 8. Recommended next docs work
+
+Create a dedicated docs index for active v0 surfaces.
+
+Recommended future file:
+
+docs/product/V0_SURFACE_INDEX.md
+
+It should list the current v0 and pilot-adjacent surfaces, their authority level, engine impact, and whether each is active v0, operator-only, product/design reference, or future-platform direction.
+
+Do not update canonical engine law to include product/design references unless a separate authority decision is made.
+
+## 9. Final ruling
+
+The attached docs are not fully up to date.
+
+They are still useful for the core v0/v1 boundary, but they do not cover completed work through S48 or the brand-feel reference.
+
+The repo should treat this file as the current product/docs currency note until a fuller v0 surface index is created.


### PR DESCRIPTION
Adds CURRENT_PROJECT_DOCS_STATUS as a non-canonical product/docs currency reference.

This documents that the older attached project docs remain useful for the v0/v1 boundary, but are not complete against current repo work through S36-S48 and the brand-feel reference work.

This is docs guidance only. It does not define engine behaviour, CI authority, legal authority, registry data, or release scope.