### PR TITLE
S-DEV-DOCS-INDEX-CLEANUP: add docs index and developer navigation layer

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -1,0 +1,82 @@
+# Kolosseum Documentation Index
+
+This index is the main navigation layer for Kolosseum documentation.
+
+It does not replace canonical product, engine, registry, proof, release, or slice documents. It helps developers find the correct document and understand which source has authority.
+
+## Start Here
+
+New developers should begin with:
+
+1. `docs/dev/NEW_DEVELOPER_START_HERE.md`
+2. `docs/dev/AUTHORITY_CHAIN.md`
+3. `docs/dev/REPO_MAP.md`
+4. `docs/dev/DOC_SEARCH_GUIDE.md`
+5. `docs/dev/DOC_MAINTENANCE_RULES.md`
+
+## Authority Model
+
+Kolosseum uses layered authority.
+
+The strongest sources are:
+
+1. Active release boundary documents
+2. Engine contracts and executable tests
+3. Registry contracts and validation rules
+4. Runtime proof, replay, hash, and evidence rules
+5. Current slice contracts
+6. Module README files and developer notes
+7. Historical documents
+
+Navigation documents explain where to look. They do not create product law.
+
+See:
+
+- `docs/dev/AUTHORITY_CHAIN.md`
+
+## Developer Navigation
+
+Use these files when working in the repo:
+
+- `docs/dev/NEW_DEVELOPER_START_HERE.md` — first reading path for a new developer.
+- `docs/dev/REPO_MAP.md` — repo area guide and ownership boundaries.
+- `docs/dev/DOC_SEARCH_GUIDE.md` — deterministic search commands.
+- `docs/dev/DOC_MAINTENANCE_RULES.md` — rules for adding, editing, and preserving docs.
+- `docs/dev/AUTHORITY_CHAIN.md` — what wins when documents appear to conflict.
+
+## Search First, Then Decide
+
+Do not rely on memory for product, engine, registry, safety, proof, or release boundary decisions.
+
+Use deterministic repo search first.
+
+Recommended searches:
+
+- `git grep -ni "release boundary"`
+- `git grep -ni "v1"`
+- `git grep -ni "not-v1"`
+- `git grep -ni "post-v1"`
+- `git grep -ni "deterministic"`
+- `git grep -ni "canonical"`
+- `git grep -ni "replay"`
+- `git grep -ni "proof"`
+- `git grep -ni "substitution"`
+- `git grep -ni "fallback"`
+- `git grep -ni "coach notes"`
+- `git grep -ni "engine-invisible"`
+- `git grep -ni "recommend"`
+- `git grep -ni "fatigue"`
+- `git grep -ni "readiness"`
+- `git grep -ni "risk"`
+
+## Documentation Principle
+
+Docs should make the system easier to understand without creating a second source of truth.
+
+When in doubt:
+
+1. Find the authoritative document.
+2. Add a pointer to it.
+3. Do not duplicate its rules.
+4. Do not soften its boundaries.
+5. Do not add implied product behaviour.

--- a/docs/dev/AUTHORITY_CHAIN.md
+++ b/docs/dev/AUTHORITY_CHAIN.md
@@ -1,0 +1,95 @@
+# Documentation Authority Chain
+
+This file explains what wins when Kolosseum documents, comments, tests, or implementation details appear to conflict.
+
+## Core Rule
+
+Navigation docs help people find the law. They do not create the law.
+
+## Authority Order
+
+Use this order unless a current release boundary explicitly states otherwise.
+
+### 1. Active Release Boundary
+
+The active release boundary defines what the current release is and is not allowed to contain.
+
+It wins over older roadmap notes, old plans, speculative commercial ideas, and abandoned drafts.
+
+### 2. Engine Contracts And Executable Tests
+
+Engine contracts and tests define deterministic behaviour.
+
+If engine behaviour is changed, the change must be intentional, sliced, documented, and proven.
+
+### 3. Registry Contracts And Validation Rules
+
+Registry contracts define supported content and closure rules.
+
+Do not add unsupported activities, hidden fallback, or undocumented mappings.
+
+### 4. Proof, Replay, Hash, And Evidence Rules
+
+Proof rules protect determinism, auditability, and replay.
+
+Do not change proof behaviour as a side effect of UI, dashboard, or developer convenience work.
+
+### 5. Current Slice Contract
+
+The active slice defines the allowed change.
+
+If an improvement is outside the slice, it should become a later slice.
+
+### 6. Module README And Developer Notes
+
+Module docs and DEV NOTE comments explain purpose, boundaries, invariants, and failure behaviour.
+
+They do not override contracts or tests.
+
+### 7. Historical Documents
+
+Historical docs may explain why a decision was made.
+
+They do not override the active release boundary.
+
+## Conflict Handling
+
+When a conflict is found:
+
+1. Identify both sources.
+2. Determine authority level.
+3. Preserve the higher-authority source.
+4. Do not silently delete the lower-authority source.
+5. Add a clarification or pointer if needed.
+6. If behaviour must change, create a slice.
+
+## Developer Comments
+
+Comments are useful when they explain:
+
+- Purpose
+- Boundary
+- Determinism
+- Failure behaviour
+- Non-obvious constraints
+
+Comments are harmful when they:
+
+- Restate obvious code
+- Create new product rules
+- Contradict canonical docs
+- Use unsupported claim language
+- Describe aspirational future behaviour as current behaviour
+
+## Rule For Future Docs
+
+Do not duplicate canonical rules into many places.
+
+Prefer:
+
+- Short summary
+- Link or pointer to authority
+- Search terms
+- Boundary warning
+
+This keeps the docs searchable without creating drift.

--- a/docs/dev/DOC_MAINTENANCE_RULES.md
+++ b/docs/dev/DOC_MAINTENANCE_RULES.md
@@ -1,0 +1,117 @@
+# Documentation Maintenance Rules
+
+This file defines how Kolosseum documentation should be kept useful without creating drift.
+
+## Main Rule
+
+Do not make docs cleaner by rewriting canonical rules into many places.
+
+Make docs cleaner by improving:
+
+- Indexes
+- Pointers
+- Search terms
+- Authority chain
+- Repo maps
+- Developer start paths
+- Missing-link visibility
+
+## Allowed Documentation Work
+
+Allowed:
+
+- Add navigation docs.
+- Add short summaries that point to authoritative docs.
+- Add search guides.
+- Add repo maps.
+- Add module README files.
+- Add DEV NOTE comments on critical functions.
+- Add missing where-to-start guidance.
+- Add CI checks that ensure important docs exist.
+- Clarify authority order.
+
+## Dangerous Documentation Work
+
+Avoid:
+
+- Rewriting canonical product rules for style.
+- Deleting old docs without a deprecation plan.
+- Moving files without updating links and references.
+- Duplicating release boundaries into multiple docs.
+- Turning future ideas into current commitments.
+- Adding product claims.
+- Adding unsupported safety, medical, or performance language.
+- Adding implementation details that contradict tests.
+- Creating docs that sound authoritative but are not.
+
+## When Adding A New Doc
+
+A new doc should state:
+
+1. Purpose
+2. Authority level
+3. What it does not override
+4. Related files
+5. Search terms if relevant
+
+## When Editing Existing Docs
+
+Before editing:
+
+1. Search for duplicate concepts.
+2. Identify the highest-authority source.
+3. Preserve original meaning.
+4. Avoid expanding scope.
+5. Avoid changing product claims.
+6. Run docs/index checks.
+7. Run relevant tests if behaviour-adjacent.
+
+## When A Doc Looks Outdated
+
+Do not delete it immediately.
+
+Instead:
+
+1. Check whether a newer authority exists.
+2. Add a note pointing to the newer authority if appropriate.
+3. Mark as historical only if the repo already has a clear replacement.
+4. Avoid relying on metadata alone.
+5. Preserve history unless there is a deliberate cleanup slice.
+
+## Required Language Style
+
+Use factual language.
+
+Prefer:
+
+- recorded
+- reported
+- declared
+- selected
+- assigned
+- completed
+- skipped
+- substituted
+- changed
+- coach review
+- available data
+
+Avoid:
+
+- recommends
+- optimal
+- safe
+- safer
+- risk
+- injury risk
+- readiness
+- fatigue
+- effective
+- programme worked
+- programme failed
+
+## Documentation CI
+
+The docs index check should prove that the navigation layer exists and contains required sections.
+
+It should not validate product truth. Product truth is validated by contracts and tests.

--- a/docs/dev/DOC_SEARCH_GUIDE.md
+++ b/docs/dev/DOC_SEARCH_GUIDE.md
@@ -1,0 +1,136 @@
+# Documentation Search Guide
+
+This guide gives deterministic commands for finding Kolosseum rules in the repo.
+
+Use search before relying on memory.
+
+## Basic Search
+
+Run from repo root:
+
+    git grep -n "search term"
+
+Examples:
+
+    git grep -n "deterministic"
+    git grep -n "substitution"
+    git grep -n "release boundary"
+
+## Case-Insensitive Search
+
+    git grep -ni "search term"
+
+Examples:
+
+    git grep -ni "readiness"
+    git grep -ni "fatigue"
+    git grep -ni "recommend"
+
+## Search Headings
+
+Markdown headings are useful search anchors.
+
+    git grep -n "^#"
+    git grep -n "^##"
+    git grep -n "^###"
+
+## Search For Scope Boundaries
+
+    git grep -ni "v0"
+    git grep -ni "v1"
+    git grep -ni "release boundary"
+    git grep -ni "not-v1"
+    git grep -ni "post-v1"
+    git grep -ni "excluded"
+    git grep -ni "non-goal"
+    git grep -ni "non-goals"
+
+## Search For Engine And Proof Rules
+
+    git grep -ni "engine"
+    git grep -ni "deterministic"
+    git grep -ni "canonical"
+    git grep -ni "hash"
+    git grep -ni "replay"
+    git grep -ni "proof"
+    git grep -ni "evidence"
+    git grep -ni "no-coupling"
+
+## Search For Registry Rules
+
+    git grep -ni "registry"
+    git grep -ni "exercise"
+    git grep -ni "equipment"
+    git grep -ni "supported activities"
+    git grep -ni "foreign key"
+    git grep -ni "closure"
+
+## Search For Substitution Rules
+
+    git grep -ni "substitution"
+    git grep -ni "substitute"
+    git grep -ni "fallback"
+    git grep -ni "equipment"
+    git grep -ni "intent"
+    git grep -ni "specificity"
+
+## Search For Claim-Language Risk
+
+    git grep -ni "recommend"
+    git grep -ni "recommended"
+    git grep -ni "optimal"
+    git grep -ni "safe"
+    git grep -ni "safer"
+    git grep -ni "risk"
+    git grep -ni "injury"
+    git grep -ni "fatigue"
+    git grep -ni "readiness"
+    git grep -ni "effective"
+
+Finding these words does not automatically mean the repo is wrong. Some files may document banned language. Review context before changing anything.
+
+## Search For Coach Notes Boundary
+
+    git grep -ni "coach notes"
+    git grep -ni "notes"
+    git grep -ni "engine-invisible"
+    git grep -ni "review"
+
+## Search For Live Session Status Boundary
+
+    git grep -ni "live session"
+    git grep -ni "session status"
+    git grep -ni "in_progress"
+    git grep -ni "split"
+    git grep -ni "returned"
+    git grep -ni "partially_completed"
+
+## Search For Developer Handover Material
+
+    git grep -ni "DEV NOTE"
+    git grep -ni "handover"
+    git grep -ni "new developer"
+    git grep -ni "repo map"
+    git grep -ni "architecture boundary"
+
+## PowerShell Search Alternative
+
+If Git search is not enough:
+
+    Get-ChildItem -Recurse -File | Select-String -Pattern "search term"
+
+Example:
+
+    Get-ChildItem -Recurse -File | Select-String -Pattern "substitution"
+
+## Search Discipline
+
+Before changing behaviour, search for:
+
+1. The feature name.
+2. The boundary name.
+3. The error token.
+4. The related test.
+5. The release or slice document.
+
+Do not implement from memory when a repo rule exists.

--- a/docs/dev/NEW_DEVELOPER_START_HERE.md
+++ b/docs/dev/NEW_DEVELOPER_START_HERE.md
@@ -1,0 +1,74 @@
+# New Developer Start Here
+
+This file gives a new developer the shortest safe path into Kolosseum.
+
+Kolosseum is not a generic fitness app. It is a deterministic coach-athlete execution product with strict boundaries around engine truth, proof, registry behaviour, coach review, and claim language.
+
+## First Rule
+
+Do not guess product rules from code shape, UI ideas, or commercial assumptions.
+
+Find the relevant boundary document, contract, registry rule, or test first.
+
+## Read In This Order
+
+1. `docs/INDEX.md`
+2. `docs/dev/AUTHORITY_CHAIN.md`
+3. `docs/dev/REPO_MAP.md`
+4. `docs/dev/DOC_SEARCH_GUIDE.md`
+5. Current release boundary document
+6. Current active slice contract
+7. Relevant module README or contract
+8. Relevant tests
+
+## What Must Stay True
+
+Kolosseum v1 must remain a deterministic coach-athlete product.
+
+The engine must remain separate from:
+
+- Coach notes
+- UI state
+- Dashboard convenience data
+- Billing
+- Auth implementation details
+- Marketing copy
+- AI or RAG layers
+- Recommendation language
+- Medical, fatigue, readiness, risk, or safety inference
+
+## Safe Developer Behaviour
+
+Before changing code:
+
+1. Identify the active slice.
+2. Identify the invariant being protected.
+3. Identify the files that are allowed to change.
+4. Identify the proof command.
+5. Run the relevant checks.
+6. Keep the change narrow.
+
+## Unsafe Developer Behaviour
+
+Do not:
+
+- Add product features outside the active slice.
+- Add recommendation language.
+- Add AI output to engine truth.
+- Let coach notes affect deterministic execution.
+- Let UI state affect proof or replay.
+- Replace tests with explanation.
+- Rewrite canonical docs while trying to tidy them.
+- Delete historical docs because they look old.
+- Add fallback behaviour without an explicit contract.
+- Add broad dashboards before the data boundary is locked.
+
+## If Something Conflicts
+
+Use `docs/dev/AUTHORITY_CHAIN.md`.
+
+If a navigation doc conflicts with a canonical contract, the canonical contract wins.
+
+If a comment conflicts with a test, the test and canonical contract win.
+
+If a historical note conflicts with the active release boundary, the active release boundary wins.

--- a/docs/dev/REPO_MAP.md
+++ b/docs/dev/REPO_MAP.md
@@ -1,0 +1,127 @@
+# Repository Map
+
+This file explains the main repo areas and how to think about them.
+
+It is a navigation guide only. It does not create product law.
+
+## Core Areas
+
+### `/docs`
+
+Product, release, architecture, proof, developer, and operating documents.
+
+Use this area to understand why the system exists, what is in scope, what is excluded, and how developers should work safely.
+
+### `/docs/dev`
+
+Developer-facing navigation and handover material.
+
+This area should explain:
+
+- How to enter the repo safely
+- Where to find rules
+- How to search
+- What not to touch
+- How docs are maintained
+
+### `/contracts`
+
+Contracts define expected structures, boundaries, and data surfaces.
+
+Treat contracts as stronger than explanatory docs.
+
+### `/registries`
+
+Registry content and registry rules.
+
+Registry behaviour must remain explicit, validated, and closed over supported v1 scope.
+
+Do not use registry content to smuggle in unsupported sports, unsupported equipment behaviour, recommendation language, or hidden fallback semantics.
+
+### `/tests`
+
+Tests are executable proof.
+
+When docs and implementation disagree, tests expose the current enforced behaviour. If the enforced behaviour is wrong, fix it through a proper slice, not by silently changing tests.
+
+### `/scripts`
+
+Repo automation, CI helpers, validation scripts, and developer checks.
+
+Scripts should fail clearly and explain what boundary was violated.
+
+### `/src`
+
+Application and engine implementation.
+
+Engine code must remain deterministic and isolated from UI, auth, billing, notes, dashboards, AI, and coach convenience layers unless a contract explicitly allows the data boundary.
+
+### `/public` or UI areas
+
+User-facing surfaces.
+
+UI may display factual outputs, but must not create engine truth or make unsupported recommendations.
+
+## Boundary Areas To Protect
+
+### Engine Boundary
+
+The engine owns deterministic compile/execution truth.
+
+It must not consume:
+
+- Coach notes
+- AI output
+- UI-only state
+- Marketing copy
+- Billing state
+- Dashboard summaries
+- Inferred fatigue/readiness/risk labels
+
+### Coach Notes Boundary
+
+Coach notes are factual review/support material.
+
+They must remain engine-invisible.
+
+### Registry Boundary
+
+Registries define supported content and allowed mappings.
+
+Do not add temporary fallback behaviour. Temporary fallback becomes hidden product law.
+
+### Proof Boundary
+
+Replay, hashes, evidence, and runtime proof must be reproducible.
+
+Do not let convenience data alter proof.
+
+### Copy Boundary
+
+Copy must avoid unsupported claims.
+
+Use factual wording such as:
+
+- recorded
+- reported
+- declared
+- completed
+- skipped
+- substituted
+- changed
+- selected period
+- coach review
+
+Avoid unsupported wording such as:
+
+- optimal
+- safe
+- safer
+- effective
+- recommends
+- fatigue
+- readiness
+- risk
+- injury risk
+- programme worked
+- programme failed

--- a/package.json
+++ b/package.json
@@ -108,7 +108,8 @@
                     "test:coach-queue-review-fixtures":  "npm run build:fast \u0026\u0026 node test/coachQueueReviewFixturePack.test.mjs",
                     "test:coach-queue-review-ui-renderer":  "npm run build:fast \u0026\u0026 node test/coachQueueReviewUiRenderer.test.mjs",
                     "preview:coach-queue-review:static":  "npm run build:fast \u0026\u0026 node scripts/render_coach_queue_review_static_preview.mjs",
-                    "test:coach-queue-review-static-preview":  "npm run preview:coach-queue-review:static \u0026\u0026 node test/coachQueueReviewStaticPreview.test.mjs"
+                    "test:coach-queue-review-static-preview":  "npm run preview:coach-queue-review:static \u0026\u0026 node test/coachQueueReviewStaticPreview.test.mjs",
+                    "check:docs-index":  "node scripts/check-docs-index.mjs"
                 },
     "dependencies":  {
                          "@kolosseum/engine":  "file:engine",
@@ -135,3 +136,4 @@
                   "ENGINE_CONTRACT.md"
               ]
 }
+

--- a/scripts/check-docs-index.mjs
+++ b/scripts/check-docs-index.mjs
@@ -1,0 +1,108 @@
+import fs from "node:fs";
+import path from "node:path";
+
+const repoRoot = process.cwd();
+
+const requiredFiles = [
+  "docs/INDEX.md",
+  "docs/dev/NEW_DEVELOPER_START_HERE.md",
+  "docs/dev/REPO_MAP.md",
+  "docs/dev/AUTHORITY_CHAIN.md",
+  "docs/dev/DOC_SEARCH_GUIDE.md",
+  "docs/dev/DOC_MAINTENANCE_RULES.md"
+];
+
+const requiredSectionsByFile = {
+  "docs/INDEX.md": [
+    "# Kolosseum Documentation Index",
+    "## Start Here",
+    "## Authority Model",
+    "## Developer Navigation",
+    "## Search First, Then Decide",
+    "## Documentation Principle"
+  ],
+  "docs/dev/NEW_DEVELOPER_START_HERE.md": [
+    "# New Developer Start Here",
+    "## First Rule",
+    "## Read In This Order",
+    "## What Must Stay True",
+    "## Safe Developer Behaviour",
+    "## Unsafe Developer Behaviour",
+    "## If Something Conflicts"
+  ],
+  "docs/dev/REPO_MAP.md": [
+    "# Repository Map",
+    "## Core Areas",
+    "## Boundary Areas To Protect"
+  ],
+  "docs/dev/AUTHORITY_CHAIN.md": [
+    "# Documentation Authority Chain",
+    "## Core Rule",
+    "## Authority Order",
+    "## Conflict Handling",
+    "## Developer Comments",
+    "## Rule For Future Docs"
+  ],
+  "docs/dev/DOC_SEARCH_GUIDE.md": [
+    "# Documentation Search Guide",
+    "## Basic Search",
+    "## Case-Insensitive Search",
+    "## Search Headings",
+    "## Search For Scope Boundaries",
+    "## Search Discipline"
+  ],
+  "docs/dev/DOC_MAINTENANCE_RULES.md": [
+    "# Documentation Maintenance Rules",
+    "## Main Rule",
+    "## Allowed Documentation Work",
+    "## Dangerous Documentation Work",
+    "## When Adding A New Doc",
+    "## When Editing Existing Docs",
+    "## Documentation CI"
+  ]
+};
+
+const failures = [];
+
+for (const file of requiredFiles) {
+  const abs = path.join(repoRoot, file);
+
+  if (!fs.existsSync(abs)) {
+    failures.push(`Missing required docs navigation file: ${file}`);
+    continue;
+  }
+
+  const text = fs.readFileSync(abs, "utf8");
+
+  for (const section of requiredSectionsByFile[file] ?? []) {
+    if (!text.includes(section)) {
+      failures.push(`Missing required section in ${file}: ${section}`);
+    }
+  }
+
+  if (!text.includes("does not") && !text.includes("do not") && !text.includes("Do not")) {
+    failures.push(`Expected boundary language in ${file}; no do-not/does-not language found.`);
+  }
+}
+
+const indexPath = path.join(repoRoot, "docs/INDEX.md");
+const indexText = fs.existsSync(indexPath) ? fs.readFileSync(indexPath, "utf8") : "";
+
+for (const file of requiredFiles.filter((file) => file !== "docs/INDEX.md")) {
+  if (!indexText.includes(file)) {
+    failures.push(`docs/INDEX.md does not reference ${file}`);
+  }
+}
+
+if (failures.length > 0) {
+  console.error("");
+  console.error("Docs index check failed:");
+  for (const failure of failures) {
+    console.error(`- ${failure}`);
+  }
+  console.error("");
+  process.exit(1);
+}
+
+console.log("Docs index check passed.");
+console.log(`Checked ${requiredFiles.length} documentation navigation files.`);


### PR DESCRIPTION
## Summary

Adds a documentation navigation layer for Kolosseum developer handover and safer repo search.

## Added

- docs/INDEX.md
- docs/dev/NEW_DEVELOPER_START_HERE.md
- docs/dev/REPO_MAP.md
- docs/dev/AUTHORITY_CHAIN.md
- docs/dev/DOC_SEARCH_GUIDE.md
- docs/dev/DOC_MAINTENANCE_RULES.md
- scripts/check-docs-index.mjs
- package script: check:docs-index

## Boundary

This slice does not rewrite canonical product, engine, registry, proof, release, or scope rules.

The new docs explain where to look and how to search. They do not create product law.

## Proof

- npm.cmd run check:docs-index

## Result

Docs index check passed.
Checked 6 documentation navigation files.