### PR TITLE
Add S49 coach queue review surface

### DIFF
--- a/docs/coach-queue-review/COACH_QUEUE_REVIEW_SURFACE.md
+++ b/docs/coach-queue-review/COACH_QUEUE_REVIEW_SURFACE.md
@@ -1,0 +1,252 @@
+# S49 — Coach Queue / Review Surface Contract
+
+Document class: implementation contract
+Status: v0 implementation slice
+Authority: subordinate to v0 scope, engine contract, CI gates, public/sales claim guard, and product/design references
+Scope: linked coach review queue and factual queue-item status derivation
+Engine impact: none
+Does not define: engine behaviour, training advice, medical judgement, safety status, readiness certification, ranking, scoring, organisation runtime, team runtime, gym runtime, evidence sealing, or exportable proof
+
+## 1. Purpose
+
+The Coach Queue / Review Surface gives a linked coach a factual list of athlete records that require attention or are available for review.
+
+This is a commercial product surface because coaches are a primary buyer/operator group.
+
+The surface must feel like an operational queue, not a motivational dashboard or advisory engine.
+
+## 2. Current v0 boundary
+
+This slice is allowed in v0 because it is coach-managed, factual, and platform-only.
+
+It may show:
+
+- athlete identifier
+- coach-athlete link status
+- latest session record status
+- latest check-in record status
+- latest coach note status
+- history count status
+- review state
+- blocked reason IDs
+- queue item status
+- source record references
+
+It must not show or imply:
+
+- safety status
+- medical readiness
+- injury risk
+- performance prediction
+- athlete ranking
+- score
+- suitability judgement
+- best action
+- prescribed training advice
+- organisation dashboard
+- team dashboard
+- gym dashboard
+- evidence sealing
+- exportable proof
+
+## 3. Classification
+
+This is an active v0 surface.
+
+It is platform-only.
+
+It is engine-inert.
+
+It is not a public/sales claim surface.
+
+It is not an operator pilot sign-off surface.
+
+It is not an organisation/team/gym runtime surface.
+
+## 4. Queue item model
+
+Each coach queue item represents one coach-visible athlete review record.
+
+The canonical input fields are:
+
+- `queue_item_id`
+- `coach_id`
+- `athlete_id`
+- `coach_athlete_link_status`
+- `latest_session_record_status`
+- `latest_checkin_record_status`
+- `latest_coach_note_status`
+- `history_count_status`
+- `source_record_refs`
+
+No additional fields are permitted in the pure builder input.
+
+## 5. Closed enums
+
+`coach_athlete_link_status` is one of:
+
+- `linked`
+- `revoked`
+- `missing`
+
+`latest_session_record_status` is one of:
+
+- `record_available`
+- `review_required`
+- `missing`
+
+`latest_checkin_record_status` is one of:
+
+- `record_available`
+- `missing`
+
+`latest_coach_note_status` is one of:
+
+- `note_available`
+- `none`
+
+`history_count_status` is one of:
+
+- `counts_available`
+- `missing`
+
+## 6. Derived queue status
+
+The builder derives exactly one `queue_status`.
+
+Allowed values:
+
+- `review_required`
+- `available`
+- `blocked`
+
+Rules:
+
+A queue item is `blocked` when:
+
+- coach-athlete link status is `revoked`
+- coach-athlete link status is `missing`
+- source record refs are missing
+- an unknown enum value is present
+- an unknown field is present
+
+A queue item is `review_required` when:
+
+- link status is `linked`
+- source record refs are present
+- latest session record status is `review_required`
+
+A queue item is `available` when:
+
+- link status is `linked`
+- source record refs are present
+- latest session record status is not `review_required`
+- no blocked reasons exist
+
+## 7. Blocked reason IDs
+
+Allowed blocked reason IDs:
+
+- `coach_athlete_link_revoked`
+- `coach_athlete_link_missing`
+- `source_record_missing`
+- `unknown_queue_item_field`
+- `unknown_queue_item_status`
+
+Unknown blocked reason IDs are not permitted.
+
+## 8. Output model
+
+Each output queue item contains exactly:
+
+- `queue_item_id`
+- `coach_id`
+- `athlete_id`
+- `queue_status`
+- `review_required`
+- `blocked_reasons`
+- `source_record_refs`
+
+No additional output fields are permitted.
+
+## 9. Sorting
+
+Queue output order is deterministic.
+
+Order:
+
+1. `review_required`
+2. `blocked`
+3. `available`
+
+Within each status group, sort by `athlete_id`, then `queue_item_id`.
+
+## 10. Prohibited behaviour
+
+The builder must not:
+
+- read from storage
+- call external services
+- use current time
+- use randomness
+- mutate input
+- infer missing data
+- produce training advice
+- produce public/sales claims
+- alter engine behaviour
+- alter Phase 1 to Phase 6 output
+- create organisation/team/gym runtime
+- create ranking
+- create score
+- create readiness certification
+- create safety or medical meaning
+
+## 11. Copy surface
+
+Allowed user-facing copy strings are factual only.
+
+Allowed copy keys:
+
+- `coach_queue_title`
+- `coach_queue_empty`
+- `coach_queue_review_required`
+- `coach_queue_available`
+- `coach_queue_blocked`
+- `coach_queue_source_missing`
+- `coach_queue_link_missing`
+- `coach_queue_link_revoked`
+- `coach_queue_open_record`
+- `coach_queue_review_item`
+
+Copy must not contain:
+
+- safe
+- safer
+- safety
+- injury
+- medical
+- clinical
+- optimal
+- optimised
+- best for you
+- tailored to you
+- guaranteed
+- proven
+- ready to train
+- performance prediction
+- readiness certification
+
+## 12. Acceptance criteria
+
+Tests must prove:
+
+- linked athlete with `review_required` session derives `review_required`
+- linked athlete without review-required session derives `available`
+- revoked coach-athlete link derives `blocked`
+- missing coach-athlete link derives `blocked`
+- missing source refs derive `blocked`
+- unknown input field derives `blocked`
+- unknown enum derives `blocked`
+- sorting is deterministic
+- builder does not mutate input
+- output does not contain score, rank, readiness certification, safety, medical, optimisation, or advice fields

--- a/docs/coach-queue-review/coach_queue_review_copy.json
+++ b/docs/coach-queue-review/coach_queue_review_copy.json
@@ -1,0 +1,34 @@
+{
+  "copy_surface_id": "coach_queue_review_copy",
+  "version": "1.0.0",
+  "authority": "v0_engine_inert_platform_copy",
+  "strings": {
+    "coach_queue_title": "Coach queue",
+    "coach_queue_empty": "No review items.",
+    "coach_queue_review_required": "Review required.",
+    "coach_queue_available": "Record available.",
+    "coach_queue_blocked": "Blocked.",
+    "coach_queue_source_missing": "Source record missing.",
+    "coach_queue_link_missing": "Coach-athlete link missing.",
+    "coach_queue_link_revoked": "Coach-athlete link revoked.",
+    "coach_queue_open_record": "Open record.",
+    "coach_queue_review_item": "Review item."
+  },
+  "forbidden_semantics": [
+    "safe",
+    "safer",
+    "safety",
+    "injury",
+    "medical",
+    "clinical",
+    "optimal",
+    "optimised",
+    "best for you",
+    "tailored to you",
+    "guaranteed",
+    "proven",
+    "ready to train",
+    "performance prediction",
+    "readiness certification"
+  ]
+}

--- a/docs/product/V0_SURFACE_INDEX.md
+++ b/docs/product/V0_SURFACE_INDEX.md
@@ -46,6 +46,7 @@ A described future surface that is not active v0 unless a later release definiti
 | S46 | Pilot sign-off record | Pilot/operator surface | None | Stores append-only coach_ready or blocked operator sign-off records. |
 | S47 | Pilot blocked reason registry | Pilot/operator surface | None | Defines the closed-world blocked reason IDs for pilot sign-off. |
 | S48 | Pilot readiness evaluator | Pilot/operator surface | None | Pure evaluator that derives coach_ready or blocked from checklist and boundary data. |
+| S49 | Coach queue / review surface | Active v0 surface | None | Derives factual linked-coach review queue status without advice, scoring, ranking, readiness certification, or safety meaning. |
 
 ## 4. Product and design references
 

--- a/docs/prompts/S49_COACH_QUEUE_REVIEW_SURFACE_PROMPT.md
+++ b/docs/prompts/S49_COACH_QUEUE_REVIEW_SURFACE_PROMPT.md
@@ -1,0 +1,40 @@
+# S49 — Coach Queue / Review Surface Prompt
+
+Build S49 as a narrow v0-safe coach queue/review surface.
+
+Goal:
+Create a factual linked-coach queue surface that shows which athlete records require review, are available, or are blocked.
+
+Hard boundaries:
+- engine-inert
+- platform-only
+- no medical meaning
+- no safety claims
+- no readiness certification
+- no score
+- no ranking
+- no performance prediction
+- no organisation/team/gym runtime
+- no evidence sealing
+- no exportable proof
+- no training advice
+- no autonomous coach authority
+
+Required outputs:
+- implementation contract doc
+- neutral copy JSON
+- pure TypeScript builder
+- Node test file
+- package script for targeted testing
+- V0 surface index update
+
+Acceptance:
+- linked review-required athlete derives review_required
+- linked non-review athlete derives available
+- revoked or missing link derives blocked
+- missing source refs derive blocked
+- unknown field derives blocked
+- unknown enum derives blocked
+- deterministic sorting
+- no input mutation
+- no forbidden output keys

--- a/package.json
+++ b/package.json
@@ -101,7 +101,8 @@
                     "agents:lint":  "node ci/agents/agent_prompt_lint.mjs \u0026\u0026 node ci/agents/agent_dormant_feature_guard.mjs \u0026\u0026 node ci/agents/agent_scope_guard.mjs",
                     "test:pilot-signoff":  "node scripts/run_pilot_signoff_record_tests.mjs",
                     "guard:pilot-blocked-reasons":  "node scripts/run_pilot_blocked_reason_registry_guard.mjs",
-                    "test:pilot-readiness-evaluator":  "node test/pilotReadinessEvaluator.test.mjs"
+                    "test:pilot-readiness-evaluator":  "node test/pilotReadinessEvaluator.test.mjs",
+                    "test:coach-queue-review":  "npm run build:fast \u0026\u0026 node test/coachQueueReviewSurface.test.mjs"
                 },
     "dependencies":  {
                          "@kolosseum/engine":  "file:engine",

--- a/src/coachQueueReviewSurface.ts
+++ b/src/coachQueueReviewSurface.ts
@@ -1,0 +1,208 @@
+export const coachQueueReviewStatusOrder = {
+  review_required: 0,
+  blocked: 1,
+  available: 2,
+} as const;
+
+export const allowedCoachAthleteLinkStatuses = [
+  "linked",
+  "revoked",
+  "missing",
+] as const;
+
+export const allowedLatestSessionRecordStatuses = [
+  "record_available",
+  "review_required",
+  "missing",
+] as const;
+
+export const allowedLatestCheckinRecordStatuses = [
+  "record_available",
+  "missing",
+] as const;
+
+export const allowedLatestCoachNoteStatuses = [
+  "note_available",
+  "none",
+] as const;
+
+export const allowedHistoryCountStatuses = [
+  "counts_available",
+  "missing",
+] as const;
+
+export const allowedCoachQueueBlockedReasons = [
+  "coach_athlete_link_revoked",
+  "coach_athlete_link_missing",
+  "source_record_missing",
+  "unknown_queue_item_field",
+  "unknown_queue_item_status",
+] as const;
+
+export type CoachAthleteLinkStatus =
+  (typeof allowedCoachAthleteLinkStatuses)[number];
+
+export type LatestSessionRecordStatus =
+  (typeof allowedLatestSessionRecordStatuses)[number];
+
+export type LatestCheckinRecordStatus =
+  (typeof allowedLatestCheckinRecordStatuses)[number];
+
+export type LatestCoachNoteStatus =
+  (typeof allowedLatestCoachNoteStatuses)[number];
+
+export type HistoryCountStatus =
+  (typeof allowedHistoryCountStatuses)[number];
+
+export type CoachQueueStatus = keyof typeof coachQueueReviewStatusOrder;
+
+export type CoachQueueBlockedReason =
+  (typeof allowedCoachQueueBlockedReasons)[number];
+
+export interface CoachQueueReviewInputItem {
+  queue_item_id: string;
+  coach_id: string;
+  athlete_id: string;
+  coach_athlete_link_status: CoachAthleteLinkStatus;
+  latest_session_record_status: LatestSessionRecordStatus;
+  latest_checkin_record_status: LatestCheckinRecordStatus;
+  latest_coach_note_status: LatestCoachNoteStatus;
+  history_count_status: HistoryCountStatus;
+  source_record_refs: string[];
+}
+
+export interface CoachQueueReviewOutputItem {
+  queue_item_id: string;
+  coach_id: string;
+  athlete_id: string;
+  queue_status: CoachQueueStatus;
+  review_required: boolean;
+  blocked_reasons: CoachQueueBlockedReason[];
+  source_record_refs: string[];
+}
+
+const allowedInputKeys = new Set([
+  "queue_item_id",
+  "coach_id",
+  "athlete_id",
+  "coach_athlete_link_status",
+  "latest_session_record_status",
+  "latest_checkin_record_status",
+  "latest_coach_note_status",
+  "history_count_status",
+  "source_record_refs",
+]);
+
+function includesString(values: readonly string[], value: unknown): value is string {
+  return typeof value === "string" && values.includes(value);
+}
+
+function hasUnknownField(item: Record<string, unknown>): boolean {
+  return Object.keys(item).some((key) => !allowedInputKeys.has(key));
+}
+
+function hasUnknownStatus(item: Record<string, unknown>): boolean {
+  return (
+    !includesString(
+      allowedCoachAthleteLinkStatuses,
+      item.coach_athlete_link_status,
+    ) ||
+    !includesString(
+      allowedLatestSessionRecordStatuses,
+      item.latest_session_record_status,
+    ) ||
+    !includesString(
+      allowedLatestCheckinRecordStatuses,
+      item.latest_checkin_record_status,
+    ) ||
+    !includesString(
+      allowedLatestCoachNoteStatuses,
+      item.latest_coach_note_status,
+    ) ||
+    !includesString(allowedHistoryCountStatuses, item.history_count_status)
+  );
+}
+
+function getString(value: unknown): string {
+  return typeof value === "string" ? value : "";
+}
+
+function getSourceRecordRefs(value: unknown): string[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  return value.filter((entry): entry is string => typeof entry === "string");
+}
+
+function buildOneCoachQueueReviewItem(
+  item: Record<string, unknown>,
+): CoachQueueReviewOutputItem {
+  const blockedReasons: CoachQueueBlockedReason[] = [];
+
+  if (hasUnknownField(item)) {
+    blockedReasons.push("unknown_queue_item_field");
+  }
+
+  if (hasUnknownStatus(item)) {
+    blockedReasons.push("unknown_queue_item_status");
+  }
+
+  const sourceRecordRefs = getSourceRecordRefs(item.source_record_refs);
+
+  if (sourceRecordRefs.length === 0) {
+    blockedReasons.push("source_record_missing");
+  }
+
+  if (item.coach_athlete_link_status === "revoked") {
+    blockedReasons.push("coach_athlete_link_revoked");
+  }
+
+  if (item.coach_athlete_link_status === "missing") {
+    blockedReasons.push("coach_athlete_link_missing");
+  }
+
+  const blocked = blockedReasons.length > 0;
+  const reviewRequired =
+    !blocked && item.latest_session_record_status === "review_required";
+
+  const queueStatus: CoachQueueStatus = blocked
+    ? "blocked"
+    : reviewRequired
+      ? "review_required"
+      : "available";
+
+  return {
+    queue_item_id: getString(item.queue_item_id),
+    coach_id: getString(item.coach_id),
+    athlete_id: getString(item.athlete_id),
+    queue_status: queueStatus,
+    review_required: reviewRequired,
+    blocked_reasons: blockedReasons,
+    source_record_refs: sourceRecordRefs,
+  };
+}
+
+export function buildCoachQueueReviewSurface(
+  inputItems: readonly Record<string, unknown>[],
+): CoachQueueReviewOutputItem[] {
+  return inputItems
+    .map((item) => buildOneCoachQueueReviewItem(item))
+    .sort((left, right) => {
+      const statusDelta =
+        coachQueueReviewStatusOrder[left.queue_status] -
+        coachQueueReviewStatusOrder[right.queue_status];
+
+      if (statusDelta !== 0) {
+        return statusDelta;
+      }
+
+      const athleteDelta = left.athlete_id.localeCompare(right.athlete_id);
+
+      if (athleteDelta !== 0) {
+        return athleteDelta;
+      }
+
+      return left.queue_item_id.localeCompare(right.queue_item_id);
+    });
+}

--- a/test/coachQueueReviewSurface.test.mjs
+++ b/test/coachQueueReviewSurface.test.mjs
@@ -1,0 +1,143 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  buildCoachQueueReviewSurface,
+} from "../dist/src/coachQueueReviewSurface.js";
+
+function baseItem(overrides = {}) {
+  return {
+    queue_item_id: "queue_item_001",
+    coach_id: "coach_001",
+    athlete_id: "athlete_001",
+    coach_athlete_link_status: "linked",
+    latest_session_record_status: "record_available",
+    latest_checkin_record_status: "record_available",
+    latest_coach_note_status: "none",
+    history_count_status: "counts_available",
+    source_record_refs: ["session_record_001"],
+    ...overrides,
+  };
+}
+
+test("linked athlete with review-required session derives review_required", () => {
+  const [item] = buildCoachQueueReviewSurface([
+    baseItem({ latest_session_record_status: "review_required" }),
+  ]);
+
+  assert.equal(item.queue_status, "review_required");
+  assert.equal(item.review_required, true);
+  assert.deepEqual(item.blocked_reasons, []);
+});
+
+test("linked athlete without review-required session derives available", () => {
+  const [item] = buildCoachQueueReviewSurface([baseItem()]);
+
+  assert.equal(item.queue_status, "available");
+  assert.equal(item.review_required, false);
+  assert.deepEqual(item.blocked_reasons, []);
+});
+
+test("revoked coach-athlete link derives blocked", () => {
+  const [item] = buildCoachQueueReviewSurface([
+    baseItem({ coach_athlete_link_status: "revoked" }),
+  ]);
+
+  assert.equal(item.queue_status, "blocked");
+  assert.equal(item.review_required, false);
+  assert.deepEqual(item.blocked_reasons, ["coach_athlete_link_revoked"]);
+});
+
+test("missing coach-athlete link derives blocked", () => {
+  const [item] = buildCoachQueueReviewSurface([
+    baseItem({ coach_athlete_link_status: "missing" }),
+  ]);
+
+  assert.equal(item.queue_status, "blocked");
+  assert.equal(item.review_required, false);
+  assert.deepEqual(item.blocked_reasons, ["coach_athlete_link_missing"]);
+});
+
+test("missing source refs derive blocked", () => {
+  const [item] = buildCoachQueueReviewSurface([
+    baseItem({ source_record_refs: [] }),
+  ]);
+
+  assert.equal(item.queue_status, "blocked");
+  assert.equal(item.review_required, false);
+  assert.deepEqual(item.blocked_reasons, ["source_record_missing"]);
+});
+
+test("unknown input field derives blocked", () => {
+  const [item] = buildCoachQueueReviewSurface([
+    baseItem({ unsupported_field: "not_allowed" }),
+  ]);
+
+  assert.equal(item.queue_status, "blocked");
+  assert.equal(item.review_required, false);
+  assert.deepEqual(item.blocked_reasons, ["unknown_queue_item_field"]);
+});
+
+test("unknown enum derives blocked", () => {
+  const [item] = buildCoachQueueReviewSurface([
+    baseItem({ latest_session_record_status: "ready_to_train" }),
+  ]);
+
+  assert.equal(item.queue_status, "blocked");
+  assert.equal(item.review_required, false);
+  assert.deepEqual(item.blocked_reasons, ["unknown_queue_item_status"]);
+});
+
+test("sorting is deterministic", () => {
+  const output = buildCoachQueueReviewSurface([
+    baseItem({
+      queue_item_id: "queue_item_003",
+      athlete_id: "athlete_c",
+    }),
+    baseItem({
+      queue_item_id: "queue_item_001",
+      athlete_id: "athlete_a",
+      latest_session_record_status: "review_required",
+    }),
+    baseItem({
+      queue_item_id: "queue_item_002",
+      athlete_id: "athlete_b",
+      coach_athlete_link_status: "revoked",
+    }),
+  ]);
+
+  assert.deepEqual(
+    output.map((item) => item.queue_item_id),
+    ["queue_item_001", "queue_item_002", "queue_item_003"],
+  );
+});
+
+test("builder does not mutate input", () => {
+  const input = [baseItem({ latest_session_record_status: "review_required" })];
+  const before = JSON.stringify(input);
+
+  buildCoachQueueReviewSurface(input);
+
+  assert.equal(JSON.stringify(input), before);
+});
+
+test("output does not contain score rank readiness safety medical optimisation or advice fields", () => {
+  const [item] = buildCoachQueueReviewSurface([baseItem()]);
+  const forbiddenKeys = [
+    "score",
+    "rank",
+    "readiness",
+    "readiness_certification",
+    "safety",
+    "medical",
+    "optimisation",
+    "optimization",
+    "advice",
+    "best_action",
+    "recommendation",
+  ];
+
+  for (const key of forbiddenKeys) {
+    assert.equal(Object.hasOwn(item, key), false, `${key} must not be emitted`);
+  }
+});


### PR DESCRIPTION
Adds S49 Coach Queue / Review Surface as a narrow v0-safe coach-facing platform surface.

Outputs:
- docs/coach-queue-review/COACH_QUEUE_REVIEW_SURFACE.md
- docs/coach-queue-review/coach_queue_review_copy.json
- docs/prompts/S49_COACH_QUEUE_REVIEW_SURFACE_PROMPT.md
- src/coachQueueReviewSurface.ts
- test/coachQueueReviewSurface.test.mjs
- package script: test:coach-queue-review
- V0 surface index update

Boundary:
- engine-inert
- platform-only
- linked-coach factual review queue only
- no safety, medical, optimisation, score, rank, readiness certification, advice, organisation/team/gym runtime, evidence sealing, or exportable proof

Validation:
- npm run test:coach-queue-review
- npm run verify