### PR TITLE
Add S52 coach queue review fixture pack

### DIFF
--- a/docs/coach-queue-review/COACH_QUEUE_REVIEW_FIXTURE_PACK.md
+++ b/docs/coach-queue-review/COACH_QUEUE_REVIEW_FIXTURE_PACK.md
@@ -1,0 +1,109 @@
+# S52 — Coach Queue / Review Read Model Fixture Pack
+
+Document class: fixture contract
+Status: v0 implementation slice
+Authority: subordinate to v0 scope, engine contract, CI gates, public/sales claim guard, S49 coach queue review surface contract, S50 coach queue review API adapter contract, S51 coach queue review route contract, and product/design references
+Scope: stable fake fixture records and expected route responses for the coach queue review surface
+Engine impact: none
+Does not define: engine behaviour, production routing, storage behaviour, UI, training advice, medical judgement, safety status, readiness certification, ranking, scoring, organisation runtime, team runtime, gym runtime, evidence sealing, or exportable proof
+
+## 1. Purpose
+
+The S52 fixture pack creates stable fake source records and expected outputs for the coach queue review surface.
+
+The fixture pack exists so future UI and API work can be built against known product states before any rendering or production route wiring is added.
+
+## 2. Current v0 boundary
+
+This slice is allowed in v0 because it is:
+
+- fixture-only
+- linked-coach scoped
+- factual
+- engine-inert
+- storage-free
+- UI-free
+- deterministic
+
+It must not create:
+
+- production route exposure
+- database access
+- network access
+- public claim surface
+- organisation dashboard
+- team dashboard
+- gym dashboard
+- medical readiness status
+- safety status
+- athlete ranking
+- score
+- recommendation
+- training advice
+- autonomous coach authority
+- evidence seal
+- exportable proof
+
+## 3. Fixture files
+
+This slice adds:
+
+- `test/fixtures/coach-queue-review/source_records.json`
+- `test/fixtures/coach-queue-review/expected_route_responses.json`
+
+The source records file contains fake in-memory S49 source records.
+
+The expected route responses file contains deterministic S51 route responses for known coach requests.
+
+## 4. Required fixture states
+
+The fixture pack must include:
+
+- one linked coach record with `review_required`
+- one linked coach record with `available`
+- one blocked record caused by revoked link
+- one blocked record caused by missing source refs
+- one record belonging to another coach that must be filtered out
+- one empty queue response for a coach with no matching records
+- one missing coach ID refusal response
+
+## 5. Determinism
+
+Expected responses must be deterministic.
+
+The queue order must follow S49 order:
+
+1. `review_required`
+2. `blocked`
+3. `available`
+
+Within each status group, order by `athlete_id`, then `queue_item_id`.
+
+## 6. Prohibited fixture output fields
+
+Fixture outputs must not contain:
+
+- score
+- rank
+- readiness
+- readiness_certification
+- safety
+- medical
+- optimisation
+- optimization
+- advice
+- best_action
+- recommendation
+
+## 7. Acceptance criteria
+
+Tests must prove:
+
+- fixture source records match expected successful route output
+- queue order is deterministic
+- coach filtering excludes other-coach records
+- empty queue fixture is stable
+- missing coach ID fixture is stable
+- expected fixture outputs contain no forbidden fields
+- fixture source records are not mutated by route handling
+- fixture JSON is valid and readable

--- a/docs/product/V0_SURFACE_INDEX.md
+++ b/docs/product/V0_SURFACE_INDEX.md
@@ -49,6 +49,7 @@ A described future surface that is not active v0 unless a later release definiti
 | S49 | Coach queue / review surface | Active v0 surface | None | Derives factual linked-coach review queue status without advice, scoring, ranking, readiness certification, or safety meaning. |
 | S50 | Coach queue / review API adapter | Active v0 surface | None | Exposes the S49 factual queue builder through a narrow in-memory adapter without storage, UI, advice, scoring, ranking, readiness certification, or safety meaning. |
 | S51 | Coach queue / review route contract | Active v0 surface | None | Defines a handler-level route contract over S50 without Express registration, storage, UI, advice, scoring, ranking, readiness certification, or safety meaning. |
+| S52 | Coach queue / review read model fixture pack | Active v0 surface | None | Provides stable fake source records and expected route responses for the S49-S51 coach queue surface without UI, storage, advice, scoring, ranking, readiness certification, or safety meaning. |
 
 ## 4. Product and design references
 

--- a/docs/prompts/S52_COACH_QUEUE_REVIEW_FIXTURE_PACK_PROMPT.md
+++ b/docs/prompts/S52_COACH_QUEUE_REVIEW_FIXTURE_PACK_PROMPT.md
@@ -1,0 +1,47 @@
+# S52 — Coach Queue / Review Read Model Fixture Pack Prompt
+
+Build S52 as a narrow v0-safe fixture/read-model hardening slice for the S49-S51 coach queue review surface.
+
+Goal:
+Create stable fake source records and expected route responses so future API/UI work can build against known product states before rendering or production route wiring.
+
+Hard boundaries:
+- engine-inert
+- fixture-only
+- platform-only
+- no UI
+- no Express app registration
+- no production route exposure
+- no database
+- no network
+- no current time
+- no randomness
+- no medical meaning
+- no safety claims
+- no readiness certification
+- no score
+- no ranking
+- no performance prediction
+- no organisation/team/gym runtime
+- no evidence sealing
+- no exportable proof
+- no training advice
+- no autonomous coach authority
+
+Required outputs:
+- fixture contract doc
+- fake source records JSON
+- expected route responses JSON
+- Node fixture validation test
+- package script for targeted testing
+- V0 surface index update
+
+Acceptance:
+- fixture source records match expected successful route output
+- deterministic queue order
+- other-coach records are filtered out
+- empty queue fixture is stable
+- missing coach ID fixture is stable
+- expected outputs contain no forbidden fields
+- source records are not mutated
+- fixture JSON is valid and readable

--- a/package.json
+++ b/package.json
@@ -104,7 +104,8 @@
                     "test:pilot-readiness-evaluator":  "node test/pilotReadinessEvaluator.test.mjs",
                     "test:coach-queue-review":  "npm run build:fast \u0026\u0026 node test/coachQueueReviewSurface.test.mjs",
                     "test:coach-queue-review-api-adapter":  "npm run build:fast \u0026\u0026 node test/coachQueueReviewApiAdapter.test.mjs",
-                    "test:coach-queue-review-route-contract":  "npm run build:fast \u0026\u0026 node test/coachQueueReviewRouteContract.test.mjs"
+                    "test:coach-queue-review-route-contract":  "npm run build:fast \u0026\u0026 node test/coachQueueReviewRouteContract.test.mjs",
+                    "test:coach-queue-review-fixtures":  "npm run build:fast \u0026\u0026 node test/coachQueueReviewFixturePack.test.mjs"
                 },
     "dependencies":  {
                          "@kolosseum/engine":  "file:engine",

--- a/test/coachQueueReviewFixturePack.test.mjs
+++ b/test/coachQueueReviewFixturePack.test.mjs
@@ -1,0 +1,157 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import test from "node:test";
+
+import {
+  createInMemoryCoachQueueReviewSource,
+} from "../dist/src/coachQueueReviewApiAdapter.js";
+import {
+  handleCoachQueueReviewRoute,
+} from "../dist/src/coachQueueReviewRouteContract.js";
+
+const repoRoot = process.cwd();
+const fixtureDir = join(repoRoot, "test", "fixtures", "coach-queue-review");
+
+function readJsonFixture(fileName) {
+  return JSON.parse(readFileSync(join(fixtureDir, fileName), "utf8"));
+}
+
+function primaryCoachRequest() {
+  return {
+    method: "GET",
+    path: "/v0/coach/queue-review",
+    query: {
+      coach_id: "coach_fixture_primary",
+    },
+  };
+}
+
+function emptyCoachRequest() {
+  return {
+    method: "GET",
+    path: "/v0/coach/queue-review",
+    query: {
+      coach_id: "coach_fixture_empty",
+    },
+  };
+}
+
+function missingCoachRequest() {
+  return {
+    method: "GET",
+    path: "/v0/coach/queue-review",
+    query: {},
+  };
+}
+
+function forbiddenTokens() {
+  return [
+    "score",
+    "rank",
+    "readiness_certification",
+    "safety",
+    "medical",
+    "optimisation",
+    "optimization",
+    "best_action",
+    "recommendation",
+    "advice"
+  ];
+}
+
+test("fixture JSON is valid and readable", () => {
+  const sourceRecords = readJsonFixture("source_records.json");
+  const expectedResponses = readJsonFixture("expected_route_responses.json");
+
+  assert.equal(
+    sourceRecords.fixture_pack_id,
+    "coach_queue_review_read_model_source_records",
+  );
+  assert.equal(
+    expectedResponses.fixture_pack_id,
+    "coach_queue_review_expected_route_responses",
+  );
+  assert.equal(Array.isArray(sourceRecords.records), true);
+  assert.equal(typeof expectedResponses.responses, "object");
+});
+
+test("fixture source records match expected successful route output", () => {
+  const sourceRecords = readJsonFixture("source_records.json");
+  const expectedResponses = readJsonFixture("expected_route_responses.json");
+  const source = createInMemoryCoachQueueReviewSource(sourceRecords.records);
+
+  const actual = handleCoachQueueReviewRoute(primaryCoachRequest(), source);
+
+  assert.deepEqual(actual, expectedResponses.responses.primary_coach_queue);
+});
+
+test("queue order is deterministic", () => {
+  const sourceRecords = readJsonFixture("source_records.json");
+  const source = createInMemoryCoachQueueReviewSource(sourceRecords.records);
+
+  const actual = handleCoachQueueReviewRoute(primaryCoachRequest(), source);
+
+  assert.deepEqual(
+    actual.body.items.map((item) => item.queue_item_id),
+    [
+      "queue_item_review_001",
+      "queue_item_blocked_revoked_001",
+      "queue_item_blocked_missing_source_001",
+      "queue_item_available_001",
+    ],
+  );
+});
+
+test("coach filtering excludes other-coach records", () => {
+  const sourceRecords = readJsonFixture("source_records.json");
+  const source = createInMemoryCoachQueueReviewSource(sourceRecords.records);
+
+  const actual = handleCoachQueueReviewRoute(primaryCoachRequest(), source);
+  const queueItemIds = actual.body.items.map((item) => item.queue_item_id);
+
+  assert.equal(queueItemIds.includes("queue_item_other_coach_001"), false);
+});
+
+test("empty queue fixture is stable", () => {
+  const sourceRecords = readJsonFixture("source_records.json");
+  const expectedResponses = readJsonFixture("expected_route_responses.json");
+  const source = createInMemoryCoachQueueReviewSource(sourceRecords.records);
+
+  const actual = handleCoachQueueReviewRoute(emptyCoachRequest(), source);
+
+  assert.deepEqual(actual, expectedResponses.responses.empty_coach_queue);
+});
+
+test("missing coach ID fixture is stable", () => {
+  const sourceRecords = readJsonFixture("source_records.json");
+  const expectedResponses = readJsonFixture("expected_route_responses.json");
+  const source = createInMemoryCoachQueueReviewSource(sourceRecords.records);
+
+  const actual = handleCoachQueueReviewRoute(missingCoachRequest(), source);
+
+  assert.deepEqual(actual, expectedResponses.responses.missing_coach_id);
+});
+
+test("expected fixture outputs contain no forbidden fields", () => {
+  const expectedResponses = readJsonFixture("expected_route_responses.json");
+  const serialized = JSON.stringify(expectedResponses);
+
+  for (const token of forbiddenTokens()) {
+    assert.equal(
+      serialized.includes(token),
+      false,
+      `${token} must not appear in expected fixture outputs`,
+    );
+  }
+});
+
+test("fixture source records are not mutated by route handling", () => {
+  const sourceRecords = readJsonFixture("source_records.json");
+  const before = JSON.stringify(sourceRecords.records);
+  const source = createInMemoryCoachQueueReviewSource(sourceRecords.records);
+
+  handleCoachQueueReviewRoute(primaryCoachRequest(), source);
+
+  assert.equal(JSON.stringify(sourceRecords.records), before);
+});

--- a/test/fixtures/coach-queue-review/expected_route_responses.json
+++ b/test/fixtures/coach-queue-review/expected_route_responses.json
@@ -1,0 +1,84 @@
+{
+  "fixture_pack_id": "coach_queue_review_expected_route_responses",
+  "fixture_pack_version": "1.0.0",
+  "responses": {
+    "primary_coach_queue": {
+      "status": 200,
+      "body": {
+        "ok": true,
+        "surface_id": "coach_queue_review_api_adapter",
+        "version": "1.0.0",
+        "coach_id": "coach_fixture_primary",
+        "items": [
+          {
+            "queue_item_id": "queue_item_review_001",
+            "coach_id": "coach_fixture_primary",
+            "athlete_id": "athlete_alpha",
+            "queue_status": "review_required",
+            "review_required": true,
+            "blocked_reasons": [],
+            "source_record_refs": [
+              "session_record_alpha_001",
+              "checkin_record_alpha_001"
+            ]
+          },
+          {
+            "queue_item_id": "queue_item_blocked_revoked_001",
+            "coach_id": "coach_fixture_primary",
+            "athlete_id": "athlete_beta",
+            "queue_status": "blocked",
+            "review_required": false,
+            "blocked_reasons": [
+              "coach_athlete_link_revoked"
+            ],
+            "source_record_refs": [
+              "session_record_beta_001"
+            ]
+          },
+          {
+            "queue_item_id": "queue_item_blocked_missing_source_001",
+            "coach_id": "coach_fixture_primary",
+            "athlete_id": "athlete_gamma",
+            "queue_status": "blocked",
+            "review_required": false,
+            "blocked_reasons": [
+              "source_record_missing"
+            ],
+            "source_record_refs": []
+          },
+          {
+            "queue_item_id": "queue_item_available_001",
+            "coach_id": "coach_fixture_primary",
+            "athlete_id": "athlete_delta",
+            "queue_status": "available",
+            "review_required": false,
+            "blocked_reasons": [],
+            "source_record_refs": [
+              "session_record_delta_001",
+              "coach_note_delta_001"
+            ]
+          }
+        ]
+      }
+    },
+    "empty_coach_queue": {
+      "status": 200,
+      "body": {
+        "ok": true,
+        "surface_id": "coach_queue_review_api_adapter",
+        "version": "1.0.0",
+        "coach_id": "coach_fixture_empty",
+        "items": []
+      }
+    },
+    "missing_coach_id": {
+      "status": 400,
+      "body": {
+        "ok": false,
+        "surface_id": "coach_queue_review_api_adapter",
+        "version": "1.0.0",
+        "error": "coach_id_required"
+      }
+    }
+  }
+}

--- a/test/fixtures/coach-queue-review/source_records.json
+++ b/test/fixtures/coach-queue-review/source_records.json
@@ -1,0 +1,71 @@
+{
+  "fixture_pack_id": "coach_queue_review_read_model_source_records",
+  "fixture_pack_version": "1.0.0",
+  "records": [
+    {
+      "queue_item_id": "queue_item_review_001",
+      "coach_id": "coach_fixture_primary",
+      "athlete_id": "athlete_alpha",
+      "coach_athlete_link_status": "linked",
+      "latest_session_record_status": "review_required",
+      "latest_checkin_record_status": "record_available",
+      "latest_coach_note_status": "none",
+      "history_count_status": "counts_available",
+      "source_record_refs": [
+        "session_record_alpha_001",
+        "checkin_record_alpha_001"
+      ]
+    },
+    {
+      "queue_item_id": "queue_item_available_001",
+      "coach_id": "coach_fixture_primary",
+      "athlete_id": "athlete_delta",
+      "coach_athlete_link_status": "linked",
+      "latest_session_record_status": "record_available",
+      "latest_checkin_record_status": "record_available",
+      "latest_coach_note_status": "note_available",
+      "history_count_status": "counts_available",
+      "source_record_refs": [
+        "session_record_delta_001",
+        "coach_note_delta_001"
+      ]
+    },
+    {
+      "queue_item_id": "queue_item_blocked_revoked_001",
+      "coach_id": "coach_fixture_primary",
+      "athlete_id": "athlete_beta",
+      "coach_athlete_link_status": "revoked",
+      "latest_session_record_status": "record_available",
+      "latest_checkin_record_status": "record_available",
+      "latest_coach_note_status": "none",
+      "history_count_status": "counts_available",
+      "source_record_refs": [
+        "session_record_beta_001"
+      ]
+    },
+    {
+      "queue_item_id": "queue_item_blocked_missing_source_001",
+      "coach_id": "coach_fixture_primary",
+      "athlete_id": "athlete_gamma",
+      "coach_athlete_link_status": "linked",
+      "latest_session_record_status": "record_available",
+      "latest_checkin_record_status": "missing",
+      "latest_coach_note_status": "none",
+      "history_count_status": "missing",
+      "source_record_refs": []
+    },
+    {
+      "queue_item_id": "queue_item_other_coach_001",
+      "coach_id": "coach_fixture_other",
+      "athlete_id": "athlete_omega",
+      "coach_athlete_link_status": "linked",
+      "latest_session_record_status": "review_required",
+      "latest_checkin_record_status": "record_available",
+      "latest_coach_note_status": "none",
+      "history_count_status": "counts_available",
+      "source_record_refs": [
+        "session_record_omega_001"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Adds S52 Coach Queue / Review Read Model Fixture Pack as a v0-safe fixture/read-model hardening slice.

Outputs:
- docs/coach-queue-review/COACH_QUEUE_REVIEW_FIXTURE_PACK.md
- docs/prompts/S52_COACH_QUEUE_REVIEW_FIXTURE_PACK_PROMPT.md
- test/fixtures/coach-queue-review/source_records.json
- test/fixtures/coach-queue-review/expected_route_responses.json
- test/coachQueueReviewFixturePack.test.mjs
- package script: test:coach-queue-review-fixtures
- V0 surface index update

Boundary:
- engine-inert
- fixture-only
- fake source records and expected responses only
- no UI
- no Express app registration
- no production route exposure
- no database
- no network
- no safety, medical, optimisation, score, rank, readiness certification, advice, organisation/team/gym runtime, evidence sealing, or exportable proof

Validation:
- npm run test:coach-queue-review-fixtures
- npm run verify