### PR TITLE
Add senior developer docs baseline

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,14 +1,94 @@
-## Mandatory Checks (No Exceptions)
+# Contributing
 
-This repository enforces strict invariants.
+This repository uses a narrow, guard-heavy workflow. Follow it exactly.
 
-Before any commit or push:
-- `ci/guards/repo_contract.mjs` MUST pass
-- `npm run lint` MUST pass
+## First rule
 
-Local hooks are provided for convenience.
-CI is authoritative.
+Do not push directly to `main`.
 
-Commits pushed with `--no-verify` that fail CI will not be merged.
+Work on a branch, open a pull request, let checks run, then merge through the PR path.
 
-If CI fails, the fix is required — not optional.
+## Normal local check
+
+Before pushing a normal change, run:
+
+    npm run verify
+
+This is the supported local verification signal for humans.
+
+## Branch workflow
+
+From the repo root:
+
+    git fetch origin
+    git switch main
+    git reset --hard origin/main
+    git switch -c ticket/short-real-slice-name
+
+Use a real branch name. Do not paste placeholder text into commands.
+
+## File hygiene
+
+Repo text files must be:
+
+- UTF-8 without BOM
+- LF-only line endings
+- free of mojibake
+- free of accidental generated junk
+
+When writing files from PowerShell, prefer .NET UTF8Encoding(false) rather than `Set-Content -Encoding UTF8`.
+
+## Commit and push
+
+After changes:
+
+    git status --short
+    npm run verify
+    git add <files>
+    git commit -m "Clear commit message"
+    git push -u origin <branch>
+
+If hooks fail, fix the issue. Do not use `--no-verify`.
+
+## Pull requests
+
+A PR should state:
+
+- what changed
+- what files were added or updated
+- why the change is engine-inert or what contract it touches
+- what validation was run
+
+PR checks are the source of truth for mergeability.
+
+## Lockfile rule
+
+If `package-lock.json` changes, update and stage `LOCKFILE_CHANGE_NOTE.md` as required by repo guards.
+
+## Contract changes
+
+If a change alters behaviour covered by `ENGINE_CONTRACT.md`, treat it as a contract change.
+
+Do not update golden outputs just to make a failing test pass. Understand the behaviour change first.
+
+## Documentation changes
+
+Docs should state their authority level.
+
+Use clear headers such as:
+
+- Document class
+- Status
+- Authority
+- Scope
+- Does not define
+
+Do not let product/design docs define engine behaviour, CI authority, legal authority, registry data, or release scope.
+
+## If CI fails
+
+The fix is required. Do not bypass guards.
+
+Use diagnostic commands only to locate the failing layer, then return to:
+
+    npm run verify

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -1,31 +1,51 @@
 # Commands
 
-This repo intentionally has **one public human command** and **one CI entrypoint**.
+This repo intentionally keeps the normal human workflow narrow.
 
-## Public (humans)
+Use the public commands first. Use lower-level commands only when diagnosing a specific failing layer.
 
-Use this when you want one authoritative signal that your change is acceptable:
+## Public command
 
-`ash
-npm run verify
-`",
-  ",
-  
+Use this when you want one authoritative local signal that your change is acceptable:
 
-CI uses the CI entrypoint. Humans generally should not run this locally unless debugging CI behavior:
+    npm run verify
 
-`ash
-npm run ci
-`",
-  ",
-  
+This is the default command for normal development.
 
-These exist for hooks, guard composition, or advanced debugging. They are **not** part of the public contract:
+## CI entrypoint
 
-- green / green:fast / green:dev: internal verification runners used by hooks/CI wiring
-- lint:fast, test:unit, build:fast: composed steps used by the verification runner
-- guard:* : guard maintenance and deterministic index generation
-- diff:* : contract/golden inspection utilities
+CI uses this entrypoint:
 
-If you're unsure which to use: run 
-pm run verify.
+    npm run ci
+
+Humans generally should not run this unless checking CI parity or debugging CI behaviour.
+
+## Common diagnostic commands
+
+Use these only when you need to isolate a failure:
+
+    npm run lint:fast
+    npm run test:unit
+    npm run test:one -- test/some_test_file.test.mjs
+    npm run build:fast
+    npm run dev:status
+    npm run diff:summary
+    gh run list --limit 10
+
+## Script groups
+
+`green`, `green:fast`, and `green:dev` are verification runners used by hooks and CI wiring.
+
+`lint:fast`, `test:unit`, and `build:fast` are composed steps used by the verification runner.
+
+`guard:*` scripts are guard maintenance and deterministic index utilities.
+
+`diff:*` scripts are contract and golden inspection utilities.
+
+## Rule
+
+If you are unsure which command to use, run:
+
+    npm run verify
+
+Do not bypass failing guards. Fix the failing layer.

--- a/docs/DEVELOPER_ONBOARDING.md
+++ b/docs/DEVELOPER_ONBOARDING.md
@@ -1,0 +1,198 @@
+# DEVELOPER_ONBOARDING
+
+Document class: developer onboarding reference
+Status: working reference
+Authority: non-canonical, engine-inert
+Scope: how to work in this repository without breaking guardrails
+Does not define: engine behaviour, CI authority, legal authority, registry data, release scope, replay, evidence, or runtime execution logic
+
+## 1. Purpose
+
+This document gives a new developer a practical path into the Kolosseum repo.
+
+It is written for someone who is still learning to code, program, and build, but wants to work in a senior-developer style.
+
+The aim is to reduce accidental drift, broken branches, bad file encoding, weak commits, and unclear PRs.
+
+## 2. Mental model
+
+This repo is not a casual app repo.
+
+It is an engine-first training platform with strict guardrails.
+
+Most mistakes are not syntax mistakes. Most mistakes are boundary mistakes.
+
+Common boundary mistakes include:
+
+- changing engine behaviour from a product or UI surface
+- adding copy that implies safety, advice, optimisation, or guarantees
+- treating pilot/operator artefacts as engine truth
+- adding future platform scope into v0
+- bypassing guards instead of fixing them
+- updating snapshots without understanding the contract change
+- writing files with BOM or CRLF from PowerShell
+
+## 3. Start every task from clean main
+
+Use this pattern:
+
+    Set-Location C:\Users\rober\kolosseum
+    git fetch origin
+    git switch main
+    git reset --hard origin/main
+    git status --short
+
+The working tree should be clean before you start.
+
+Then create a branch:
+
+    git switch -c ticket/short-real-slice-name
+
+## 4. Use the right verification command
+
+For normal development:
+
+    npm run verify
+
+For deeper diagnosis only:
+
+    npm run lint:fast
+    npm run test:unit
+    npm run build:fast
+    npm run dev:status
+    npm run diff:summary
+
+Do not start with low-level commands unless you are isolating a specific failure.
+
+## 5. File writing rules
+
+Write text files as UTF-8 without BOM and LF-only.
+
+PowerShell-safe write pattern:
+
+    $Utf8NoBom = New-Object System.Text.UTF8Encoding($false)
+    $Text = $Text -replace "`r`n", "`n"
+    $Text = $Text -replace "`r", "`n"
+    [System.IO.File]::WriteAllText($Path, $Text, $Utf8NoBom)
+
+Avoid:
+
+    Set-Content -Encoding UTF8
+
+That can write UTF-8 with BOM on Windows PowerShell.
+
+## 6. Authority levels
+
+Before editing or creating a document, decide what kind of document it is.
+
+Common classes:
+
+- canonical engine law
+- CI or guard contract
+- registry data
+- implementation contract
+- product/design reference
+- developer onboarding reference
+- docs status reference
+- prompt/reference material
+
+If a document is product/design guidance, say clearly that it does not define engine behaviour, CI authority, legal authority, registry data, or release scope.
+
+## 7. v0 boundary
+
+Current v0 is the Deterministic Execution Alpha.
+
+Keep v0 focused on:
+
+- individual and coach-managed use
+- Phase 1 through Phase 6
+- factual runtime execution
+- split and return
+- partial completion
+- coach assignment
+- session artefact viewing
+- non-binding coach notes
+- history counts
+- pilot/operator readiness surfaces where explicitly implemented
+
+Do not silently add:
+
+- Phase 7
+- Phase 8
+- evidence sealing
+- exportable proof artefacts
+- organisation runtime
+- team runtime
+- gym runtime
+- analytics
+- rankings
+- predictive readiness
+- medical or safety claims
+- optimisation claims
+
+## 8. Product/design docs
+
+Product/design docs are useful, but they must remain engine-inert.
+
+Examples:
+
+- docs/product/BRAND_FEEL_PARAMETERS_v0.md
+- docs/product/CURRENT_PROJECT_DOCS_STATUS.md
+- docs/product/V0_SURFACE_INDEX.md
+
+These documents guide product feel, scope interpretation, and developer orientation.
+
+They must not create engine capability.
+
+## 9. How to read the repo
+
+Start here:
+
+1. README.md
+2. docs/COMMANDS.md
+3. CONTRIBUTING.md
+4. ENGINE_CONTRACT.md
+5. docs/product/CURRENT_PROJECT_DOCS_STATUS.md
+6. docs/product/V0_SURFACE_INDEX.md
+7. package.json
+8. .github/workflows/
+9. ci/guards/
+10. ci/scripts/
+11. src/
+12. test/
+
+## 10. Pull request standard
+
+A good PR says:
+
+- what was added
+- what was changed
+- what was not changed
+- whether there is engine impact
+- what validation was run
+- why the change is inside v0 or outside v0
+
+A weak PR says only "updates docs" or "fixes stuff."
+
+## 11. Do not bypass guardrails
+
+If a guard fails, stop and read the failure.
+
+Examples:
+
+- no_bom_guard means rewrite as UTF-8 without BOM
+- no_crlf_guard means normalise to LF
+- no_mojibake_guard means fix corrupted text encoding
+- clean_tree_guard means uncommitted files exist
+- sales claim lint means copy or public claim language is unsafe
+- v0 boundary guard means the change probably claims unsupported scope
+
+The guard is usually telling you exactly what to fix.
+
+## 12. Final rule
+
+Move slowly enough that the repo remains clean.
+
+Small, well-scoped PRs are better than large mixed changes.
+
+When unsure, document the boundary instead of adding behaviour.

--- a/docs/product/V0_SURFACE_INDEX.md
+++ b/docs/product/V0_SURFACE_INDEX.md
@@ -1,0 +1,125 @@
+# V0_SURFACE_INDEX
+
+Document class: product surface index
+Status: working reference
+Authority: non-canonical, engine-inert
+Scope: current v0, pilot-adjacent, and product/design surfaces on main
+Does not define: engine behaviour, CI authority, legal authority, registry data, release scope, replay, evidence, or runtime execution logic
+
+## 1. Purpose
+
+This document lists the current user-facing, operator-facing, pilot-facing, and product/design surfaces that exist in the repo.
+
+It exists so developers and future AI agents do not confuse completed implementation slices, pilot controls, product references, and future-platform direction.
+
+## 2. Classification key
+
+Active v0 surface:
+A surface that belongs to the current v0 product or implementation slice.
+
+Pilot/operator surface:
+A surface used to evaluate, prepare, or control a paid coach pilot. It is platform/operator logic, not engine law.
+
+Product/design reference:
+A product, design, or documentation guide. It must remain engine-inert.
+
+Diagnostic-only surface:
+A fenced or disabled surface that exists for diagnostics only.
+
+Future-platform direction:
+A described future surface that is not active v0 unless a later release definition explicitly activates it.
+
+## 3. Current active v0 and adjacent surfaces
+
+| Slice | Surface | Classification | Engine impact | Current meaning |
+|---|---|---|---|---|
+| S36 | Extra work / deviation event capture | Active v0 surface | None beyond factual runtime event capture | Records factual append-only runtime deviations without mutating future engine behaviour. |
+| S37 | Session artefact viewer | Active v0 surface | None | Provides read-only factual session artefact viewing for permitted users. |
+| S38 | Non-binding coach notes | Active v0 surface | None | Allows linked coaches to add observational notes that remain non-authoritative and engine-inert. |
+| S39 | Coach assignment within limits | Active v0 surface | None | Controls platform visibility and access only. |
+| S40 | History counts only | Active v0 surface | None | Provides factual history counts without analytics, scoring, ranking, readiness, or outcome evaluation. |
+| S41 | Operator pilot dashboard | Pilot/operator surface | None | Provides factual operator view for pilot readiness source state. |
+| S42 | Pilot state machine enforcement | Pilot/operator surface | None | Enforces closed pilot lifecycle transitions. |
+| S43 | Support boundary templates | Pilot/operator and support surface | None | Provides factual boundary-safe support templates and operator picker contract. |
+| S44 | Public/sales claim registry guard | Product/commercial guard surface | None | Enforces registered, proof-linked, boundary-safe public claims. |
+| S45 | Coach-ready pilot acceptance pack | Pilot/operator surface | None | Defines pilot readiness checklist and negative boundary requirements. |
+| S46 | Pilot sign-off record | Pilot/operator surface | None | Stores append-only coach_ready or blocked operator sign-off records. |
+| S47 | Pilot blocked reason registry | Pilot/operator surface | None | Defines the closed-world blocked reason IDs for pilot sign-off. |
+| S48 | Pilot readiness evaluator | Pilot/operator surface | None | Pure evaluator that derives coach_ready or blocked from checklist and boundary data. |
+
+## 4. Product and design references
+
+| Document | Classification | Engine impact | Meaning |
+|---|---|---|---|
+| docs/product/BRAND_FEEL_PARAMETERS_v0.md | Product/design reference | None | Defines ecosystem user-feel, visual direction, copy posture, and brand separation. |
+| docs/product/BRAND_FEEL_PARAMETERS_v0_PROMPT.md | Prompt/reference material | None | Reusable prompt used to generate the brand-feel reference. |
+| docs/product/CURRENT_PROJECT_DOCS_STATUS.md | Docs status reference | None | Records that older attached docs are directionally useful but incomplete against current repo work. |
+| docs/product/V0_SURFACE_INDEX.md | Product surface index | None | Maps current v0 and pilot-adjacent surfaces. |
+
+## 5. Diagnostic-only surfaces
+
+| Surface | Classification | Engine impact | Meaning |
+|---|---|---|---|
+| Public UI diagnostics fence | Diagnostic-only surface | None | Legacy public UI files are fenced and disabled unless explicitly enabled for diagnostics. |
+
+## 6. Future-platform direction
+
+These are not active v0 unless a later release definition explicitly activates them:
+
+- full organisation dashboards
+- team-wide operating standards
+- compliance exports
+- evidence sealing
+- proof artefacts
+- event readiness dashboards
+- broad reporting systems
+- staff oversight layers
+- cross-entity governance
+- advanced AI administration
+- ranking
+- scoring
+- predictive readiness
+- organisation runtime
+- team runtime
+- gym runtime
+
+## 7. Terms that require care
+
+The following terms are allowed only with careful factual framing:
+
+- readiness
+- coach_ready
+- sign-off
+- compliance
+- evidence
+- proof
+- dashboard
+- reporting
+- oversight
+- status
+- progress
+- performance
+
+Do not use these terms to imply safety, medical judgement, suitability, optimisation, performance prediction, readiness certification, or guaranteed outcomes.
+
+## 8. Senior developer review rule
+
+When adding a new surface, update this document if the new surface changes the repo's product map.
+
+Every new surface should answer:
+
+- Is it active v0, pilot/operator, product/design, diagnostic-only, or future direction?
+- Does it affect engine behaviour?
+- Does it create public claims?
+- Does it introduce role authority?
+- Does it require a guard?
+- Does it need copy registry treatment?
+- Does it risk v0 scope expansion?
+
+## 9. Final rule
+
+This index is a map, not authority.
+
+If this index conflicts with canonical engine, legal, CI, registry, or release-scope documents, the canonical documents win.
+
+If this index conflicts with completed repo work, update this index.


### PR DESCRIPTION
Adds a senior-developer documentation baseline for the repo.

Changes:
- fixes docs/COMMANDS.md corruption and clarifies the command contract
- expands CONTRIBUTING.md into a practical workflow guide
- adds docs/DEVELOPER_ONBOARDING.md for new developers and AI-assisted work
- adds docs/product/V0_SURFACE_INDEX.md to map current v0, pilot/operator, product/design, diagnostic-only, and future-platform surfaces

This is documentation guidance only. It does not define engine behaviour, CI authority, legal authority, registry data, or release scope.