### PR TITLE
Add architecture and senior review docs

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,267 @@
+# ARCHITECTURE
+
+Document class: developer architecture reference
+Status: working reference
+Authority: non-canonical, engine-inert
+Scope: repo structure, responsibility boundaries, and safe navigation
+Does not define: engine behaviour, CI authority, legal authority, registry data, release scope, replay, evidence, or runtime execution logic
+
+## 1. Purpose
+
+This document explains how the Kolosseum repository is organised and how a developer should think about the main directories, contracts, guards, scripts, and product documentation.
+
+It is a navigation and architecture reference. It does not override canonical engine, legal, CI, registry, or release-scope documents.
+
+## 2. Architectural posture
+
+Kolosseum is an engine-first training platform repository.
+
+The dominant design principle is controlled determinism.
+
+The repo is designed to make accidental drift difficult by using:
+
+- narrow human workflow
+- strict CI and local guards
+- contract documents
+- generated or pinned artefact checks
+- registry validation
+- golden output checks
+- public/sales claim checks
+- v0 boundary checks
+- file hygiene guards
+
+The repo should be treated as a controlled system, not a casual app workspace.
+
+## 3. High-level responsibility map
+
+| Area | Responsibility | Developer rule |
+|---|---|---|
+| `src/` | Application and platform implementation code | Keep behaviour explicit, tested, and inside v0 scope. |
+| `engine/` | Engine package and exported deterministic engine surface | Treat changes as high-risk unless explicitly scoped. |
+| `test/` | Unit and contract tests | Add or update tests when behaviour changes. |
+| `ci/guards/` | Guard scripts enforcing repo and product invariants | Do not bypass. Update only with clear reason. |
+| `ci/scripts/` | CI orchestration, golden, schema, and validation scripts | Treat as infrastructure. Keep deterministic. |
+| `ci/contracts/` | CI composition contracts and manifests | Keep aligned when adding guarded test surfaces. |
+| `registries/` | Registry data and registry-related artefacts | Closed-world data. Do not infer or silently extend. |
+| `docs/` | Developer, product, contract, and surface documentation | State authority level clearly. |
+| `docs/product/` | Product/design/status references | Engine-inert. Must not create engine capability. |
+| `scripts/` | Developer, guard, runner, and operational scripts | Prefer deterministic PowerShell-safe workflows. |
+| `.github/workflows/` | GitHub Actions workflows | PR checks are merge source of truth. |
+| `dist/` | Build output where applicable | Do not hand-edit. |
+| `examples/` | Example payloads and runner fixtures | Keep aligned with current contracts. |
+| `out/` | Local/export output where applicable | Do not treat as source of truth. |
+
+## 4. Engine and platform separation
+
+The engine is responsible for deterministic training computation and contract-bound output.
+
+The platform may add storage, visibility, operator workflow, pilot workflow, product references, support templates, and access surfaces where explicitly implemented.
+
+Platform surfaces must not silently mutate engine truth.
+
+Product/design references must not create engine behaviour.
+
+Pilot/operator artefacts must not become public claims or engine authority.
+
+## 5. Current v0 shape
+
+Current v0 should be understood as the Deterministic Execution Alpha.
+
+v0 includes the implemented current and adjacent surfaces listed in:
+
+    docs/product/V0_SURFACE_INDEX.md
+
+v0 remains bounded by the current release-scope and engine-contract documents.
+
+Do not infer v0 capability from future-platform language, product ambition, or brand-feel docs.
+
+## 6. Engine contract
+
+The primary engine contract is:
+
+    ENGINE_CONTRACT.md
+
+Treat the following as contract-sensitive:
+
+- Phase 1 through Phase 6 behaviour
+- runner output shape
+- CLI output shape
+- deterministic ordering
+- notes strings in golden outputs
+- golden hashes
+- registry-derived output
+- Phase 6 stub and non-empty session shape
+- exported CLI files
+
+If a change alters behaviour covered by `ENGINE_CONTRACT.md`, treat it as a contract change.
+
+Do not update golden outputs just to make a failing test pass.
+
+## 7. CI and guard architecture
+
+The repo uses layered guardrails.
+
+Important guard categories include:
+
+- clean working tree checks
+- file encoding and line-ending checks
+- repo contract checks
+- workflow policy checks
+- engine contract checks
+- golden manifest and golden output checks
+- schema checks
+- registry checks
+- commercial artefact checks
+- public/sales claim checks
+- v0 boundary consistency checks
+- Phase 1 acceptance record checks
+
+A failed guard is usually not noise. Read the failure and fix the cause.
+
+## 8. Developer workflow architecture
+
+Normal local workflow:
+
+    npm run verify
+
+Diagnostic workflow:
+
+    npm run lint:fast
+    npm run test:unit
+    npm run build:fast
+    npm run dev:status
+    npm run diff:summary
+
+PR workflow:
+
+    git fetch origin
+    git switch main
+    git reset --hard origin/main
+    git switch -c ticket/short-real-slice-name
+    npm run verify
+    git add <files>
+    git commit -m "Clear commit message"
+    git push -u origin <branch>
+    gh pr create
+
+Do not push directly to `main`.
+
+## 9. Documentation architecture
+
+Docs should state their authority level.
+
+Recommended header fields:
+
+- Document class
+- Status
+- Authority
+- Scope
+- Does not define
+
+Examples of engine-inert documents:
+
+- `docs/DEVELOPER_ONBOARDING.md`
+- `docs/product/CURRENT_PROJECT_DOCS_STATUS.md`
+- `docs/product/BRAND_FEEL_PARAMETERS_v0.md`
+- `docs/product/V0_SURFACE_INDEX.md`
+
+These documents help developers work correctly. They do not create runtime capability.
+
+## 10. Product and claim boundaries
+
+Kolosseum product copy and public claims are controlled.
+
+Avoid unsupported claims around:
+
+- safety
+- medical meaning
+- injury prevention
+- optimisation
+- suitability
+- guaranteed progress
+- readiness certification
+- performance prediction
+- organisation/team/gym runtime if not active
+
+When in doubt, use factual language:
+
+- recorded
+- available
+- declared
+- submitted
+- review required
+- blocked
+- not available
+- coach_ready
+- history available
+
+## 11. Registry posture
+
+Registries are closed-world data sources.
+
+Do not add values casually.
+
+Do not infer unknown values.
+
+Do not silently coerce values.
+
+Do not use registry edits to smuggle new product capability.
+
+Registry changes should have clear purpose, guard coverage, and tests where applicable.
+
+## 12. Testing posture
+
+A senior developer should ask:
+
+- What behaviour changed?
+- What contract owns that behaviour?
+- What test proves it?
+- What guard prevents future drift?
+- What docs need updating?
+- What public or product copy risk exists?
+- Does this affect v0 boundary?
+
+Small deterministic tests are better than broad vague tests.
+
+## 13. Common risk patterns
+
+High-risk changes include:
+
+- engine output changes
+- registry changes
+- golden output updates
+- public claim changes
+- workflow changes
+- API contract changes
+- role or permission changes
+- Phase 1 acceptance changes
+- anything using readiness, proof, evidence, safety, compliance, or optimisation language
+
+Treat those as senior-review required.
+
+## 14. Repo reading order
+
+Recommended order for a new developer:
+
+1. `README.md`
+2. `docs/COMMANDS.md`
+3. `CONTRIBUTING.md`
+4. `docs/DEVELOPER_ONBOARDING.md`
+5. `docs/ARCHITECTURE.md`
+6. `ENGINE_CONTRACT.md`
+7. `docs/product/CURRENT_PROJECT_DOCS_STATUS.md`
+8. `docs/product/V0_SURFACE_INDEX.md`
+9. `package.json`
+10. `.github/workflows/`
+11. `ci/guards/`
+12. `ci/scripts/`
+13. `src/`
+14. `test/`
+
+## 15. Final rule
+
+The architecture is intentionally narrow.
+
+Do not add capability because the product direction sounds plausible.
+
+Add capability only when it is scoped, tested, guarded, documented, and inside the active boundary.

--- a/docs/DEVELOPER_ONBOARDING.md
+++ b/docs/DEVELOPER_ONBOARDING.md
@@ -151,15 +151,17 @@ Start here:
 1. README.md
 2. docs/COMMANDS.md
 3. CONTRIBUTING.md
-4. ENGINE_CONTRACT.md
-5. docs/product/CURRENT_PROJECT_DOCS_STATUS.md
-6. docs/product/V0_SURFACE_INDEX.md
-7. package.json
-8. .github/workflows/
-9. ci/guards/
-10. ci/scripts/
-11. src/
-12. test/
+4. docs/ARCHITECTURE.md
+5. docs/SENIOR_DEVELOPER_REVIEW_CHECKLIST.md
+6. ENGINE_CONTRACT.md
+7. docs/product/CURRENT_PROJECT_DOCS_STATUS.md
+8. docs/product/V0_SURFACE_INDEX.md
+9. package.json
+10. .github/workflows/
+11. ci/guards/
+12. ci/scripts/
+13. src/
+14. test/
 
 ## 10. Pull request standard
 

--- a/docs/SENIOR_DEVELOPER_REVIEW_CHECKLIST.md
+++ b/docs/SENIOR_DEVELOPER_REVIEW_CHECKLIST.md
@@ -1,0 +1,244 @@
+# SENIOR_DEVELOPER_REVIEW_CHECKLIST
+
+Document class: developer review checklist
+Status: working reference
+Authority: non-canonical, engine-inert
+Scope: pull request and slice review discipline
+Does not define: engine behaviour, CI authority, legal authority, registry data, release scope, replay, evidence, or runtime execution logic
+
+## 1. Purpose
+
+This checklist defines how a senior developer should review a Kolosseum change.
+
+It is designed to help newer developers avoid common mistakes while keeping the repo strict, deterministic, and commercially defensible.
+
+## 2. First-pass review
+
+Before reading code deeply, answer:
+
+- What is the purpose of this change?
+- What files changed?
+- Is this engine, platform, docs, CI, registry, product, or UI?
+- Is the scope narrow enough?
+- Is this inside current v0?
+- Is anything being smuggled in under a vague name?
+- Does the PR description explain what was not changed?
+
+If the change is unclear, the PR is not ready.
+
+## 3. Boundary review
+
+Check whether the change claims or implies any of the following without authority:
+
+- Phase 7
+- Phase 8
+- evidence sealing
+- exportable proof
+- organisation runtime
+- team runtime
+- gym runtime
+- analytics
+- rankings
+- predictive readiness
+- medical meaning
+- safety meaning
+- optimisation
+- guaranteed outcomes
+- suitability judgement
+- autonomous coaching authority
+
+If yes, block or revise.
+
+## 4. Engine impact review
+
+Ask:
+
+- Does this change engine output?
+- Does it change Phase 1 to Phase 6 behaviour?
+- Does it change CLI output?
+- Does it change notes strings?
+- Does it change session shape?
+- Does it change deterministic ordering?
+- Does it change registry-derived output?
+- Does it change golden hashes?
+
+If yes, treat it as a contract-sensitive change.
+
+Contract-sensitive changes require clear explanation and intentional fixture/golden handling.
+
+## 5. Platform impact review
+
+Ask:
+
+- Does this add a role or permission?
+- Does this change visibility?
+- Does this change storage?
+- Does this create an operator workflow?
+- Does this create public copy?
+- Does this expose a new surface?
+- Does this create a new source of truth?
+
+Platform changes must not mutate engine truth unless explicitly designed and authorised.
+
+## 6. Docs review
+
+Ask:
+
+- Does the document state its authority level?
+- Does it say what it does not define?
+- Does it accidentally create engine capability?
+- Does it accidentally expand v0?
+- Does it use future-platform language as current product language?
+- Does it conflict with `CURRENT_PROJECT_DOCS_STATUS.md`?
+- Does it require `V0_SURFACE_INDEX.md` to be updated?
+
+Good docs reduce ambiguity.
+
+Bad docs create scope creep.
+
+## 7. Copy and claim review
+
+Block unsupported language such as:
+
+- safe
+- safer
+- safety
+- injury prevention
+- reduce risk
+- rehab
+- treatment
+- medical
+- clinical
+- optimised
+- optimal
+- best for you
+- tailored to you
+- guaranteed progress
+- proven results
+- ready to train
+- performance prediction
+- readiness certification
+
+Prefer factual wording:
+
+- recorded
+- submitted
+- declared
+- available
+- unavailable
+- review required
+- blocked
+- accepted
+- source missing
+- status updated
+
+## 8. Test review
+
+Ask:
+
+- Is there a test for the changed behaviour?
+- Is there a negative test?
+- Is unknown input rejected?
+- Is fail-closed behaviour proven?
+- Is determinism proven where relevant?
+- Are permissions tested?
+- Are boundary claims tested?
+- Are affected tests wired into CI?
+- Did the PR rely only on local green without PR green?
+
+If no tests are needed, the PR should explain why.
+
+## 9. Guard review
+
+Ask:
+
+- Does this need a guard?
+- Does this modify guard behaviour?
+- Does this weaken a guard?
+- Does this bypass a guard?
+- Does this add a new class of drift that should be machine-checked?
+
+Do not accept manual discipline where a guard is clearly needed.
+
+## 10. Registry review
+
+For registry changes, ask:
+
+- Is the registry closed-world?
+- Are unknown values rejected?
+- Is ordering deterministic?
+- Is schema validation present?
+- Are aliases explicit?
+- Are no defaults or inference being introduced?
+- Are values being added for real product need or speculative future scope?
+
+Registry changes are high-risk.
+
+## 11. File hygiene review
+
+Check:
+
+- UTF-8 without BOM
+- LF-only line endings
+- no mojibake
+- no accidental binary files
+- no generated junk
+- no untracked files
+- no unintended lockfile change
+- clean working tree after commit
+
+The guards should enforce most of this, but reviewers should still notice obvious drift.
+
+## 12. PR quality review
+
+A good PR includes:
+
+- clear title
+- clear summary
+- changed files
+- engine impact statement
+- validation run
+- explicit non-goals
+- v0 boundary statement if relevant
+
+A weak PR includes:
+
+- vague title
+- "updates docs"
+- "fixes stuff"
+- no validation
+- no boundary statement
+- no explanation of risk
+
+## 13. Merge review
+
+Before merge:
+
+- PR checks must be green or intentionally admin-merged for a known branch-protection-only block
+- no failing checks
+- no unresolved scope concern
+- no unexplained contract change
+- no known file hygiene issue
+- branch should be deleted after merge
+- local main should be synced after merge
+
+## 14. Reviewer decision
+
+Use these outcomes:
+
+Approve:
+The change is scoped, tested, guarded where needed, documented, and inside boundary.
+
+Request changes:
+The change is useful but has fixable issues.
+
+Block:
+The change expands scope, weakens guardrails, makes unsupported claims, changes engine behaviour accidentally, or creates unclear authority.
+
+## 15. Final rule
+
+A senior developer protects the system from unclear work.
+
+Do not reward speed if it creates drift.
+
+Small, explicit, tested, guarded changes win.


### PR DESCRIPTION
Adds the next senior-developer documentation layer.

Changes:
- adds docs/ARCHITECTURE.md to explain repo structure, boundaries, contracts, guards, and reading order
- adds docs/SENIOR_DEVELOPER_REVIEW_CHECKLIST.md for PR and slice review discipline
- updates docs/DEVELOPER_ONBOARDING.md to point new developers to the architecture and review checklist docs

This is documentation guidance only. It does not define engine behaviour, CI authority, legal authority, registry data, or release scope.