### PR TITLE
Add repo docs index

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Kolosseum
 
+Docs index: see `docs/REPO_DOCS_INDEX.md`
+
 Commands: see `docs/COMMANDS.md`
 
 ## What this repo is
@@ -16,9 +18,7 @@ Work on a ticket branch, open a PR, wait for checks, then merge through the PR p
 
 Use one manual verification signal:
 
-```powershell
-npm run verify
-```
+    npm run verify
 
 That is the default supported local check.
 
@@ -26,12 +26,10 @@ That is the default supported local check.
 
 ### Start from main
 
-```powershell
-Set-Location C:\Users\rober\kolosseum
-git switch main
-git pull --ff-only
-git switch -c ticket/real-slice-name
-```
+    Set-Location C:\Users\rober\kolosseum
+    git switch main
+    git pull --ff-only
+    git switch -c ticket/real-slice-name
 
 Use a real branch name. Do not paste placeholder text into Git commands.
 
@@ -39,27 +37,22 @@ Use a real branch name. Do not paste placeholder text into Git commands.
 
 After changes, use the standard repo commands:
 
-```powershell
-npm run verify
-npm run dev:status
-gh run list --limit 10
-```
+    npm run verify
+    npm run dev:status
+    gh run list --limit 10
 
 ### Push through PR flow
 
-```powershell
-git push -u origin ticket/real-slice-name
-gh pr create
-gh pr checks --watch
-```
+    git push -u origin ticket/real-slice-name
+    gh pr create
+    gh pr checks --watch
 
 ### Merge through the supported helper
 
-```powershell
-Merge-KolosseumPr 123
-```
+    Merge-KolosseumPr 123
 
 That helper is expected to:
+
 - wait for PR checks
 - merge via PR
 - return local repo to `main`
@@ -81,15 +74,13 @@ That helper is expected to:
 
 Useful for isolating failures, not as the normal workflow:
 
-```powershell
-npm run lint:fast
-npm run test:unit
-npm run test:one -- test/some_test_file.test.mjs
-npm run build:fast
-npm run dev:status
-npm run diff:summary
-gh run list --limit 10
-```
+    npm run lint:fast
+    npm run test:unit
+    npm run test:one -- test/some_test_file.test.mjs
+    npm run build:fast
+    npm run dev:status
+    npm run diff:summary
+    gh run list --limit 10
 
 Use them to identify the failing layer. Use `npm run verify` when you want the single authoritative local signal.
 
@@ -113,7 +104,15 @@ That coverage is enforced through CI cluster manifests. When adding a new handle
 
 ## Where to look next
 
+Start with:
+
+- `docs/REPO_DOCS_INDEX.md` for the full documentation map
+- `docs/DEVELOPER_ONBOARDING.md` for safe learning/building workflow
+- `docs/ARCHITECTURE.md` for repo structure and boundaries
+- `docs/SENIOR_DEVELOPER_REVIEW_CHECKLIST.md` for PR review discipline
+- `docs/product/V0_SURFACE_INDEX.md` for the current v0 and pilot surface map
+- `docs/product/CURRENT_PROJECT_DOCS_STATUS.md` for current docs currency
 - `docs/COMMANDS.md` for command reference
 - `package.json` for supported scripts
 - `ci/contracts/` for CI composition manifests
-- `.github/workflows/` for GitHub Actions behavior
+- `.github/workflows/` for GitHub Actions behaviour

--- a/docs/DEVELOPER_ONBOARDING.md
+++ b/docs/DEVELOPER_ONBOARDING.md
@@ -149,19 +149,21 @@ They must not create engine capability.
 Start here:
 
 1. README.md
-2. docs/COMMANDS.md
-3. CONTRIBUTING.md
-4. docs/ARCHITECTURE.md
-5. docs/SENIOR_DEVELOPER_REVIEW_CHECKLIST.md
-6. ENGINE_CONTRACT.md
-7. docs/product/CURRENT_PROJECT_DOCS_STATUS.md
-8. docs/product/V0_SURFACE_INDEX.md
-9. package.json
-10. .github/workflows/
-11. ci/guards/
-12. ci/scripts/
-13. src/
-14. test/
+2. docs/REPO_DOCS_INDEX.md
+3. docs/COMMANDS.md
+4. CONTRIBUTING.md
+5. docs/DEVELOPER_ONBOARDING.md
+6. docs/ARCHITECTURE.md
+7. docs/SENIOR_DEVELOPER_REVIEW_CHECKLIST.md
+8. ENGINE_CONTRACT.md
+9. docs/product/CURRENT_PROJECT_DOCS_STATUS.md
+10. docs/product/V0_SURFACE_INDEX.md
+11. package.json
+12. .github/workflows/
+13. ci/guards/
+14. ci/scripts/
+15. src/
+16. test/
 
 ## 10. Pull request standard
 

--- a/docs/REPO_DOCS_INDEX.md
+++ b/docs/REPO_DOCS_INDEX.md
@@ -1,0 +1,112 @@
+# REPO_DOCS_INDEX
+
+Document class: repository documentation index
+Status: working reference
+Authority: non-canonical, engine-inert
+Scope: documentation navigation for developers, reviewers, and future AI agents
+Does not define: engine behaviour, CI authority, legal authority, registry data, release scope, replay, evidence, or runtime execution logic
+
+## 1. Purpose
+
+This document is the front-door map for Kolosseum repository documentation.
+
+Use it to decide which document to read before editing code, docs, product surfaces, CI, registries, or public copy.
+
+## 2. Start here
+
+Read these first:
+
+1. `README.md`
+2. `docs/COMMANDS.md`
+3. `CONTRIBUTING.md`
+4. `docs/DEVELOPER_ONBOARDING.md`
+5. `docs/ARCHITECTURE.md`
+6. `docs/SENIOR_DEVELOPER_REVIEW_CHECKLIST.md`
+
+## 3. Core contract and boundary docs
+
+Read these before touching engine behaviour, contracts, boundaries, or product scope:
+
+| Document | Purpose |
+|---|---|
+| `ENGINE_CONTRACT.md` | Defines Phase 1 through Phase 6 engine contract and deterministic guarantees. |
+| `docs/product/CURRENT_PROJECT_DOCS_STATUS.md` | States which project docs are current and which older docs are incomplete. |
+| `docs/product/V0_SURFACE_INDEX.md` | Maps active v0, pilot/operator, product/design, diagnostic-only, and future-platform surfaces. |
+
+## 4. Product and design reference docs
+
+Read these before changing UI, product copy, brand language, or public-facing surfaces:
+
+| Document | Purpose |
+|---|---|
+| `docs/product/BRAND_FEEL_PARAMETERS_v0.md` | Defines ecosystem user feel, visual direction, copy posture, and brand separation. |
+| `docs/product/BRAND_FEEL_PARAMETERS_v0_PROMPT.md` | Stores the reusable prompt used to generate the brand-feel reference. |
+
+## 5. Workflow and command docs
+
+Read these before running commands, pushing branches, or debugging CI:
+
+| Document | Purpose |
+|---|---|
+| `docs/COMMANDS.md` | Defines the normal command contract and diagnostic commands. |
+| `CONTRIBUTING.md` | Defines branch, PR, file hygiene, and contribution workflow rules. |
+| `package.json` | Lists supported npm scripts. |
+
+## 6. Review docs
+
+Read these before reviewing a PR or asking an AI agent to modify the repo:
+
+| Document | Purpose |
+|---|---|
+| `docs/SENIOR_DEVELOPER_REVIEW_CHECKLIST.md` | Gives PR and slice review discipline. |
+| `docs/DEVELOPER_ONBOARDING.md` | Explains safe learning/building workflow for this repo. |
+| `docs/ARCHITECTURE.md` | Explains repo structure, responsibility boundaries, and safe navigation. |
+
+## 7. CI and implementation areas
+
+Inspect these when debugging guard, workflow, test, or build behaviour:
+
+| Area | Purpose |
+|---|---|
+| `.github/workflows/` | GitHub Actions workflow definitions. |
+| `ci/guards/` | Guard scripts enforcing repo and product invariants. |
+| `ci/scripts/` | CI orchestration, golden, schema, and validation scripts. |
+| `ci/contracts/` | CI composition contracts and manifests. |
+| `test/` | Unit, contract, and behaviour tests. |
+| `src/` | Application and platform implementation. |
+| `engine/` | Engine package and deterministic engine surface. |
+| `registries/` | Closed-world registry data. |
+| `scripts/` | Developer, runner, guard, and operational scripts. |
+
+## 8. When adding new docs
+
+New docs should state:
+
+- Document class
+- Status
+- Authority
+- Scope
+- Does not define
+
+Product/design docs must remain engine-inert.
+
+Developer docs must not create runtime capability.
+
+Prompt docs must not override canonical engine, CI, legal, registry, or release-scope documents.
+
+## 9. When to update this index
+
+Update this document when:
+
+- a new senior developer doc is added
+- a new product/design reference is added
+- a major v0 surface map changes
+- a new canonical contract doc is added
+- the recommended repo reading order changes
+- a document becomes obsolete or superseded
+
+## 10. Final rule
+
+If a developer cannot find the right document from this index, the docs system is not good enough.
+
+Keep this index short, current, and useful.


### PR DESCRIPTION
Adds a repository documentation index and wires it into the main entry points.

Changes:
- adds docs/REPO_DOCS_INDEX.md as the central documentation map
- updates README.md to point to the docs index and current senior-developer docs
- updates docs/DEVELOPER_ONBOARDING.md reading order to include the docs index

This is documentation guidance only. It does not define engine behaviour, CI authority, legal authority, registry data, or release scope.