### PR TITLE
Add S51 coach queue review route contract

### DIFF
--- a/docs/coach-queue-review/COACH_QUEUE_REVIEW_ROUTE_CONTRACT.md
+++ b/docs/coach-queue-review/COACH_QUEUE_REVIEW_ROUTE_CONTRACT.md
@@ -1,0 +1,152 @@
+# S51 — Coach Queue / Review Route Contract
+
+Document class: implementation contract
+Status: v0 implementation slice
+Authority: subordinate to v0 scope, engine contract, CI gates, public/sales claim guard, S49 coach queue review surface contract, S50 coach queue review API adapter contract, and product/design references
+Scope: route/handler-level contract for the coach queue review surface using fake/in-memory source wiring
+Engine impact: none
+Does not define: engine behaviour, Express app registration, production routing, storage behaviour, UI, training advice, medical judgement, safety status, readiness certification, ranking, scoring, organisation runtime, team runtime, gym runtime, evidence sealing, or exportable proof
+
+## 1. Purpose
+
+The S51 Coach Queue / Review Route Contract defines a narrow handler-level route surface over the S50 adapter.
+
+This slice creates a stable request-to-response contract that later API wiring can use without coupling UI or production routing into the current work.
+
+This is not a live registered route.
+
+## 2. Current v0 boundary
+
+This slice is allowed in v0 because it is:
+
+- linked-coach scoped
+- factual
+- handler-level only
+- fake/in-memory source only
+- engine-inert
+- storage-free
+- UI-free
+- deterministic
+
+It must not create:
+
+- Express app registration
+- production route exposure
+- database access
+- network access
+- public claim surface
+- organisation dashboard
+- team dashboard
+- gym dashboard
+- medical readiness status
+- safety status
+- athlete ranking
+- score
+- recommendation
+- training advice
+- autonomous coach authority
+- evidence seal
+- exportable proof
+
+## 3. Route identity
+
+Logical route:
+
+- `GET /v0/coach/queue-review`
+
+This route identity is contractual only in this slice.
+
+No Express route is registered by S51.
+
+## 4. Request contract
+
+The handler accepts a route request object with:
+
+- `method`
+- `path`
+- `query`
+
+The only meaningful query field is:
+
+- `coach_id`
+
+Allowed method:
+
+- `GET`
+
+Allowed path:
+
+- `/v0/coach/queue-review`
+
+## 5. Response contract
+
+Successful response:
+
+- HTTP status `200`
+- body is the successful S50 adapter response
+
+Missing coach ID:
+
+- HTTP status `400`
+- body is the S50 adapter refusal response with `coach_id_required`
+
+Wrong method:
+
+- HTTP status `405`
+- body error is `method_not_allowed`
+
+Wrong path:
+
+- HTTP status `404`
+- body error is `route_not_found`
+
+Source failure:
+
+- HTTP status `503`
+- body error is `source_unavailable`
+
+## 6. Source wiring
+
+S51 uses a provided fake/in-memory source.
+
+The handler must not:
+
+- create storage
+- read storage
+- call a network
+- use current time
+- use randomness
+- mutate source records
+- mutate engine data
+- infer missing data
+
+## 7. Prohibited output fields
+
+The handler response must not output:
+
+- score
+- rank
+- readiness
+- readiness_certification
+- safety
+- medical
+- optimisation
+- optimization
+- advice
+- best_action
+- recommendation
+
+## 8. Acceptance criteria
+
+Tests must prove:
+
+- GET with valid coach ID returns HTTP 200
+- handler filters by coach ID via S50 adapter
+- missing coach ID returns HTTP 400
+- blank coach ID returns HTTP 400
+- wrong method returns HTTP 405
+- wrong path returns HTTP 404
+- source failure returns HTTP 503
+- blocked S49/S50 record is returned without advice
+- handler response contains no forbidden fields
+- handler does not mutate source records

--- a/docs/product/V0_SURFACE_INDEX.md
+++ b/docs/product/V0_SURFACE_INDEX.md
@@ -48,6 +48,7 @@ A described future surface that is not active v0 unless a later release definiti
 | S48 | Pilot readiness evaluator | Pilot/operator surface | None | Pure evaluator that derives coach_ready or blocked from checklist and boundary data. |
 | S49 | Coach queue / review surface | Active v0 surface | None | Derives factual linked-coach review queue status without advice, scoring, ranking, readiness certification, or safety meaning. |
 | S50 | Coach queue / review API adapter | Active v0 surface | None | Exposes the S49 factual queue builder through a narrow in-memory adapter without storage, UI, advice, scoring, ranking, readiness certification, or safety meaning. |
+| S51 | Coach queue / review route contract | Active v0 surface | None | Defines a handler-level route contract over S50 without Express registration, storage, UI, advice, scoring, ranking, readiness certification, or safety meaning. |
 
 ## 4. Product and design references
 

--- a/docs/prompts/S51_COACH_QUEUE_REVIEW_ROUTE_CONTRACT_PROMPT.md
+++ b/docs/prompts/S51_COACH_QUEUE_REVIEW_ROUTE_CONTRACT_PROMPT.md
@@ -1,0 +1,47 @@
+# S51 — Coach Queue / Review Route Contract Prompt
+
+Build S51 as a narrow v0-safe route/handler contract over the S50 Coach Queue / Review API Adapter.
+
+Goal:
+Create a stable handler-level request/response contract for the coach queue review surface using fake/in-memory source wiring only.
+
+Hard boundaries:
+- engine-inert
+- platform-only
+- no UI
+- no Express app registration
+- no production route exposure
+- no database
+- no network
+- no current time
+- no randomness
+- no medical meaning
+- no safety claims
+- no readiness certification
+- no score
+- no ranking
+- no performance prediction
+- no organisation/team/gym runtime
+- no evidence sealing
+- no exportable proof
+- no training advice
+- no autonomous coach authority
+
+Required outputs:
+- implementation contract doc
+- pure TypeScript route/handler contract
+- Node test file
+- package script for targeted testing
+- V0 surface index update
+
+Acceptance:
+- GET with valid coach ID returns HTTP 200
+- filters by coach ID via S50 adapter
+- missing coach ID returns HTTP 400
+- blank coach ID returns HTTP 400
+- wrong method returns HTTP 405
+- wrong path returns HTTP 404
+- source failure returns HTTP 503
+- blocked S49/S50 record returned without advice
+- response contains no forbidden fields
+- handler does not mutate source records

--- a/package.json
+++ b/package.json
@@ -103,7 +103,8 @@
                     "guard:pilot-blocked-reasons":  "node scripts/run_pilot_blocked_reason_registry_guard.mjs",
                     "test:pilot-readiness-evaluator":  "node test/pilotReadinessEvaluator.test.mjs",
                     "test:coach-queue-review":  "npm run build:fast \u0026\u0026 node test/coachQueueReviewSurface.test.mjs",
-                    "test:coach-queue-review-api-adapter":  "npm run build:fast \u0026\u0026 node test/coachQueueReviewApiAdapter.test.mjs"
+                    "test:coach-queue-review-api-adapter":  "npm run build:fast \u0026\u0026 node test/coachQueueReviewApiAdapter.test.mjs",
+                    "test:coach-queue-review-route-contract":  "npm run build:fast \u0026\u0026 node test/coachQueueReviewRouteContract.test.mjs"
                 },
     "dependencies":  {
                          "@kolosseum/engine":  "file:engine",

--- a/src/coachQueueReviewRouteContract.ts
+++ b/src/coachQueueReviewRouteContract.ts
@@ -1,0 +1,108 @@
+import {
+  coachQueueReviewApiAdapterSurfaceId,
+  coachQueueReviewApiAdapterVersion,
+  getCoachQueueReviewApiAdapterResponse,
+  type CoachQueueReviewApiAdapterResponse,
+  type CoachQueueReviewSource,
+} from "./coachQueueReviewApiAdapter.js";
+
+export const coachQueueReviewRoutePath = "/v0/coach/queue-review" as const;
+export const coachQueueReviewRouteMethod = "GET" as const;
+export const coachQueueReviewRouteContractSurfaceId =
+  "coach_queue_review_route_contract" as const;
+export const coachQueueReviewRouteContractVersion = "1.0.0" as const;
+
+export type CoachQueueReviewRouteError =
+  | "method_not_allowed"
+  | "route_not_found";
+
+export interface CoachQueueReviewRouteRequest {
+  method: string;
+  path: string;
+  query?: {
+    coach_id?: string;
+  };
+}
+
+export interface CoachQueueReviewRouteErrorBody {
+  ok: false;
+  surface_id: typeof coachQueueReviewRouteContractSurfaceId;
+  version: typeof coachQueueReviewRouteContractVersion;
+  error: CoachQueueReviewRouteError;
+}
+
+export type CoachQueueReviewRouteBody =
+  | CoachQueueReviewApiAdapterResponse
+  | CoachQueueReviewRouteErrorBody;
+
+export interface CoachQueueReviewRouteResponse {
+  status: 200 | 400 | 404 | 405 | 503;
+  body: CoachQueueReviewRouteBody;
+}
+
+function routeErrorBody(
+  error: CoachQueueReviewRouteError,
+): CoachQueueReviewRouteErrorBody {
+  return {
+    ok: false,
+    surface_id: coachQueueReviewRouteContractSurfaceId,
+    version: coachQueueReviewRouteContractVersion,
+    error,
+  };
+}
+
+function adapterStatus(response: CoachQueueReviewApiAdapterResponse): 200 | 400 | 503 {
+  if (response.ok) {
+    return 200;
+  }
+
+  if (response.error === "coach_id_required") {
+    return 400;
+  }
+
+  if (response.error === "source_unavailable") {
+    return 503;
+  }
+
+  return 503;
+}
+
+export function handleCoachQueueReviewRoute(
+  request: CoachQueueReviewRouteRequest,
+  source: CoachQueueReviewSource,
+): CoachQueueReviewRouteResponse {
+  if (request.path !== coachQueueReviewRoutePath) {
+    return {
+      status: 404,
+      body: routeErrorBody("route_not_found"),
+    };
+  }
+
+  if (request.method !== coachQueueReviewRouteMethod) {
+    return {
+      status: 405,
+      body: routeErrorBody("method_not_allowed"),
+    };
+  }
+
+  const adapterResponse = getCoachQueueReviewApiAdapterResponse(
+    {
+      coach_id: request.query?.coach_id,
+    },
+    source,
+  );
+
+  return {
+    status: adapterStatus(adapterResponse),
+    body: adapterResponse,
+  };
+}
+
+export const coachQueueReviewRouteContract = {
+  method: coachQueueReviewRouteMethod,
+  path: coachQueueReviewRoutePath,
+  surface_id: coachQueueReviewRouteContractSurfaceId,
+  version: coachQueueReviewRouteContractVersion,
+  adapter_surface_id: coachQueueReviewApiAdapterSurfaceId,
+  adapter_version: coachQueueReviewApiAdapterVersion,
+} as const;

--- a/test/coachQueueReviewRouteContract.test.mjs
+++ b/test/coachQueueReviewRouteContract.test.mjs
@@ -1,0 +1,205 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  createInMemoryCoachQueueReviewSource,
+} from "../dist/src/coachQueueReviewApiAdapter.js";
+import {
+  coachQueueReviewRouteContract,
+  handleCoachQueueReviewRoute,
+} from "../dist/src/coachQueueReviewRouteContract.js";
+
+function baseItem(overrides = {}) {
+  return {
+    queue_item_id: "queue_item_001",
+    coach_id: "coach_001",
+    athlete_id: "athlete_001",
+    coach_athlete_link_status: "linked",
+    latest_session_record_status: "record_available",
+    latest_checkin_record_status: "record_available",
+    latest_coach_note_status: "none",
+    history_count_status: "counts_available",
+    source_record_refs: ["session_record_001"],
+    ...overrides,
+  };
+}
+
+function validRequest(overrides = {}) {
+  return {
+    method: "GET",
+    path: "/v0/coach/queue-review",
+    query: {
+      coach_id: "coach_001",
+    },
+    ...overrides,
+  };
+}
+
+test("route contract exposes expected method and path without registering Express", () => {
+  assert.equal(coachQueueReviewRouteContract.method, "GET");
+  assert.equal(coachQueueReviewRouteContract.path, "/v0/coach/queue-review");
+  assert.equal(
+    coachQueueReviewRouteContract.surface_id,
+    "coach_queue_review_route_contract",
+  );
+});
+
+test("GET with valid coach ID returns HTTP 200", () => {
+  const source = createInMemoryCoachQueueReviewSource([baseItem()]);
+  const response = handleCoachQueueReviewRoute(validRequest(), source);
+
+  assert.equal(response.status, 200);
+  assert.equal(response.body.ok, true);
+  assert.equal(response.body.coach_id, "coach_001");
+  assert.equal(response.body.items.length, 1);
+});
+
+test("handler filters by coach ID via S50 adapter", () => {
+  const source = createInMemoryCoachQueueReviewSource([
+    baseItem({
+      queue_item_id: "queue_item_001",
+      coach_id: "coach_001",
+      athlete_id: "athlete_001",
+    }),
+    baseItem({
+      queue_item_id: "queue_item_002",
+      coach_id: "coach_002",
+      athlete_id: "athlete_002",
+    }),
+  ]);
+
+  const response = handleCoachQueueReviewRoute(validRequest(), source);
+
+  assert.equal(response.status, 200);
+  assert.equal(response.body.ok, true);
+  assert.deepEqual(
+    response.body.items.map((item) => item.queue_item_id),
+    ["queue_item_001"],
+  );
+});
+
+test("missing coach ID returns HTTP 400", () => {
+  const source = createInMemoryCoachQueueReviewSource([baseItem()]);
+  const response = handleCoachQueueReviewRoute(
+    {
+      method: "GET",
+      path: "/v0/coach/queue-review",
+      query: {},
+    },
+    source,
+  );
+
+  assert.equal(response.status, 400);
+  assert.equal(response.body.ok, false);
+  assert.equal(response.body.error, "coach_id_required");
+});
+
+test("blank coach ID returns HTTP 400", () => {
+  const source = createInMemoryCoachQueueReviewSource([baseItem()]);
+  const response = handleCoachQueueReviewRoute(
+    validRequest({ query: { coach_id: "   " } }),
+    source,
+  );
+
+  assert.equal(response.status, 400);
+  assert.equal(response.body.ok, false);
+  assert.equal(response.body.error, "coach_id_required");
+});
+
+test("wrong method returns HTTP 405", () => {
+  const source = createInMemoryCoachQueueReviewSource([baseItem()]);
+  const response = handleCoachQueueReviewRoute(
+    validRequest({ method: "POST" }),
+    source,
+  );
+
+  assert.equal(response.status, 405);
+  assert.equal(response.body.ok, false);
+  assert.equal(response.body.error, "method_not_allowed");
+});
+
+test("wrong path returns HTTP 404", () => {
+  const source = createInMemoryCoachQueueReviewSource([baseItem()]);
+  const response = handleCoachQueueReviewRoute(
+    validRequest({ path: "/v0/coach/unknown" }),
+    source,
+  );
+
+  assert.equal(response.status, 404);
+  assert.equal(response.body.ok, false);
+  assert.equal(response.body.error, "route_not_found");
+});
+
+test("source failure returns HTTP 503", () => {
+  const source = {
+    listCoachQueueReviewItems() {
+      throw new Error("source failure");
+    },
+  };
+
+  const response = handleCoachQueueReviewRoute(validRequest(), source);
+
+  assert.equal(response.status, 503);
+  assert.equal(response.body.ok, false);
+  assert.equal(response.body.error, "source_unavailable");
+});
+
+test("blocked S49/S50 record is returned without advice", () => {
+  const source = createInMemoryCoachQueueReviewSource([
+    baseItem({
+      coach_athlete_link_status: "revoked",
+    }),
+  ]);
+
+  const response = handleCoachQueueReviewRoute(validRequest(), source);
+
+  assert.equal(response.status, 200);
+  assert.equal(response.body.ok, true);
+  assert.equal(response.body.items[0].queue_status, "blocked");
+  assert.deepEqual(response.body.items[0].blocked_reasons, [
+    "coach_athlete_link_revoked",
+  ]);
+  assert.equal(Object.hasOwn(response.body.items[0], "advice"), false);
+  assert.equal(Object.hasOwn(response.body.items[0], "recommendation"), false);
+});
+
+test("handler response contains no forbidden fields", () => {
+  const source = createInMemoryCoachQueueReviewSource([baseItem()]);
+  const response = handleCoachQueueReviewRoute(validRequest(), source);
+  const serialized = JSON.stringify(response);
+
+  const forbiddenTokens = [
+    "score",
+    "rank",
+    "readiness_certification",
+    "safety",
+    "medical",
+    "optimisation",
+    "optimization",
+    "best_action",
+    "recommendation",
+  ];
+
+  for (const token of forbiddenTokens) {
+    assert.equal(
+      serialized.includes(token),
+      false,
+      `${token} must not be emitted`,
+    );
+  }
+});
+
+test("handler does not mutate source records", () => {
+  const source = createInMemoryCoachQueueReviewSource([
+    baseItem({
+      latest_session_record_status: "review_required",
+    }),
+  ]);
+  const before = JSON.stringify(source.listCoachQueueReviewItems());
+
+  handleCoachQueueReviewRoute(validRequest(), source);
+
+  const after = JSON.stringify(source.listCoachQueueReviewItems());
+
+  assert.equal(after, before);
+});


### PR DESCRIPTION
Adds S51 Coach Queue / Review Route Contract as a narrow v0-safe handler-level route contract over the S50 adapter.

Outputs:
- docs/coach-queue-review/COACH_QUEUE_REVIEW_ROUTE_CONTRACT.md
- docs/prompts/S51_COACH_QUEUE_REVIEW_ROUTE_CONTRACT_PROMPT.md
- src/coachQueueReviewRouteContract.ts
- test/coachQueueReviewRouteContract.test.mjs
- package script: test:coach-queue-review-route-contract
- V0 surface index update

Boundary:
- engine-inert
- platform-only
- fake/in-memory source wiring only
- no UI
- no Express app registration
- no production route exposure
- no database
- no network
- no safety, medical, optimisation, score, rank, readiness certification, advice, organisation/team/gym runtime, evidence sealing, or exportable proof

Validation:
- npm run test:coach-queue-review-route-contract
- npm run verify