### PR TITLE
Add S50 coach queue review API adapter

### DIFF
--- a/docs/coach-queue-review/COACH_QUEUE_REVIEW_API_ADAPTER.md
+++ b/docs/coach-queue-review/COACH_QUEUE_REVIEW_API_ADAPTER.md
@@ -1,0 +1,138 @@
+# S50 — Coach Queue / Review API Adapter
+
+Document class: implementation contract
+Status: v0 implementation slice
+Authority: subordinate to v0 scope, engine contract, CI gates, public/sales claim guard, S49 coach queue review surface contract, and product/design references
+Scope: narrow API-style adapter over the S49 pure coach queue review builder
+Engine impact: none
+Does not define: engine behaviour, storage behaviour, Express routing, UI, training advice, medical judgement, safety status, readiness certification, ranking, scoring, organisation runtime, team runtime, gym runtime, evidence sealing, or exportable proof
+
+## 1. Purpose
+
+The S50 Coach Queue / Review API Adapter exposes the S49 coach queue review builder through a narrow platform adapter.
+
+The adapter exists so later UI/API work can consume a stable response shape without directly coupling to source records.
+
+This slice uses fake/in-memory source data only.
+
+## 2. Current v0 boundary
+
+This slice is allowed in v0 because it is:
+
+- linked-coach scoped
+- factual
+- platform-only
+- engine-inert
+- storage-free
+- UI-free
+- deterministic
+
+It must not create:
+
+- public claim surface
+- organisation dashboard
+- team dashboard
+- gym dashboard
+- medical readiness status
+- safety status
+- athlete ranking
+- score
+- recommendation
+- training advice
+- autonomous coach authority
+- evidence seal
+- exportable proof
+
+## 3. Adapter input
+
+The adapter accepts a request object with:
+
+- `coach_id`
+
+No other request field has product meaning.
+
+If `coach_id` is missing or blank, the adapter refuses the request.
+
+## 4. Adapter source
+
+The adapter uses a provided in-memory source with one method:
+
+- `listCoachQueueReviewItems()`
+
+The source returns S49 queue input items.
+
+The source must not:
+
+- read a database
+- call a network
+- use current time
+- mutate records
+- infer missing records
+- create engine output
+
+## 5. Adapter output
+
+Successful response:
+
+- `ok: true`
+- `surface_id: "coach_queue_review_api_adapter"`
+- `version: "1.0.0"`
+- `coach_id`
+- `items`
+
+Refusal response:
+
+- `ok: false`
+- `surface_id: "coach_queue_review_api_adapter"`
+- `version: "1.0.0"`
+- `error`
+
+Allowed errors:
+
+- `coach_id_required`
+- `source_unavailable`
+
+No other errors are part of this slice.
+
+## 6. Filtering rule
+
+The adapter filters source items by exact `coach_id`.
+
+A coach must not receive queue items belonging to another coach.
+
+## 7. Sorting rule
+
+The adapter delegates status derivation and deterministic sorting to the S49 builder.
+
+It must not reorder output after the builder returns it.
+
+## 8. Prohibited output fields
+
+The adapter must not output:
+
+- score
+- rank
+- readiness
+- readiness_certification
+- safety
+- medical
+- optimisation
+- optimization
+- advice
+- best_action
+- recommendation
+
+## 9. Acceptance criteria
+
+Tests must prove:
+
+- missing coach ID is refused
+- blank coach ID is refused
+- adapter filters records by coach ID
+- adapter delegates status derivation to S49 builder
+- adapter returns deterministic queue order
+- adapter returns blocked records from S49 builder without advice
+- source failure returns `source_unavailable`
+- adapter output contains no forbidden fields
+- in-memory source returns copies, not shared mutable records
+- adapter does not mutate source records

--- a/docs/product/V0_SURFACE_INDEX.md
+++ b/docs/product/V0_SURFACE_INDEX.md
@@ -47,6 +47,7 @@ A described future surface that is not active v0 unless a later release definiti
 | S47 | Pilot blocked reason registry | Pilot/operator surface | None | Defines the closed-world blocked reason IDs for pilot sign-off. |
 | S48 | Pilot readiness evaluator | Pilot/operator surface | None | Pure evaluator that derives coach_ready or blocked from checklist and boundary data. |
 | S49 | Coach queue / review surface | Active v0 surface | None | Derives factual linked-coach review queue status without advice, scoring, ranking, readiness certification, or safety meaning. |
+| S50 | Coach queue / review API adapter | Active v0 surface | None | Exposes the S49 factual queue builder through a narrow in-memory adapter without storage, UI, advice, scoring, ranking, readiness certification, or safety meaning. |
 
 ## 4. Product and design references
 

--- a/docs/prompts/S50_COACH_QUEUE_REVIEW_API_ADAPTER_PROMPT.md
+++ b/docs/prompts/S50_COACH_QUEUE_REVIEW_API_ADAPTER_PROMPT.md
@@ -1,0 +1,47 @@
+# S50 — Coach Queue / Review API Adapter Prompt
+
+Build S50 as a narrow v0-safe API-style adapter over the S49 Coach Queue / Review Surface.
+
+Goal:
+Expose the S49 pure builder through a stable adapter response shape using fake/in-memory source data only.
+
+Hard boundaries:
+- engine-inert
+- platform-only
+- no UI
+- no Express route yet
+- no database
+- no network
+- no current time
+- no randomness
+- no medical meaning
+- no safety claims
+- no readiness certification
+- no score
+- no ranking
+- no performance prediction
+- no organisation/team/gym runtime
+- no evidence sealing
+- no exportable proof
+- no training advice
+- no autonomous coach authority
+
+Required outputs:
+- implementation contract doc
+- pure TypeScript adapter
+- in-memory source helper
+- Node test file
+- package script for targeted testing
+- V0 surface index update
+
+Acceptance:
+- missing coach ID refused
+- blank coach ID refused
+- filters records by coach ID
+- delegates derivation to S49 builder
+- deterministic order preserved
+- blocked records returned without advice
+- source failure returns source_unavailable
+- output contains no forbidden fields
+- in-memory source returns copies
+- adapter does not mutate source records

--- a/package.json
+++ b/package.json
@@ -102,7 +102,8 @@
                     "test:pilot-signoff":  "node scripts/run_pilot_signoff_record_tests.mjs",
                     "guard:pilot-blocked-reasons":  "node scripts/run_pilot_blocked_reason_registry_guard.mjs",
                     "test:pilot-readiness-evaluator":  "node test/pilotReadinessEvaluator.test.mjs",
-                    "test:coach-queue-review":  "npm run build:fast \u0026\u0026 node test/coachQueueReviewSurface.test.mjs"
+                    "test:coach-queue-review":  "npm run build:fast \u0026\u0026 node test/coachQueueReviewSurface.test.mjs",
+                    "test:coach-queue-review-api-adapter":  "npm run build:fast \u0026\u0026 node test/coachQueueReviewApiAdapter.test.mjs"
                 },
     "dependencies":  {
                          "@kolosseum/engine":  "file:engine",

--- a/src/coachQueueReviewApiAdapter.ts
+++ b/src/coachQueueReviewApiAdapter.ts
@@ -1,0 +1,113 @@
+import {
+  buildCoachQueueReviewSurface,
+  type CoachQueueReviewInputItem,
+  type CoachQueueReviewOutputItem,
+} from "./coachQueueReviewSurface.js";
+
+export const coachQueueReviewApiAdapterSurfaceId =
+  "coach_queue_review_api_adapter" as const;
+
+export const coachQueueReviewApiAdapterVersion = "1.0.0" as const;
+
+export type CoachQueueReviewApiAdapterError =
+  | "coach_id_required"
+  | "source_unavailable";
+
+export interface CoachQueueReviewApiAdapterRequest {
+  coach_id?: string;
+}
+
+export interface CoachQueueReviewSource {
+  listCoachQueueReviewItems(): readonly CoachQueueReviewInputItem[];
+}
+
+export interface CoachQueueReviewApiAdapterOkResponse {
+  ok: true;
+  surface_id: typeof coachQueueReviewApiAdapterSurfaceId;
+  version: typeof coachQueueReviewApiAdapterVersion;
+  coach_id: string;
+  items: CoachQueueReviewOutputItem[];
+}
+
+export interface CoachQueueReviewApiAdapterErrorResponse {
+  ok: false;
+  surface_id: typeof coachQueueReviewApiAdapterSurfaceId;
+  version: typeof coachQueueReviewApiAdapterVersion;
+  error: CoachQueueReviewApiAdapterError;
+}
+
+export type CoachQueueReviewApiAdapterResponse =
+  | CoachQueueReviewApiAdapterOkResponse
+  | CoachQueueReviewApiAdapterErrorResponse;
+
+function cloneInputItem(
+  item: CoachQueueReviewInputItem,
+): CoachQueueReviewInputItem {
+  return {
+    queue_item_id: item.queue_item_id,
+    coach_id: item.coach_id,
+    athlete_id: item.athlete_id,
+    coach_athlete_link_status: item.coach_athlete_link_status,
+    latest_session_record_status: item.latest_session_record_status,
+    latest_checkin_record_status: item.latest_checkin_record_status,
+    latest_coach_note_status: item.latest_coach_note_status,
+    history_count_status: item.history_count_status,
+    source_record_refs: [...item.source_record_refs],
+  };
+}
+
+export function createInMemoryCoachQueueReviewSource(
+  items: readonly CoachQueueReviewInputItem[],
+): CoachQueueReviewSource {
+  const storedItems = items.map((item) => cloneInputItem(item));
+
+  return {
+    listCoachQueueReviewItems(): readonly CoachQueueReviewInputItem[] {
+      return storedItems.map((item) => cloneInputItem(item));
+    },
+  };
+}
+
+function baseErrorResponse(
+  error: CoachQueueReviewApiAdapterError,
+): CoachQueueReviewApiAdapterErrorResponse {
+  return {
+    ok: false,
+    surface_id: coachQueueReviewApiAdapterSurfaceId,
+    version: coachQueueReviewApiAdapterVersion,
+    error,
+  };
+}
+
+export function getCoachQueueReviewApiAdapterResponse(
+  request: CoachQueueReviewApiAdapterRequest,
+  source: CoachQueueReviewSource,
+): CoachQueueReviewApiAdapterResponse {
+  const coachId =
+    typeof request.coach_id === "string" ? request.coach_id.trim() : "";
+
+  if (coachId.length === 0) {
+    return baseErrorResponse("coach_id_required");
+  }
+
+  let sourceItems: readonly CoachQueueReviewInputItem[];
+
+  try {
+    sourceItems = source.listCoachQueueReviewItems();
+  } catch {
+    return baseErrorResponse("source_unavailable");
+  }
+
+  const coachItems = sourceItems
+    .filter((item) => item.coach_id === coachId)
+    .map((item) => ({ ...item, source_record_refs: [...item.source_record_refs] }));
+  const queueItems = buildCoachQueueReviewSurface(coachItems);
+
+  return {
+    ok: true,
+    surface_id: coachQueueReviewApiAdapterSurfaceId,
+    version: coachQueueReviewApiAdapterVersion,
+    coach_id: coachId,
+    items: queueItems,
+  };
+}

--- a/test/coachQueueReviewApiAdapter.test.mjs
+++ b/test/coachQueueReviewApiAdapter.test.mjs
@@ -1,0 +1,205 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  createInMemoryCoachQueueReviewSource,
+  getCoachQueueReviewApiAdapterResponse,
+} from "../dist/src/coachQueueReviewApiAdapter.js";
+
+function baseItem(overrides = {}) {
+  return {
+    queue_item_id: "queue_item_001",
+    coach_id: "coach_001",
+    athlete_id: "athlete_001",
+    coach_athlete_link_status: "linked",
+    latest_session_record_status: "record_available",
+    latest_checkin_record_status: "record_available",
+    latest_coach_note_status: "none",
+    history_count_status: "counts_available",
+    source_record_refs: ["session_record_001"],
+    ...overrides,
+  };
+}
+
+test("missing coach ID is refused", () => {
+  const source = createInMemoryCoachQueueReviewSource([baseItem()]);
+  const response = getCoachQueueReviewApiAdapterResponse({}, source);
+
+  assert.equal(response.ok, false);
+  assert.equal(response.error, "coach_id_required");
+});
+
+test("blank coach ID is refused", () => {
+  const source = createInMemoryCoachQueueReviewSource([baseItem()]);
+  const response = getCoachQueueReviewApiAdapterResponse(
+    { coach_id: "   " },
+    source,
+  );
+
+  assert.equal(response.ok, false);
+  assert.equal(response.error, "coach_id_required");
+});
+
+test("adapter filters records by coach ID", () => {
+  const source = createInMemoryCoachQueueReviewSource([
+    baseItem({
+      queue_item_id: "queue_item_001",
+      coach_id: "coach_001",
+      athlete_id: "athlete_001",
+    }),
+    baseItem({
+      queue_item_id: "queue_item_002",
+      coach_id: "coach_002",
+      athlete_id: "athlete_002",
+    }),
+  ]);
+
+  const response = getCoachQueueReviewApiAdapterResponse(
+    { coach_id: "coach_001" },
+    source,
+  );
+
+  assert.equal(response.ok, true);
+  assert.equal(response.items.length, 1);
+  assert.equal(response.items[0].queue_item_id, "queue_item_001");
+  assert.equal(response.items[0].coach_id, "coach_001");
+});
+
+test("adapter delegates status derivation to S49 builder", () => {
+  const source = createInMemoryCoachQueueReviewSource([
+    baseItem({
+      latest_session_record_status: "review_required",
+    }),
+  ]);
+
+  const response = getCoachQueueReviewApiAdapterResponse(
+    { coach_id: "coach_001" },
+    source,
+  );
+
+  assert.equal(response.ok, true);
+  assert.equal(response.items[0].queue_status, "review_required");
+  assert.equal(response.items[0].review_required, true);
+});
+
+test("adapter returns deterministic queue order", () => {
+  const source = createInMemoryCoachQueueReviewSource([
+    baseItem({
+      queue_item_id: "queue_item_003",
+      athlete_id: "athlete_c",
+    }),
+    baseItem({
+      queue_item_id: "queue_item_001",
+      athlete_id: "athlete_a",
+      latest_session_record_status: "review_required",
+    }),
+    baseItem({
+      queue_item_id: "queue_item_002",
+      athlete_id: "athlete_b",
+      coach_athlete_link_status: "revoked",
+    }),
+  ]);
+
+  const response = getCoachQueueReviewApiAdapterResponse(
+    { coach_id: "coach_001" },
+    source,
+  );
+
+  assert.equal(response.ok, true);
+  assert.deepEqual(
+    response.items.map((item) => item.queue_item_id),
+    ["queue_item_001", "queue_item_002", "queue_item_003"],
+  );
+});
+
+test("adapter returns blocked records from S49 builder without advice", () => {
+  const source = createInMemoryCoachQueueReviewSource([
+    baseItem({
+      coach_athlete_link_status: "missing",
+    }),
+  ]);
+
+  const response = getCoachQueueReviewApiAdapterResponse(
+    { coach_id: "coach_001" },
+    source,
+  );
+
+  assert.equal(response.ok, true);
+  assert.equal(response.items[0].queue_status, "blocked");
+  assert.deepEqual(response.items[0].blocked_reasons, [
+    "coach_athlete_link_missing",
+  ]);
+  assert.equal(Object.hasOwn(response.items[0], "recommendation"), false);
+  assert.equal(Object.hasOwn(response.items[0], "advice"), false);
+});
+
+test("source failure returns source_unavailable", () => {
+  const source = {
+    listCoachQueueReviewItems() {
+      throw new Error("source failure");
+    },
+  };
+
+  const response = getCoachQueueReviewApiAdapterResponse(
+    { coach_id: "coach_001" },
+    source,
+  );
+
+  assert.equal(response.ok, false);
+  assert.equal(response.error, "source_unavailable");
+});
+
+test("adapter output contains no forbidden fields", () => {
+  const source = createInMemoryCoachQueueReviewSource([baseItem()]);
+  const response = getCoachQueueReviewApiAdapterResponse(
+    { coach_id: "coach_001" },
+    source,
+  );
+
+  assert.equal(response.ok, true);
+
+  const serialized = JSON.stringify(response);
+  const forbiddenTokens = [
+    "score",
+    "rank",
+    "readiness_certification",
+    "safety",
+    "medical",
+    "optimisation",
+    "optimization",
+    "best_action",
+    "recommendation",
+  ];
+
+  for (const token of forbiddenTokens) {
+    assert.equal(
+      serialized.includes(token),
+      false,
+      `${token} must not be emitted`,
+    );
+  }
+});
+
+test("in-memory source returns copies not shared mutable records", () => {
+  const source = createInMemoryCoachQueueReviewSource([baseItem()]);
+  const first = source.listCoachQueueReviewItems();
+  first[0].source_record_refs.push("mutated_ref");
+
+  const second = source.listCoachQueueReviewItems();
+
+  assert.deepEqual(second[0].source_record_refs, ["session_record_001"]);
+});
+
+test("adapter does not mutate source records", () => {
+  const item = baseItem({
+    latest_session_record_status: "review_required",
+  });
+  const source = createInMemoryCoachQueueReviewSource([item]);
+  const before = JSON.stringify(source.listCoachQueueReviewItems());
+
+  getCoachQueueReviewApiAdapterResponse({ coach_id: "coach_001" }, source);
+
+  const after = JSON.stringify(source.listCoachQueueReviewItems());
+
+  assert.equal(after, before);
+});


### PR DESCRIPTION
Adds S50 Coach Queue / Review API Adapter as a narrow v0-safe platform adapter over the S49 queue builder.

Outputs:
- docs/coach-queue-review/COACH_QUEUE_REVIEW_API_ADAPTER.md
- docs/prompts/S50_COACH_QUEUE_REVIEW_API_ADAPTER_PROMPT.md
- src/coachQueueReviewApiAdapter.ts
- test/coachQueueReviewApiAdapter.test.mjs
- package script: test:coach-queue-review-api-adapter
- V0 surface index update

Boundary:
- engine-inert
- platform-only
- fake/in-memory source data only
- no UI
- no Express route yet
- no database
- no network
- no safety, medical, optimisation, score, rank, readiness certification, advice, organisation/team/gym runtime, evidence sealing, or exportable proof

Validation:
- npm run test:coach-queue-review-api-adapter
- npm run verify