### PR TITLE
S-V0-22 Commercial Artefact Registry Closure

### DIFF
--- a/ci/registries/commercial_artefact_registry.json
+++ b/ci/registries/commercial_artefact_registry.json
@@ -316,5 +316,16 @@
                           "path":  "docs/commercial/P202_PILOT_CONVERSION_PROOF_PACK.md",
                           "class":  "commercial_surface"
                       }
-                  ]
+                  ],
+    "v0_boundary_policy":  {
+                               "policy_id":  "v0_commercial_artefact_registry_boundary_policy",
+                               "v0_role":  "boundary_protection_only",
+                               "grants_product_scope":  false,
+                               "grants_engine_behaviour":  false,
+                               "permits_billing_or_subscriptions":  false,
+                               "permits_sales_dashboards":  false,
+                               "permits_market_launch_features":  false,
+                               "future_or_post_v0_artefacts_rule":  "Artefacts outside the active v0 commercial boundary must remain explicitly future, v1, post-v0, dormant, or excluded. Registry inclusion does not make them active v0 product scope.",
+                               "required_guard":  "ci/scripts/run_commercial_artefact_registry_guard.mjs"
+                           }
 }

--- a/ci/scripts/run_commercial_artefact_registry_guard.mjs
+++ b/ci/scripts/run_commercial_artefact_registry_guard.mjs
@@ -160,6 +160,41 @@ export function runCommercialArtefactRegistryGuard(options = {}) {
     );
   }
 
+  if (!registry.v0_boundary_policy || typeof registry.v0_boundary_policy !== "object") {
+    return fail(
+      "CI_COMMERCIAL_ARTEFACT_REGISTRY_INVALID",
+      "v0_boundary_policy must be present for commercial registry closure.",
+      { path: toPosix(path.relative(cwd, registryPath)) }
+    );
+  }
+
+  const boundaryPolicy = registry.v0_boundary_policy;
+  const requiredBoundaryBooleans = [
+    "grants_product_scope",
+    "grants_engine_behaviour",
+    "permits_billing_or_subscriptions",
+    "permits_sales_dashboards",
+    "permits_market_launch_features"
+  ];
+
+  if (boundaryPolicy.v0_role !== "boundary_protection_only") {
+    return fail(
+      "CI_COMMERCIAL_ARTEFACT_REGISTRY_INVALID",
+      "v0_boundary_policy.v0_role must equal 'boundary_protection_only'.",
+      { path: toPosix(path.relative(cwd, registryPath)) }
+    );
+  }
+
+  for (const key of requiredBoundaryBooleans) {
+    if (boundaryPolicy[key] !== false) {
+      return fail(
+        "CI_COMMERCIAL_ARTEFACT_REGISTRY_INVALID",
+        `v0_boundary_policy.${key} must be false.`,
+        { path: toPosix(path.relative(cwd, registryPath)) }
+      );
+    }
+  }
+
   const declaredPaths = new Set();
   for (const artefact of registry.artefacts) {
     if (!artefact || typeof artefact !== "object") {

--- a/docs/release/V0_COMMERCIAL_ARTEFACT_REGISTRY_CLOSURE.md
+++ b/docs/release/V0_COMMERCIAL_ARTEFACT_REGISTRY_CLOSURE.md
@@ -1,0 +1,58 @@
+# V0 Commercial Artefact Registry Closure
+
+Status: v0 commercial artefact registry closure record.
+
+Slice coverage: S-V0-22 Commercial Artefact Registry Closure.
+
+## Purpose
+
+This record closes the v0 commercial artefact registry surface.
+
+The commercial artefact registry exists as boundary protection only. It ensures commercial-facing artefacts are known, pinned, and checked. It does not add billing, subscriptions, sales dashboards, market launch features, or commercial runtime behaviour to v0.
+
+## Active guard
+
+The active guard is:
+
+- `ci/scripts/run_commercial_artefact_registry_guard.mjs`
+
+The guard is included in `lint:fast`.
+
+## Active registry
+
+The active registry is:
+
+- `ci/registries/commercial_artefact_registry.json`
+
+The registry is closed-world. Declared artefacts must exist. Undeclared artefacts under tracked commercial roots fail.
+
+## Boundary policy
+
+The registry must state that its v0 role is boundary protection only.
+
+The registry must not grant:
+
+- product scope
+- engine behaviour
+- billing or subscription capability
+- sales dashboard capability
+- market launch feature capability
+
+Future, v1, post-v0, dormant, or excluded commercial artefacts may be documented only as inactive or boundary-protected surfaces. Registry inclusion does not make a surface active v0 product scope.
+
+## Proof
+
+S-V0-22 is complete only when:
+
+1. The commercial artefact registry exists.
+2. The commercial artefact guard exists.
+3. The guard catches missing declared artefacts.
+4. The guard catches undeclared commercial artefacts.
+5. The guard rejects registry metadata that grants v0 commercial product scope.
+6. Copy and claim gates pass.
+7. Active v0 scope gates pass.
+8. `lint:fast`, `test:ci`, and `test:full` pass.
+
+## Non-expansion rule
+
+This closure does not add billing, subscriptions, sales dashboards, checkout, payment flows, launch tooling, commercial dashboards, market launch automation, or revenue operations to v0.

--- a/test/commercial_artefact_registry_guard.test.mjs
+++ b/test/commercial_artefact_registry_guard.test.mjs
@@ -24,6 +24,18 @@ function makeRegistry() {
     scope_class: "closed_world",
     rewrite_policy: "rewrite_only",
     purpose: "Pinned CI-only registry for commercial-facing docs and packs.",
+    v0_boundary_policy: {
+      policy_id: "v0_commercial_artefact_registry_boundary_policy",
+      v0_role: "boundary_protection_only",
+      grants_product_scope: false,
+      grants_engine_behaviour: false,
+      permits_billing_or_subscriptions: false,
+      permits_sales_dashboards: false,
+      permits_market_launch_features: false,
+      future_or_post_v0_artefacts_rule:
+        "Artefacts outside the active v0 commercial boundary must remain explicitly future, v1, post-v0, dormant, or excluded. Registry inclusion does not make them active v0 product scope.",
+      required_guard: "ci/scripts/run_commercial_artefact_registry_guard.mjs"
+    },
     scan_roots: [
       "docs/commercial",
       "docs/pricing",
@@ -100,4 +112,16 @@ test("commercial artefact registry guard fails when an undeclared commercial art
   assert.equal(report.ok, false);
   assert.equal(report.failures[0].token, "CI_COMMERCIAL_ARTEFACT_UNDECLARED");
   assert.match(report.failures[0].details, /Undeclared commercial artefact detected/);
+});
+test("commercial artefact registry guard fails when boundary policy grants product scope", () => {
+  const root = setupPassFixture();
+  const registryPath = path.join(root, "ci/registries/commercial_artefact_registry.json");
+  const registry = JSON.parse(fs.readFileSync(registryPath, "utf8"));
+  registry.v0_boundary_policy.permits_billing_or_subscriptions = true;
+  fs.writeFileSync(registryPath, JSON.stringify(registry, null, 2), "utf8");
+
+  const report = runCommercialArtefactRegistryGuard({ cwd: root });
+  assert.equal(report.ok, false);
+  assert.equal(report.failures[0].token, "CI_COMMERCIAL_ARTEFACT_REGISTRY_INVALID");
+  assert.match(report.failures[0].details, /permits_billing_or_subscriptions must be false/);
 });


### PR DESCRIPTION
## Summary

Closes S-V0-22 Commercial Artefact Registry Closure.

This branch hardens the commercial artefact registry as v0 boundary protection only.

## Changes

- Adds v0 boundary policy metadata to ci/registries/commercial_artefact_registry.json
- Extends ci/scripts/run_commercial_artefact_registry_guard.mjs to reject commercial registry metadata that grants product scope
- Adds a negative test proving billing/subscription-style scope cannot be enabled through the registry
- Adds docs/release/V0_COMMERCIAL_ARTEFACT_REGISTRY_CLOSURE.md

## Local gates passed

- 
pm.cmd run build:fast
- 
ode ci/scripts/run_commercial_artefact_registry_guard.mjs
- 
ode test/commercial_artefact_registry_guard.test.mjs
- 
ode ci/scripts/lint_sales_claims.mjs
- 
ode ci/scripts/run_no_inference_copy_guard.mjs
- 
ode ci/guards/run_v0_boundary_claim_consistency_guard.mjs
- 
ode ci/scripts/run_v0_active_scope_guard.mjs
- 
ode ci/scripts/run_v0_active_scope_negative_tests.mjs
- 
pm.cmd run lint:fast
- 
pm.cmd run test:ci
- 
pm.cmd run test:full

## Boundary

This PR does not add billing, subscriptions, sales dashboards, checkout, payment flows, launch tooling, commercial dashboards, market launch automation, or revenue operations to v0.