### PR TITLE
Add S53 coach queue review UI renderer

### DIFF
--- a/docs/coach-queue-review/COACH_QUEUE_REVIEW_UI_RENDERER.md
+++ b/docs/coach-queue-review/COACH_QUEUE_REVIEW_UI_RENDERER.md
@@ -1,0 +1,129 @@
+# S53 — Coach Queue / Review Minimal UI Read Model Renderer
+
+Document class: implementation contract
+Status: v0 implementation slice
+Authority: subordinate to v0 scope, engine contract, CI gates, public/sales claim guard, S49 coach queue review surface contract, S50 API adapter contract, S51 route contract, S52 fixture pack, and product/design references
+Scope: fixture-backed minimal renderer for coach queue review read-model states
+Engine impact: none
+Does not define: engine behaviour, production routing, storage behaviour, live API behaviour, UI framework adoption, training advice, medical judgement, safety status, readiness certification, ranking, scoring, organisation runtime, team runtime, gym runtime, evidence sealing, or exportable proof
+
+## 1. Purpose
+
+The S53 Coach Queue / Review Minimal UI Read Model Renderer turns known S52 fixture-backed route responses into deterministic, safe HTML strings.
+
+This creates a visual read-model bridge without introducing a live API, route registration, database, network, or production UI framework.
+
+## 2. Current v0 boundary
+
+This slice is allowed in v0 because it is:
+
+- renderer-only
+- fixture-backed
+- linked-coach scoped
+- factual
+- engine-inert
+- storage-free
+- route-registration-free
+- deterministic
+
+It must not create:
+
+- production route exposure
+- database access
+- network access
+- live API fetching
+- public claim surface
+- organisation dashboard
+- team dashboard
+- gym dashboard
+- medical readiness status
+- safety status
+- athlete ranking
+- score
+- recommendation
+- training advice
+- autonomous coach authority
+- evidence seal
+- exportable proof
+
+## 3. Renderer input
+
+The renderer accepts an S51 route response object.
+
+The renderer does not call S51 itself.
+
+The renderer does not read fixture files directly.
+
+Tests may read fixtures and pass route responses into the renderer.
+
+## 4. Renderer output
+
+The renderer returns:
+
+- `surface_id`
+- `version`
+- `html`
+
+The HTML is a deterministic string.
+
+It may contain:
+
+- title
+- coach ID
+- queue item count
+- item cards
+- item status
+- athlete ID
+- source record refs
+- blocked reason IDs
+- empty state
+- refusal state
+
+It must not contain advice, scoring, ranking, medical, safety, optimisation, or readiness-certification language.
+
+## 5. Copy rules
+
+Allowed user-facing strings:
+
+- Coach queue
+- Review required
+- Record available
+- Blocked
+- No review items
+- Source records
+- Blocked reasons
+- Coach ID
+- Athlete ID
+- Queue item
+- Request unavailable
+- Required coach identifier missing
+- Source unavailable
+- Route unavailable
+- Method unavailable
+
+## 6. HTML safety
+
+All dynamic text must be escaped.
+
+The renderer must not trust:
+
+- coach ID
+- athlete ID
+- queue item ID
+- source refs
+- blocked reason IDs
+- error IDs
+
+## 7. Acceptance criteria
+
+Tests must prove:
+
+- primary fixture renders deterministic HTML
+- empty fixture renders empty state
+- missing coach ID fixture renders refusal state
+- rendered HTML contains no forbidden terms
+- rendered HTML includes factual status labels
+- dynamic values are escaped
+- renderer does not mutate input response
+- renderer does not import or call S51 route handler
+- renderer does not import filesystem, network, database, Express, or browser APIs

--- a/docs/product/V0_SURFACE_INDEX.md
+++ b/docs/product/V0_SURFACE_INDEX.md
@@ -50,6 +50,7 @@ A described future surface that is not active v0 unless a later release definiti
 | S50 | Coach queue / review API adapter | Active v0 surface | None | Exposes the S49 factual queue builder through a narrow in-memory adapter without storage, UI, advice, scoring, ranking, readiness certification, or safety meaning. |
 | S51 | Coach queue / review route contract | Active v0 surface | None | Defines a handler-level route contract over S50 without Express registration, storage, UI, advice, scoring, ranking, readiness certification, or safety meaning. |
 | S52 | Coach queue / review read model fixture pack | Active v0 surface | None | Provides stable fake source records and expected route responses for the S49-S51 coach queue surface without UI, storage, advice, scoring, ranking, readiness certification, or safety meaning. |
+| S53 | Coach queue / review minimal UI read model renderer | Active v0 surface | None | Renders fixture-backed coach queue read-model states as deterministic safe HTML without live API, storage, route registration, advice, scoring, ranking, readiness certification, or safety meaning. |
 
 ## 4. Product and design references
 

--- a/docs/prompts/S53_COACH_QUEUE_REVIEW_UI_RENDERER_PROMPT.md
+++ b/docs/prompts/S53_COACH_QUEUE_REVIEW_UI_RENDERER_PROMPT.md
@@ -1,0 +1,48 @@
+# S53 — Coach Queue / Review Minimal UI Read Model Renderer Prompt
+
+Build S53 as a narrow v0-safe fixture-backed renderer for the S49-S52 coach queue review surface.
+
+Goal:
+Create a minimal deterministic renderer that turns S52 expected route responses into safe HTML strings.
+
+Hard boundaries:
+- engine-inert
+- renderer-only
+- fixture-backed
+- platform-only
+- no live API
+- no Express app registration
+- no production route exposure
+- no database
+- no network
+- no current time
+- no randomness
+- no medical meaning
+- no safety claims
+- no readiness certification
+- no score
+- no ranking
+- no performance prediction
+- no organisation/team/gym runtime
+- no evidence sealing
+- no exportable proof
+- no training advice
+- no autonomous coach authority
+
+Required outputs:
+- implementation contract doc
+- pure TypeScript renderer
+- Node renderer test file
+- package script for targeted testing
+- V0 surface index update
+
+Acceptance:
+- primary fixture renders deterministic HTML
+- empty fixture renders empty state
+- missing coach ID fixture renders refusal state
+- rendered HTML contains no forbidden terms
+- factual status labels render
+- dynamic values are escaped
+- renderer does not mutate input response
+- renderer does not import or call S51 route handler
+- renderer does not import filesystem, network, database, Express, or browser APIs

--- a/package.json
+++ b/package.json
@@ -105,7 +105,8 @@
                     "test:coach-queue-review":  "npm run build:fast \u0026\u0026 node test/coachQueueReviewSurface.test.mjs",
                     "test:coach-queue-review-api-adapter":  "npm run build:fast \u0026\u0026 node test/coachQueueReviewApiAdapter.test.mjs",
                     "test:coach-queue-review-route-contract":  "npm run build:fast \u0026\u0026 node test/coachQueueReviewRouteContract.test.mjs",
-                    "test:coach-queue-review-fixtures":  "npm run build:fast \u0026\u0026 node test/coachQueueReviewFixturePack.test.mjs"
+                    "test:coach-queue-review-fixtures":  "npm run build:fast \u0026\u0026 node test/coachQueueReviewFixturePack.test.mjs",
+                    "test:coach-queue-review-ui-renderer":  "npm run build:fast \u0026\u0026 node test/coachQueueReviewUiRenderer.test.mjs"
                 },
     "dependencies":  {
                          "@kolosseum/engine":  "file:engine",

--- a/src/coachQueueReviewUiRenderer.ts
+++ b/src/coachQueueReviewUiRenderer.ts
@@ -1,0 +1,179 @@
+type CoachQueueReviewRendererItem = {
+  queue_item_id: string;
+  coach_id: string;
+  athlete_id: string;
+  queue_status: string;
+  review_required: boolean;
+  blocked_reasons: readonly string[];
+  source_record_refs: readonly string[];
+};
+
+type CoachQueueReviewRendererResponse =
+  | {
+      status: 200;
+      body: {
+        ok: true;
+        surface_id: string;
+        version: string;
+        coach_id: string;
+        items: readonly CoachQueueReviewRendererItem[];
+      };
+    }
+  | {
+      status: 400 | 404 | 405 | 503;
+      body: {
+        ok: false;
+        surface_id: string;
+        version: string;
+        error: string;
+      };
+    };
+
+export const coachQueueReviewUiRendererSurfaceId =
+  "coach_queue_review_ui_renderer" as const;
+
+export const coachQueueReviewUiRendererVersion = "1.0.0" as const;
+
+export interface CoachQueueReviewUiRenderResult {
+  surface_id: typeof coachQueueReviewUiRendererSurfaceId;
+  version: typeof coachQueueReviewUiRendererVersion;
+  html: string;
+}
+
+function escapeHtml(value: unknown): string {
+  return String(value)
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#39;");
+}
+
+function renderStatusLabel(status: string): string {
+  if (status === "review_required") {
+    return "Review required";
+  }
+
+  if (status === "available") {
+    return "Record available";
+  }
+
+  if (status === "blocked") {
+    return "Blocked";
+  }
+
+  return "Blocked";
+}
+
+function renderErrorLabel(error: string): string {
+  if (error === "coach_id_required") {
+    return "Required coach identifier missing";
+  }
+
+  if (error === "source_unavailable") {
+    return "Source unavailable";
+  }
+
+  if (error === "route_not_found") {
+    return "Route unavailable";
+  }
+
+  if (error === "method_not_allowed") {
+    return "Method unavailable";
+  }
+
+  return "Request unavailable";
+}
+
+function renderSourceRefs(sourceRecordRefs: readonly string[]): string {
+  if (sourceRecordRefs.length === 0) {
+    return '<p class="kq-muted">Source records: none</p>';
+  }
+
+  const refs = sourceRecordRefs
+    .map((ref) => `<li>${escapeHtml(ref)}</li>`)
+    .join("");
+
+  return `<div class="kq-section"><h4>Source records</h4><ul>${refs}</ul></div>`;
+}
+
+function renderBlockedReasons(blockedReasons: readonly string[]): string {
+  if (blockedReasons.length === 0) {
+    return "";
+  }
+
+  const reasons = blockedReasons
+    .map((reason) => `<li>${escapeHtml(reason)}</li>`)
+    .join("");
+
+  return `<div class="kq-section"><h4>Blocked reasons</h4><ul>${reasons}</ul></div>`;
+}
+
+function renderQueueItems(
+  items: readonly {
+    queue_item_id: string;
+    coach_id: string;
+    athlete_id: string;
+    queue_status: string;
+    review_required: boolean;
+    blocked_reasons: readonly string[];
+    source_record_refs: readonly string[];
+  }[],
+): string {
+  if (items.length === 0) {
+    return '<section class="kq-empty"><h3>No review items</h3></section>';
+  }
+
+  return items
+    .map((item) => {
+      const statusLabel = renderStatusLabel(item.queue_status);
+
+      return [
+        `<article class="kq-card" data-status="${escapeHtml(item.queue_status)}">`,
+        `<header><p class="kq-eyebrow">Queue item</p><h3>${escapeHtml(item.queue_item_id)}</h3></header>`,
+        `<p><strong>Status:</strong> ${escapeHtml(statusLabel)}</p>`,
+        `<p><strong>Athlete ID:</strong> ${escapeHtml(item.athlete_id)}</p>`,
+        `<p><strong>Coach ID:</strong> ${escapeHtml(item.coach_id)}</p>`,
+        renderSourceRefs(item.source_record_refs),
+        renderBlockedReasons(item.blocked_reasons),
+        `</article>`,
+      ].join("");
+    })
+    .join("");
+}
+
+export function renderCoachQueueReviewReadModel(
+  response: CoachQueueReviewRendererResponse,
+): CoachQueueReviewUiRenderResult {
+  if (!response.body.ok) {
+    const errorLabel = renderErrorLabel(response.body.error);
+
+    return {
+      surface_id: coachQueueReviewUiRendererSurfaceId,
+      version: coachQueueReviewUiRendererVersion,
+      html: [
+        '<section class="kq-shell" data-surface="coach_queue_review">',
+        '<header class="kq-header"><h2>Coach queue</h2></header>',
+        `<section class="kq-error"><h3>${escapeHtml(errorLabel)}</h3><p>${escapeHtml(response.body.error)}</p></section>`,
+        '</section>',
+      ].join(""),
+    };
+  }
+
+  return {
+    surface_id: coachQueueReviewUiRendererSurfaceId,
+    version: coachQueueReviewUiRendererVersion,
+    html: [
+      '<section class="kq-shell" data-surface="coach_queue_review">',
+      '<header class="kq-header">',
+      '<h2>Coach queue</h2>',
+      `<p><strong>Coach ID:</strong> ${escapeHtml(response.body.coach_id)}</p>`,
+      `<p><strong>Queue item count:</strong> ${response.body.items.length}</p>`,
+      '</header>',
+      '<section class="kq-list">',
+      renderQueueItems(response.body.items),
+      '</section>',
+      '</section>',
+    ].join(""),
+  };
+}

--- a/test/coachQueueReviewUiRenderer.test.mjs
+++ b/test/coachQueueReviewUiRenderer.test.mjs
@@ -1,0 +1,169 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import test from "node:test";
+
+import {
+  renderCoachQueueReviewReadModel,
+} from "../dist/src/coachQueueReviewUiRenderer.js";
+
+const repoRoot = process.cwd();
+const fixtureDir = join(repoRoot, "test", "fixtures", "coach-queue-review");
+
+function readExpectedResponses() {
+  return JSON.parse(
+    readFileSync(join(fixtureDir, "expected_route_responses.json"), "utf8"),
+  ).responses;
+}
+
+function forbiddenTokens() {
+  return [
+    "score",
+    "rank",
+    "readiness_certification",
+    "safety",
+    "medical",
+    "optimisation",
+    "optimization",
+    "best_action",
+    "recommendation",
+    "advice",
+    "ready to train"
+  ];
+}
+
+test("primary fixture renders deterministic HTML", () => {
+  const responses = readExpectedResponses();
+  const first = renderCoachQueueReviewReadModel(responses.primary_coach_queue);
+  const second = renderCoachQueueReviewReadModel(responses.primary_coach_queue);
+
+  assert.deepEqual(first, second);
+  assert.equal(first.surface_id, "coach_queue_review_ui_renderer");
+  assert.equal(first.version, "1.0.0");
+  assert.equal(first.html.includes("Coach queue"), true);
+  assert.equal(first.html.includes("coach_fixture_primary"), true);
+  assert.equal(first.html.includes("queue_item_review_001"), true);
+});
+
+test("empty fixture renders empty state", () => {
+  const responses = readExpectedResponses();
+  const rendered = renderCoachQueueReviewReadModel(responses.empty_coach_queue);
+
+  assert.equal(rendered.html.includes("No review items"), true);
+  assert.equal(rendered.html.includes("Queue item count:</strong> 0"), true);
+});
+
+test("missing coach ID fixture renders refusal state", () => {
+  const responses = readExpectedResponses();
+  const rendered = renderCoachQueueReviewReadModel(responses.missing_coach_id);
+
+  assert.equal(rendered.html.includes("Required coach identifier missing"), true);
+  assert.equal(rendered.html.includes("coach_id_required"), true);
+});
+
+test("rendered HTML contains no forbidden terms", () => {
+  const responses = readExpectedResponses();
+
+  for (const response of Object.values(responses)) {
+    const rendered = renderCoachQueueReviewReadModel(response);
+    const lowerHtml = rendered.html.toLowerCase();
+
+    for (const token of forbiddenTokens()) {
+      assert.equal(
+        lowerHtml.includes(token.toLowerCase()),
+        false,
+        `${token} must not appear in rendered HTML`,
+      );
+    }
+  }
+});
+
+test("rendered HTML includes factual status labels", () => {
+  const responses = readExpectedResponses();
+  const rendered = renderCoachQueueReviewReadModel(responses.primary_coach_queue);
+
+  assert.equal(rendered.html.includes("Review required"), true);
+  assert.equal(rendered.html.includes("Record available"), true);
+  assert.equal(rendered.html.includes("Blocked"), true);
+  assert.equal(rendered.html.includes("Source records"), true);
+  assert.equal(rendered.html.includes("Blocked reasons"), true);
+});
+
+test("dynamic values are escaped", () => {
+  const response = {
+    status: 200,
+    body: {
+      ok: true,
+      surface_id: "coach_queue_review_api_adapter",
+      version: "1.0.0",
+      coach_id: 'coach_<script>"x"',
+      items: [
+        {
+          queue_item_id: "queue_<item>",
+          coach_id: 'coach_<script>"x"',
+          athlete_id: "athlete_&_'_>",
+          queue_status: "available",
+          review_required: false,
+          blocked_reasons: [],
+          source_record_refs: ["source_<ref>&"]
+        }
+      ]
+    }
+  };
+
+  const rendered = renderCoachQueueReviewReadModel(response);
+
+  assert.equal(rendered.html.includes("<script>"), false);
+  assert.equal(rendered.html.includes("&lt;script&gt;"), true);
+  assert.equal(rendered.html.includes("&quot;x&quot;"), true);
+  assert.equal(rendered.html.includes("athlete_&amp;_&#39;_&gt;"), true);
+  assert.equal(rendered.html.includes("source_&lt;ref&gt;&amp;"), true);
+});
+
+test("renderer does not mutate input response", () => {
+  const responses = readExpectedResponses();
+  const response = structuredClone(responses.primary_coach_queue);
+  const before = JSON.stringify(response);
+
+  renderCoachQueueReviewReadModel(response);
+
+  assert.equal(JSON.stringify(response), before);
+});
+
+test("renderer source does not import or call route handler", () => {
+  const rendererSource = readFileSync(
+    join(repoRoot, "src", "coachQueueReviewUiRenderer.ts"),
+    "utf8",
+  );
+
+  assert.equal(rendererSource.includes("handleCoachQueueReviewRoute"), false);
+  assert.equal(rendererSource.includes("from \"./coachQueueReviewRouteContract.js\""), false);
+});
+
+test("renderer source does not import filesystem network database Express or browser APIs", () => {
+  const rendererSource = readFileSync(
+    join(repoRoot, "src", "coachQueueReviewUiRenderer.ts"),
+    "utf8",
+  );
+
+  const banned = [
+    "node:fs",
+    "node:http",
+    "node:https",
+    "fetch(",
+    "express",
+    "sqlite",
+    "postgres",
+    "prisma",
+    "document.",
+    "window."
+  ];
+
+  for (const token of banned) {
+    assert.equal(
+      rendererSource.includes(token),
+      false,
+      `${token} must not appear in renderer source`,
+    );
+  }
+});


### PR DESCRIPTION
Adds S53 Coach Queue / Review Minimal UI Read Model Renderer as a v0-safe fixture-backed renderer slice.

Outputs:
- docs/coach-queue-review/COACH_QUEUE_REVIEW_UI_RENDERER.md
- docs/prompts/S53_COACH_QUEUE_REVIEW_UI_RENDERER_PROMPT.md
- src/coachQueueReviewUiRenderer.ts
- test/coachQueueReviewUiRenderer.test.mjs
- package script: test:coach-queue-review-ui-renderer
- V0 surface index update

Boundary:
- engine-inert
- renderer-only
- fixture-backed read-model states only
- no live API
- no S51 route handler import/call
- no Express app registration
- no production route exposure
- no database
- no network
- no safety, medical, optimisation, score, rank, readiness certification, advice, organisation/team/gym runtime, evidence sealing, or exportable proof

Validation:
- npm run test:coach-queue-review-ui-renderer
- npm run verify