### PR TITLE
S-V1-02A tighten controlled launch boundary wording

### DIFF
--- a/docs/v1/V1_ACCEPTANCE_GATE.md
+++ b/docs/v1/V1_ACCEPTANCE_GATE.md
@@ -147,16 +147,41 @@ If a command is renamed, the replacement must be documented in the active releas
 
 ## Final acceptance statement
 
-V1 may be called complete only when the coach-athlete product works end to end and CI proves that product, UI, auth, billing, notes, copy, metrics, proof, and commercial surfaces do not alter engine truth.### Required operational acceptance
-* Status page green ≤ 5 min heartbeat.
-* Sentry unhandled-exception rate < 2 % (24 h).
-* Nightly backup & restore test pass.
+V1 may be called complete only when the coach-athlete product works end to end and CI proves that product, UI, auth, billing, notes, copy, metrics, proof, and commercial surfaces do not alter engine truth.
 
-### Required legal acceptance
-* `/legal/terms` `/legal/privacy` `/legal/dpa` render.
-* GDPR export < 5 min; delete queue written.
+## Required controlled-launch operational acceptance
 
-### Required billing acceptance
-* Stripe Checkout / Portal live-mode OK.
-* Upgrade / downgrade webhook reconciles seats.
-* Non-payment suspension after 72 h grace proven by CI.
+V1 must prove operational readiness for a controlled commercial launch without creating new product scope or engine authority.
+
+V1 controlled-launch operations may include public status, factual error-reporting, backup, restore, and incident-record surfaces only where deliberately activated.
+
+Operational monitoring must remain factual. It must not create readiness, safety, suitability, effectiveness, coaching-quality, medical, operational, or external-approval claims.
+
+Implementation-specific thresholds, alert timings, incident response targets, and service-level targets belong in operational readiness records, not engine law or release-boundary law.
+
+## Required legal acceptance
+
+V1 must prove controlled-launch legal surfaces exist where activated.
+
+Required legal surfaces may include:
+
+- terms surface
+- privacy surface
+- DPA surface where required
+- GDPR export handling
+- GDPR deletion-request handling
+
+Legal surfaces must not imply medical, safety, suitability, readiness, coaching-quality, training-effectiveness, operational, or external-approval claims.
+
+## Required billing acceptance
+
+V1 must prove controlled-launch billing surfaces exist where activated.
+
+Required billing acceptance may include:
+
+- Stripe Checkout or equivalent payment entry flow
+- customer portal or equivalent billing-management flow
+- upgrade and downgrade event handling for access, seats, or billing records only
+- non-payment access handling as a product-access rule only
+
+Billing state must not alter engine legality, deterministic compile output, substitution legality, replay truth, proof truth, factual history, or coach-athlete relationship truth.

--- a/docs/v1/V1_NOT_IN_SCOPE.md
+++ b/docs/v1/V1_NOT_IN_SCOPE.md
@@ -187,11 +187,18 @@ Proof may show process integrity only.
 
 ## Final exclusion rule
 
-If a feature is listed here, it must remain absent, dormant, or explicitly blocked until a later release-boundary rewrite activates it.### Commercial rollout exceptions (2026-06-13)
+If a feature is listed here, it must remain absent, dormant, or explicitly blocked until a later release-boundary rewrite activates it.
 
-The following features are **now permitted** and removed from the exclusion list, subject to copy/claim bans and zero impact on engine truth:
+## Controlled-launch exceptions
 
-* Stripe self-serve purchase & seat management
-* Public status page + error tracking
-* Legal doc surfaces (Terms, Privacy, DPA, GDPR export/delete)
-* Email session reminders + weekly digest
+The following surfaces may exist in v1 only as controlled-launch support surfaces, subject to copy and claim bans and zero impact on engine truth:
+
+- Stripe self-serve purchase and seat management
+- public status and factual error-reporting surfaces
+- legal document surfaces for Terms, Privacy, DPA, GDPR export, and GDPR deletion-request handling
+- backup and restore readiness records
+- factual email notifications only where deliberately sliced
+
+Controlled-launch exceptions do not activate marketplace, messaging, chat, social, broad analytics, gym access, EPOS, enterprise, organisation, team, unit, federation, or dashboard scope.
+
+Factual email notifications must not contain coaching advice, recommendations, readiness claims, safety claims, suitability claims, optimisation claims, medical claims, or any content that changes engine input, output, legality, replay, proof, substitution, or factual history.

--- a/docs/v1/V1_RELEASE_BOUNDARY.md
+++ b/docs/v1/V1_RELEASE_BOUNDARY.md
@@ -177,6 +177,20 @@ If it cannot name those things, it is not ready to build.
 
 V1 is complete only when the coach-athlete product is fully usable, commercially credible, and boundary-proven.
 
-Anything outside this document and its authority map is not v1 unless a deliberate boundary-change slice rewrites this document and updates the matching acceptance and not-in-scope records.## Commercial rollout extension (2026-06-13)
+Anything outside this document and its authority map is not v1 unless a deliberate boundary-change slice rewrites this document and updates the matching acceptance and not-in-scope records.
 
-*Self-serve launch additions (Stripe Checkout / Portal, status page, Sentry, legal surfaces, backups, email reminders) are included **only if they never alter deterministic engine truth**.*
+## Controlled commercial launch extension
+
+Self-serve launch additions may be included in v1 only as controlled-launch support surfaces.
+
+Permitted controlled-launch support surfaces may include Stripe Checkout or customer portal, public status and factual error-reporting surfaces, legal surfaces, backup and restore readiness records, and factual email notifications where deliberately sliced.
+
+These surfaces must never alter deterministic engine truth, programme assignment legality, compile output, substitution legality, replay truth, proof truth, factual history, or coach-athlete relationship authority.
+
+Implementation-specific operational thresholds belong in operational readiness records, not this release-boundary law.
+
+## Final rule
+
+V1 is complete only when the coach-athlete product is fully usable, commercially credible, and boundary-proven.
+
+Anything outside this document and its authority map is not v1 unless a deliberate boundary-change slice rewrites this document and updates the matching acceptance and not-in-scope records.


### PR DESCRIPTION
## Boundary

S-V1-02A tightens the v1 controlled-launch wording after PR #653 added useful launch-readiness material with loose commercial rollout wording.

This PR keeps the v1 boundary as a complete coach-athlete product with controlled commercial launch support only.

## Proof

Local proof passed before PR:

- checksum regeneration through owning generator: npm.cmd run hash:write
- sha256_guard
- no_bom_guard
- no_crlf_guard
- no_mojibake_guard
- npm.cmd run lint:fast

## Non-scope

This PR does not:

- touch engine code
- touch registry content
- touch app/payment implementation
- touch workflows
- touch package scripts
- merge or delete the auto-revert branch
- activate organisations, teams, gyms, federations, marketplace, messaging, EPOS, enterprise, broad dashboards, or broad rollout